### PR TITLE
Add non-reentrant comment to remove reentrancies detected by Slither

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -12,6 +12,7 @@ abstract contract Test is DSTest {
 
     event WARNING_Deprecated(string msg);
 
+    /// @custom:security non-reentrant
     Vm public constant vm = Vm(HEVM_ADDRESS);
     StdStorage internal stdstore;
 
@@ -361,6 +362,7 @@ library stdStorage {
     event SlotFound(address who, bytes4 fsig, bytes32 keysHash, uint slot);
     event WARNING_UninitedSlot(address who, uint slot);
 
+    /// @custom:security non-reentrant
     Vm private constant vm_std_store = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
 
     function sigs(


### PR DESCRIPTION
Slither [0.8.3](https://github.com/crytic/slither/releases/tag/0.8.3) added the support for custom code comments to help the detectors.

In particular, adding `@custom:security non-reentrant` before a contract variable will remove any reentrancy findings related to this contract. Because `vm` and `vm_std_store` are only used for internal testing through hevm cheatcode, I think that we can safely assume that they don't create reentrancy risks.