### PR TITLE
Add base contracts to simplify mocking on tests

### DIFF
--- a/src/Mocks.sol
+++ b/src/Mocks.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.6.0 <0.9.0;
+
+import "./Vm.sol";
+import "./Test.sol";
+
+contract Mocks is Test {
+    /// @dev creates a strict mock and labels it, it's a good practice to always use strict mocks unless you really, really want leniency.
+    function mock(string memory label) internal returns (address mock_) {
+        mock_ = address(new StrictMock());
+        vm.label(mock_, label);
+    }
+
+    /// @dev same as `mock` but it deploys a lenient mock.
+    function lenientMock(string memory label) internal returns (address mock_) {
+        mock_ = address(new LenientMock());
+        vm.label(mock_, label);
+    }
+
+    /// @dev creates a strict mock (and labels it) on a pre-specified address,
+    /// useful to replace existing contracts on a fork or to test contracts that rely on deterministic addresses like uniswap pools
+    function mockAt(address where, string memory label)
+        internal
+        returns (address)
+    {
+        vm.etch(where, vm.getCode("Mocks.sol:StrictMock"));
+        vm.label(where, label);
+        return where;
+    }
+
+    /// @dev same as `mockAt` but it deploys a lenient mock.
+    function lenientMockAt(address where, string memory label)
+        internal
+        returns (address)
+    {
+        vm.etch(where, vm.getCode("Mocks.sol:LenientMock"));
+        vm.label(where, label);
+        return where;
+    }
+
+    function mockVoidCall(address _mock, bytes memory _calldata) internal {
+        vm.mockCall(
+            _mock,
+            _calldata,
+            abi.encode(0) // Would be nice to have a `vm.mockCall` that didn't require a return value
+        );
+    }
+}
+
+/// @dev Empty contract to deploy and use as a Mock, needed due to the fact that `vm.mockCall()` doesn't with non-contract addresses
+/// @notice this contract will purposely fail if called on an un-stubbed method
+contract StrictMock {
+    fallback() external payable {
+        revert("Not mocked!");
+    }
+}
+
+/// @dev Empty contract to deploy and use as a Mock, needed due to the fact that `vm.mockCall()` doesn't with non-contract addresses
+/// @notice this contract will do nothing if called on a method that wasn't previously stubbed
+contract LenientMock {
+    fallback() external payable {}
+}

--- a/src/test/Mocks.t.sol
+++ b/src/test/Mocks.t.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity >=0.6.0 <0.9.0;
+
+import "../Test.sol";
+import "../Mocks.sol";
+
+contract MocksTest is Test, Mocks {
+    function testFailStrictMockWhenUnstubbedFunctionIsCalled() public {
+        address thirdParty = mock("ThirParty");
+        SomeThirdParty(thirdParty).foo();
+    }
+
+    function testStrictMockCanStubAndVerifyParameterlessVoidFunctions() public {
+        address thirdParty = mock("ThirParty");
+
+        mockVoidCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.foo.selector)
+        );
+
+        vm.expectCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.foo.selector)
+        );
+
+        SomeThirdParty(thirdParty).foo();
+    }
+
+    function testStrictMockCanStubAndVerifyVoidFunctions() public {
+        address thirdParty = mock("ThirParty");
+
+        // When making verifications, it's easier to leave the function params out cause the error message
+        // in case there's a mismatch parameter is better
+        mockVoidCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.bar.selector)
+        );
+
+        vm.expectCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.bar.selector, 42)
+        );
+
+        SomeThirdParty(thirdParty).bar(42);
+    }
+
+    function testFailStrictMockOnUnexpectedParams() public {
+        address thirdParty = mock("ThirParty");
+
+        // When making verifications, it's easier to leave the function params out cause the error message
+        // in case there's a mismatch parameter is better
+        mockVoidCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.bar.selector)
+        );
+
+        vm.expectCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.bar.selector, 42)
+        );
+
+        SomeThirdParty(thirdParty).bar(43);
+    }
+
+    function testStrictMockCanStubAndVerifyFunctions() public {
+        address thirdParty = mock("ThirParty");
+
+        // When making verifications, it's easier to leave the function params out cause the error message
+        // in case there's a mismatch parameter is better
+        vm.mockCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.baz.selector),
+            abi.encode(69420)
+        );
+
+        vm.expectCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.baz.selector, 42)
+        );
+
+        assertEq(SomeThirdParty(thirdParty).baz(42), 69420);
+    }
+
+    function testLenientMockCanVerifyUnstubbedParameterlessVoidFunctions()
+        public
+    {
+        address thirdParty = lenientMock("ThirParty");
+
+        vm.expectCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.foo.selector)
+        );
+
+        SomeThirdParty(thirdParty).foo();
+    }
+
+    function testLenientMockCanVerifyUnstubbedVoidFunctions() public {
+        address thirdParty = lenientMock("ThirParty");
+
+        vm.expectCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.bar.selector, 42)
+        );
+
+        SomeThirdParty(thirdParty).bar(42);
+    }
+
+    function testFailLenientMockCanVerifyUnstubbedVoidFunctions() public {
+        address thirdParty = lenientMock("ThirParty");
+
+        vm.expectCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.bar.selector, 42)
+        );
+
+        SomeThirdParty(thirdParty).bar(43);
+    }
+
+    function testFailCantUseLenientMockOnNonVoidFunctions() public {
+        address thirdParty = lenientMock("ThirParty");
+        SomeThirdParty(thirdParty).baz(43);
+    }
+
+    function testCanDeployStrictMockOnArbitraryAddress() public {
+        address thirdParty = mockAt(address(1), "ThirParty");
+
+        mockVoidCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.foo.selector)
+        );
+
+        vm.expectCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.foo.selector)
+        );
+
+        SomeThirdParty(address(1)).foo();
+    }
+
+    function testCanDeployLenientMockOnArbitraryAddress() public {
+        address thirdParty = lenientMockAt(address(1), "ThirParty");
+
+        vm.expectCall(
+            thirdParty,
+            abi.encodeWithSelector(SomeThirdParty.foo.selector)
+        );
+
+        SomeThirdParty(address(1)).foo();
+    }
+}
+
+interface SomeThirdParty {
+    function foo() external;
+
+    function bar(uint256 i) external;
+
+    function baz(uint256 i) external returns (uint256);
+}


### PR DESCRIPTION
Adds wrappers and conveniece functions and contracts to make mocking easier with foundry.
It also adds a buch of tests, mostly as self-documenting examples.

