### PR TITLE
:gear: Additional Standard Cheats

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -23,6 +23,16 @@ abstract contract Test is DSTest {
         vm.warp(block.timestamp - time);
     }
 
+    // Abstract redundant signature encoding
+    function reverie(string memory sig) public {
+        vm.expectRevert(abi.encodeWithSignature(sig));
+    }
+
+    // Expect a full event
+    function emission() public {
+        vm.expectEmit(true, true, true, true);
+    }
+
     // Setup a prank from an address that has some ether
     function hoax(address who) public {
         vm.deal(who, 1 << 128);

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -14,6 +14,9 @@ abstract contract Test is DSTest {
     Vm public constant vm = Vm(HEVM_ADDRESS);
     StdStorage internal stdstore;
 
+    // The order of the secp256k1 curve
+    uint256 public constant SECP256K1_ORDER = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141;
+
     // Skip forward or rewind time by the specified number of seconds
     function skip(uint256 time) public {
         vm.warp(block.timestamp + time);
@@ -26,6 +29,16 @@ abstract contract Test is DSTest {
     // Abstract redundant signature encoding
     function reverie(string memory sig) public {
         vm.expectRevert(abi.encodeWithSignature(sig));
+    }
+
+    // Address Footguns
+    // A valid private key for secp256k1 must not be:
+    // 1. Equal to 0
+    // 2. Greater than or equal to the order of the secp256k1 curve
+    // ** Returns address(0) in either case, assuming no private key **
+    function key(uint256 pvk) public returns(address) {
+        if (pvk == 0 || pvk >= SECP256K1_ORDER) return address(0);
+        return vm.addr(pvk);
     }
 
     // Expect a full event

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -5,6 +5,8 @@ import "../Test.sol";
 
 contract StdCheatsTest is Test {
     Bar test;
+
+    event Car(address sender);
     
     function setUp() public {
         test = new Bar();
@@ -20,6 +22,17 @@ contract StdCheatsTest is Test {
         vm.warp(100);
         rewind(25);
         assertEq(block.timestamp, 75);
+    }
+
+    function testReverie() public {
+        reverie("Reverie()");
+        test.iRevert();
+    }
+
+    function testEmission() public {
+        emission();
+        emit Car(address(this));
+        test.bar(address(this));
     }
 
     function testHoax() public {
@@ -105,6 +118,8 @@ contract StdCheatsTest is Test {
 }
 
 contract Bar {
+    error Reverie();
+    event Car(address sender);
     constructor() {
         /// `DEAL` STDCHEAT
         totalSupply = 10000e18;
@@ -114,6 +129,7 @@ contract Bar {
     /// `HOAX` STDCHEATS
     function bar(address expectedSender) public payable {
         require(msg.sender == expectedSender, "!prank");
+        emit Car(msg.sender);
     }
     function origin(address expectedSender) public payable {
         require(msg.sender == expectedSender, "!prank");
@@ -122,6 +138,9 @@ contract Bar {
     function origin(address expectedSender, address expectedOrigin) public payable {
         require(msg.sender == expectedSender, "!prank");
         require(tx.origin == expectedOrigin, "!prank");
+    }
+    function iRevert() public pure {
+        revert Reverie();
     }
 
     /// `DEAL` STDCHEAT

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -29,6 +29,16 @@ contract StdCheatsTest is Test {
         test.iRevert();
     }
 
+    function testKey(uint256 pvk) public {
+        address pubKey = key(pvk);
+        if (pvk == 0 || pvk >= SECP256K1_ORDER) {
+            assertEq(pubKey, address(0));
+        } else {
+            // If this breaks, there's a private key for address 0 ;_;
+            assertTrue(pubKey != address(0));
+        }
+    }
+
     function testEmission() public {
         emission();
         emit Car(address(this));


### PR DESCRIPTION
## Overview

Introduces new Standard Cheats to abstract redundant operations I find myself doing too frequently with foundry testing.

## Checlist

- [x] `reverie`
- [x] `emission`
- [x] `key` 