### PR TITLE
Fix STD-Math 0.6.0 compatibility

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -567,10 +567,11 @@ library stdStorage {
 
 library stdMath {
     function abs(int256 a) internal pure returns (uint256) {
-         unchecked {
-             // must be unchecked in order to support `a = type(int256).min`
-            return uint256(a >= 0 ? a : -a);
-        }
+        // Required or it will fail when `a = type(int256).min`
+        if (a == -57896044618658097711785492504343953926634992332820282019728792003956564819968)
+            return 57896044618658097711785492504343953926634992332820282019728792003956564819968;
+
+        return uint256(a >= 0 ? a : -a);
     }
 
     function delta(uint256 a, uint256 b) internal pure returns (uint256) {


### PR DESCRIPTION
Fixes #53 

## Description

- Removes `unchecked` to keep `0.6.0` compatibility
- Hardcodes case for `a = type(int256).min`

## Notes

Unfortunately, I can't do something like:

```
if (a == type(int256).min)
            return  type(int256).max + 1;
```

Since `type()` was introduced in [Solidity `0.6.8`](https://github.com/ethereum/solidity/releases/tag/v0.6.8)
If you want to use `type()`, you can bump the min version for this package to `0.6.8`