### PR TITLE
Improve stdlib import ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,11 @@ See the contract itself for all error codes.
 
 ```solidity
 
-import "ds-test/test.sol";
-import "forge-std/stdlib.sol";
-import "forge-std/Vm.sol";
+import "forge-std/Test.sol";
 
-contract TestContract is DSTest {
-    Vm public constant vm = Vm(HEVM_ADDRESS);
-
+contract TestContract is Test {
     ErrorsTest test;
+
     function setUp() public {
         test = new ErrorsTest();
     }
@@ -43,7 +40,6 @@ contract ErrorsTest {
     }
 }
 ```
-
 
 ### stdStorage
 
@@ -64,18 +60,12 @@ struct T {
 #### Example usage
 
 ```solidity
+import "forge-std/Test.sol";
 
-import "ds-test/test.sol";
-import "forge-std/stdlib.sol";
-import "forge-std/Vm.sol";
-
-contract TestContract is DSTest {
+contract TestContract is Test {
     using stdStorage for StdStorage;
 
-    Vm public constant vm = Vm(HEVM_ADDRESS);
-
     Storage test;
-    StdStorage stdstore;
 
     function setUp() public {
         test = new Storage();
@@ -85,7 +75,7 @@ contract TestContract is DSTest {
         // Lets say we want to find the slot for the public
         // variable `exists`. We just pass in the function selector
         // to the `find` command
-        uint256 slot = stdstore.target(address(test)).sig("exists()").find();
+        uint256 slot = storage.target(address(test)).sig("exists()").find();
         assertEq(slot, 0);
     }
 
@@ -93,7 +83,7 @@ contract TestContract is DSTest {
         // Lets say we want to write to the slot for the public
         // variable `exists`. We just pass in the function selector
         // to the `checked_write` command
-        stdstore.target(address(test)).sig("exists()").checked_write(100);
+        storage.target(address(test)).sig("exists()").checked_write(100);
         assertEq(test.exists(), 100);
     }
 
@@ -102,14 +92,14 @@ contract TestContract is DSTest {
         // `hidden` is a random hash of a bytes, iteration through slots would
         // not find it. Our mechanism does
         // Also, you can use the selector instead of a string
-        uint256 slot = stdstore.target(address(test)).sig(test.hidden.selector).find();
+        uint256 slot = storage.target(address(test)).sig(test.hidden.selector).find();
         assertEq(slot, keccak256("my.random.var"));
     }
 
     // If targeting a mapping, you have to pass in the keys necessary to perform the find
     // i.e.:
     function testFindMapping() public {
-        uint256 slot = stdstore
+        uint256 slot = storage
             .target(address(test))
             .sig(test.map_addr.selector)
             .with_key(address(this))
@@ -122,13 +112,13 @@ contract TestContract is DSTest {
     // If the target is a struct, you can specify the field depth:
     function testFindStruct() public {
         // NOTE: see the depth parameter - 0 means 0th field, 1 means 1st field, etc.
-        uint256 slot_for_a_field = stdstore
+        uint256 slot_for_a_field = storage
             .target(address(test))
             .sig(test.basicStruct.selector)
             .depth(0)
             .find();
 
-        uint256 slot_for_b_field = stdstore
+        uint256 slot_for_b_field = storage
             .target(address(test))
             .sig(test.basicStruct.selector)
             .depth(1)
@@ -182,14 +172,10 @@ This is a wrapper over miscellaneous cheatcodes that need wrappers to be more de
 // SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
-import "ds-test/test.sol";
-import {stdCheats} from "../stdlib.sol";
-import "../Vm.sol";
+import "forge-std/Test.sol";
 
 // Inherit the stdCheats
-contract StdCheatsTest is DSTest, stdCheats {
-    Vm public constant vm = Vm(HEVM_ADDRESS);
-
+contract StdCheatsTest is Test {
     Bar test;
     function setUp() public {
         test = new Bar();
@@ -231,8 +217,10 @@ contract Bar {
 
 Usage follows the same format as [Hardhat](https://hardhat.org/hardhat-network/reference/#console-log):
 ```solidity
+// import it indirectly via Test.sol
+import "forge-std/Test.sol";
+// or directly import it
 import "forge-std/console.sol";
 ...
 console.log(someValue);
-
 ```

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -2,67 +2,68 @@
 pragma solidity >=0.6.0 <0.9.0;
 
 import "./Vm.sol";
+import "ds-test/test.sol";
 
 // Wrappers around Cheatcodes to avoid footguns
-abstract contract stdCheats {
+abstract contract Test is DSTest {
     using stdStorage for StdStorage;
 
     event WARNING_Deprecated(string msg);
 
-    Vm private constant vm_std_cheats = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
+    Vm public constant vm = Vm(HEVM_ADDRESS);
     StdStorage private std_store_std_cheats;
 
     // Skip forward or rewind time by the specified number of seconds
     function skip(uint256 time) public {
-        vm_std_cheats.warp(block.timestamp + time);
+        vm.warp(block.timestamp + time);
     }
 
     function rewind(uint256 time) public {
-        vm_std_cheats.warp(block.timestamp - time);
+        vm.warp(block.timestamp - time);
     }
 
     // Setup a prank from an address that has some ether
     function hoax(address who) public {
-        vm_std_cheats.deal(who, 1 << 128);
-        vm_std_cheats.prank(who);
+        vm.deal(who, 1 << 128);
+        vm.prank(who);
     }
 
     function hoax(address who, uint256 give) public {
-        vm_std_cheats.deal(who, give);
-        vm_std_cheats.prank(who);
+        vm.deal(who, give);
+        vm.prank(who);
     }
 
     function hoax(address who, address origin) public {
-        vm_std_cheats.deal(who, 1 << 128);
-        vm_std_cheats.prank(who, origin);
+        vm.deal(who, 1 << 128);
+        vm.prank(who, origin);
     }
 
     function hoax(address who, address origin, uint256 give) public {
-        vm_std_cheats.deal(who, give);
-        vm_std_cheats.prank(who, origin);
+        vm.deal(who, give);
+        vm.prank(who, origin);
     }
 
     // Start perpetual prank from an address that has some ether
     function startHoax(address who) public {
-        vm_std_cheats.deal(who, 1 << 128);
-        vm_std_cheats.startPrank(who);
+        vm.deal(who, 1 << 128);
+        vm.startPrank(who);
     }
 
     function startHoax(address who, uint256 give) public {
-        vm_std_cheats.deal(who, give);
-        vm_std_cheats.startPrank(who);
+        vm.deal(who, give);
+        vm.startPrank(who);
     }
 
     // Start perpetual prank from an address that has some ether
     // tx.origin is set to the origin parameter
     function startHoax(address who, address origin) public {
-        vm_std_cheats.deal(who, 1 << 128);
-        vm_std_cheats.startPrank(who, origin);
+        vm.deal(who, 1 << 128);
+        vm.startPrank(who, origin);
     }
 
     function startHoax(address who, address origin, uint256 give) public {
-        vm_std_cheats.deal(who, give);
-        vm_std_cheats.startPrank(who, origin);
+        vm.deal(who, give);
+        vm.startPrank(who, origin);
     }
 
     // DEPRECATED: Use `deal` instead
@@ -78,7 +79,7 @@ abstract contract stdCheats {
     // The same as Hevm's `deal`
     // Use the alternative signature for ERC20 tokens
     function deal(address to, uint256 give) public {
-        vm_std_cheats.deal(to, give);
+        vm.deal(to, give);
     }
 
     // Set the balance of an account for any ERC20 token
@@ -122,7 +123,7 @@ abstract contract stdCheats {
         public
         returns (address addr)
     {
-        bytes memory bytecode = abi.encodePacked(vm_std_cheats.getCode(what), args);
+        bytes memory bytecode = abi.encodePacked(vm.getCode(what), args);
         assembly {
             addr := create(0, add(bytecode, 0x20), mload(bytecode))
         }
@@ -132,7 +133,7 @@ abstract contract stdCheats {
         public
         returns (address addr)
     {
-        bytes memory bytecode = vm_std_cheats.getCode(what);
+        bytes memory bytecode = vm.getCode(what);
         assembly {
             addr := create(0, add(bytecode, 0x20), mload(bytecode))
         }

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -11,7 +11,7 @@ abstract contract Test is DSTest {
     event WARNING_Deprecated(string msg);
 
     Vm public constant vm = Vm(HEVM_ADDRESS);
-    StdStorage private std_store_std_cheats;
+    StdStorage internal stdstore;
 
     // Skip forward or rewind time by the specified number of seconds
     function skip(uint256 time) public {
@@ -69,7 +69,7 @@ abstract contract Test is DSTest {
     // DEPRECATED: Use `deal` instead
     function tip(address token, address to, uint256 give) public {
         emit WARNING_Deprecated("The `tip` stdcheat has been deprecated. Use `deal` instead.");
-        std_store_std_cheats
+        stdstore
             .target(token)
             .sig(0x70a08231)
             .with_key(to)
@@ -94,7 +94,7 @@ abstract contract Test is DSTest {
         uint256 prevBal = abi.decode(balData, (uint256));
 
         // update balance
-        std_store_std_cheats
+        stdstore
             .target(token)
             .sig(0x70a08231)
             .with_key(to)
@@ -109,7 +109,7 @@ abstract contract Test is DSTest {
             } else {
                 totSup += (give - prevBal);
             }
-            std_store_std_cheats
+            stdstore
                 .target(token)
                 .sig(0x18160ddd)
                 .checked_write(totSup);

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.6.0 <0.9.0;
 
 import "./Vm.sol";
 import "ds-test/test.sol";
+import "./console.sol";
 
 // Wrappers around Cheatcodes to avoid footguns
 abstract contract Test is DSTest {

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.6.0 <0.9.0;
 
-import "ds-test/test.sol";
-import {stdCheats} from "../stdlib.sol";
-import "../Vm.sol";
+import "../Test.sol";
 
-contract StdCheatsTest is DSTest, stdCheats {
-    Vm public constant vm = Vm(HEVM_ADDRESS);
-
+contract StdCheatsTest is Test {
     Bar test;
     
     function setUp() public {
@@ -108,7 +104,7 @@ contract StdCheatsTest is DSTest, stdCheats {
 }
 
 contract Bar {
-    constructor() public {
+    constructor() {
         /// `DEAL` STDCHEAT
         totalSupply = 10000e18;
         balanceOf[address(this)] = totalSupply;

--- a/src/test/StdError.t.sol
+++ b/src/test/StdError.t.sol
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity 0.8.10;
 
-import "ds-test/test.sol";
-import {stdError} from "../stdlib.sol";
-import "../Vm.sol";
+import "../Test.sol";
 
-contract StdErrorsTest is DSTest {
-    Vm public constant vm = Vm(HEVM_ADDRESS);
-
+contract StdErrorsTest is Test {
     ErrorsTest test;
 
     function setUp() public {

--- a/src/test/StdStorage.t.sol
+++ b/src/test/StdStorage.t.sol
@@ -6,7 +6,6 @@ import "../Test.sol";
 contract StdStorageTest is Test {
     using stdStorage for StdStorage;
 
-    StdStorage stdstore;
     StorageTest test;
 
     function setUp() public {

--- a/src/test/StdStorage.t.sol
+++ b/src/test/StdStorage.t.sol
@@ -1,14 +1,10 @@
 // SPDX-License-Identifier: Unlicense
 pragma solidity >=0.6.0 <0.9.0;
 
-import "ds-test/test.sol";
-import "../stdlib.sol";
-import "../Vm.sol";
+import "../Test.sol";
 
-contract StdStorageTest is DSTest {
+contract StdStorageTest is Test {
     using stdStorage for StdStorage;
-
-    Vm public constant vm = Vm(HEVM_ADDRESS);
 
     StdStorage stdstore;
     StorageTest test;
@@ -249,7 +245,7 @@ contract StorageTest {
 
     mapping(address => bool) public map_bool;
 
-    constructor() public {
+    constructor() {
         basic = UnpackedStruct({
             a: 1337,
             b: 1337


### PR DESCRIPTION
Instead of having to do multiple imports, we now have a canonical `import forge-std/Test.sol` which is inherited from as `contract MyTest is Test`.

Test.sol now contains:
1) Cheatcodes under `vm`
2) all ds-test assert/log emits because it inherits from `DSTest`
3) console.log because it now imports it
4) `stdstore` which is made available by doing `using stdStorage for StdStorage` because libraries are not inherited (https://ethereum.stackexchange.com/a/98923)

This improves testing UX a lot, as you don't need to really remember any special imports or magic variables. You just import `Test` and you're g2g.

```solidity
pragma solidity 0.8.10;

import "forge-std/Test.sol";

contract ContractTest is Test {
    function testExample() public {
        vm.roll(100);
        console.log(1);
        emit log("hi");
        assertTrue(true);
    }
}
```


**This is a BREAKING change.**