### PR TITLE
feat: upstream Solmate's bound 

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -345,25 +345,6 @@ abstract contract Test is DSTest {
             assertApproxEqRel(a, b, maxPercentDelta);
         }
     }
-
-    function assertRelApproxEq(
-        uint256 a,
-        uint256 b,
-        uint256 maxPercentDelta // An 18 decimal fixed point number, where 1e18 == 100%
-    ) internal virtual {
-        if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
-
-        uint256 percentDelta = ((a > b ? a - b : b - a) * 1e18) / b;
-
-        if (percentDelta > maxPercentDelta) {
-            emit log("Error: a ~= b not satisfied [uint]");
-            emit log_named_uint("    Expected", b);
-            emit log_named_uint("      Actual", a);
-            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta, 18);
-            emit log_named_decimal_uint("     % Delta", percentDelta, 18);
-            fail();
-        }
-    }
 }
 
 /*//////////////////////////////////////////////////////////////////////////

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -122,25 +122,25 @@ abstract contract Test is DSTest {
         }
     }
 
-    function bound(
-        uint256 x,
-        uint256 min,
-        uint256 max
-    ) internal returns (uint256 result) {
-        require(max >= min, "MAX_LESS_THAN_MIN");
+    function bound(uint256 x, uint256 min, uint256 max) public returns (uint256 result) {
+        require(min <= max, "MAX_LESS_THAN_MIN");
 
         uint256 size = max - min;
 
-        if (max != type(uint256).max) size++; // Make the max inclusive.
-        if (size == 0) return min; // Using max would be equivalent as well.
-        // Ensure max is inclusive in cases where x != 0 and max is at uint max.
-        if (max == type(uint256).max && x != 0) x--; // Accounted for later.
-
-        if (x < min) x += size * (((min - x) / size) + 1);
-        result = min + ((x - min) % size);
-
-        // Account for decrementing x to make max inclusive.
-        if (max == type(uint256).max && x != 0) result++;
+        if (size == 0)
+        {
+            result = min;
+        }
+        else if (size == type(uint256).max)
+        {
+            result = x;
+        }
+        else
+        {
+            ++size; // make `max` inclusive
+            uint256 mod = x % size;
+            result = min + mod;
+        }
 
         emit log_named_uint("Bound Result", result);
     }

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -80,13 +80,13 @@ contract StdCheatsTest is Test {
         assertEq(bound(5, 0, 4), 0);
         assertEq(bound(0, 69, 69), 69);
         assertEq(bound(0, 68, 69), 68);
-        assertEq(bound(10, 150, 190), 174);
-        assertEq(bound(300, 2800, 3200), 3107);
-        assertEq(bound(9999, 1337, 6666), 4669);
+        assertEq(bound(10, 150, 190), 160);
+        assertEq(bound(300, 2800, 3200), 3100);
+        assertEq(bound(9999, 1337, 6666), 6006);
         
     }
 
-    function testRevertBoundMinBiggerThanMax() public {
+    function testCannotBoundMaxLessThanMin() public {
         vm.expectRevert(bytes("MAX_LESS_THAN_MIN"));
         bound(5, 100, 10);
     }
@@ -105,10 +105,10 @@ contract StdCheatsTest is Test {
     }
 
     function testBoundUint256Max() public {
-        assertEq(bound(0, type(uint256).max - 1, type(uint256).max), type(uint256).max);
+        assertEq(bound(0, type(uint256).max - 1, type(uint256).max), type(uint256).max - 1);
     }
 
-    function testRevertBoundMinBiggerThanMax(
+    function testCannotBoundMaxLessThanMin(
         uint256 num,
         uint256 min,
         uint256 max

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -76,6 +76,60 @@ contract StdCheatsTest is Test {
         assertEq(barToken.totalSupply(), 10000e18);
     }
 
+    function testBound() public {
+        assertEq(bound(5, 0, 4), 0);
+        assertEq(bound(0, 69, 69), 69);
+        assertEq(bound(0, 68, 69), 68);
+        assertEq(bound(10, 150, 190), 174);
+        assertEq(bound(300, 2800, 3200), 3107);
+        assertEq(bound(9999, 1337, 6666), 4669);
+        
+    }
+
+    function testRevertBoundMinBiggerThanMax() public {
+        vm.expectRevert(bytes("MAX_LESS_THAN_MIN"));
+        bound(5, 100, 10);
+    }
+
+    function testRelApproxEqBothZeroesPasses() public {
+        assertRelApproxEq(0, 0, 1e18);
+        assertRelApproxEq(0, 0, 0);
+    }
+
+    function testBound(
+        uint256 num,
+        uint256 min,
+        uint256 max
+    ) public {
+        if (min > max) (min, max) = (max, min);
+
+        uint256 bounded = bound(num, min, max);
+
+        assertGe(bounded, min);
+        assertLe(bounded, max);
+    }
+
+    function testBound_Uint256Max() public {
+        assertEq(bound(0, type(uint256).max - 1, type(uint256).max), type(uint256).max);
+    }
+
+    function testRevertBoundMinBiggerThanMax(
+        uint256 num,
+        uint256 min,
+        uint256 max
+    ) public {
+        if (max == min) {
+            unchecked {
+                min++; // Overflow is handled below.
+            }
+        }
+
+        if (max > min) (min, max) = (max, min);
+
+        vm.expectRevert(bytes("MAX_LESS_THAN_MIN"));
+        bound(num, min, max);
+    }
+
     function testDeployCode() public {
         address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", bytes(""));
         assertEq(string(getCode(deployed)), string(getCode(address(this))));

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -91,11 +91,6 @@ contract StdCheatsTest is Test {
         bound(5, 100, 10);
     }
 
-    function testRelApproxEqBothZeroesPasses() public {
-        assertRelApproxEq(0, 0, 1e18);
-        assertRelApproxEq(0, 0, 0);
-    }
-
     function testBound(
         uint256 num,
         uint256 min,
@@ -109,7 +104,7 @@ contract StdCheatsTest is Test {
         assertLe(bounded, max);
     }
 
-    function testBound_Uint256Max() public {
+    function testBoundUint256Max() public {
         assertEq(bound(0, type(uint256).max - 1, type(uint256).max), type(uint256).max);
     }
 
@@ -118,14 +113,7 @@ contract StdCheatsTest is Test {
         uint256 min,
         uint256 max
     ) public {
-        if (max == min) {
-            unchecked {
-                min++; // Overflow is handled below.
-            }
-        }
-
-        if (max > min) (min, max) = (max, min);
-
+        vm.assume(min > max);
         vm.expectRevert(bytes("MAX_LESS_THAN_MIN"));
         bound(num, min, max);
     }

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -106,6 +106,7 @@ contract StdCheatsTest is Test {
 
     function testBoundUint256Max() public {
         assertEq(bound(0, type(uint256).max - 1, type(uint256).max), type(uint256).max - 1);
+        assertEq(bound(1, type(uint256).max - 1, type(uint256).max), type(uint256).max);
     }
 
     function testCannotBoundMaxLessThanMin(


### PR DESCRIPTION
Added ```bound``` from Solmate and added the associated tests from the repo as well. All ```testFail``` style tests were updated to ```expectRevert``` and an additional test for ```type(uint256).max``` as the upper bound was also added to test edge case.

Closes #48 