### PR TITLE
build: check compatibility with older solc versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,3 +19,8 @@ jobs:
         run: forge install
       - name: Run tests
         run: forge test -vvv
+      - name: Build Test with older solc versions
+        run: |
+          forge build --contracts src/Test.sol --use solc:0.8.0
+          forge build --contracts src/Test.sol --use solc:0.7.0
+          forge build --contracts src/Test.sol --use solc:0.6.0

--- a/src/test/StdAssertions.t.sol
+++ b/src/test/StdAssertions.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicense
-pragma solidity 0.8.10;
+pragma solidity >=0.7.0 <0.9.0;
 
 import "../Test.sol";
 

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicense
-pragma solidity >=0.6.0 <0.9.0;
+pragma solidity >=0.7.0 <0.9.0;
 
 import "../Test.sol";
 

--- a/src/test/StdError.t.sol
+++ b/src/test/StdError.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicense
-pragma solidity 0.8.10;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "../Test.sol";
 

--- a/src/test/StdError.t.sol
+++ b/src/test/StdError.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicense
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity >=0.8.10 <0.9.0;
 
 import "../Test.sol";
 

--- a/src/test/StdMath.t.sol
+++ b/src/test/StdMath.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicense
-pragma solidity 0.8.10;
+pragma solidity >=0.8.0 <0.9.0;
 
 import "../Test.sol";
 

--- a/src/test/StdStorage.t.sol
+++ b/src/test/StdStorage.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicense
-pragma solidity >=0.6.0 <0.9.0;
+pragma solidity >=0.7.0 <0.9.0;
 
 import "../Test.sol";
 


### PR DESCRIPTION
## Motivation

Fixes #55

## Solution

Update the CI to additionally build the `Test` contract with solc versions `0.8.0`, `0.7.0`, `0.6.0`.

This will prevent us from accidentally breaking compatibility with older Solidity versions in the future.