### PR TITLE
fix(test): hardcore `type(uint256).max` value

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -131,7 +131,7 @@ abstract contract Test is DSTest {
         {
             result = min;
         }
-        else if (size == type(uint256).max)
+        else if (size == 115792089237316195423570985008687907853269984665640564039457584007913129639935)
         {
             result = x;
         }


### PR DESCRIPTION
Fix `Test.sol` compatibility with Solidity version `0.6.0`.