### PR TITLE
feat(storage): add `read` functions

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -564,32 +564,31 @@ library stdStorage {
         delete self._depth;
     }
 
-    function read_bytes32(StdStorage storage self) internal returns (bytes32) {
+    function read(StdStorage storage self) private returns (bytes memory) {
         address t = self._target;
         uint256 s = find(self);
-        return vm_std_store.load(t, bytes32(s));
+        return abi.encode(vm_std_store.load(t, bytes32(s)));
+    }
+
+    function read_bytes32(StdStorage storage self) internal returns (bytes32) {
+        return abi.decode(read(self), (bytes32));
     }
 
 
     function read_bool(StdStorage storage self) internal returns (bool) {
-        return read_bytes32(self) == hex"00" ? false : true;
+        return abi.decode(read(self), (bool));
     }
 
     function read_address(StdStorage storage self) internal returns (address) {
-        return address(uint160(uint256(read_bytes32(self))));
+        return abi.decode(read(self), (address));
     }
 
     function read_uint(StdStorage storage self) internal returns (uint256) {
-        return uint256(read_bytes32(self));
+        return abi.decode(read(self), (uint256));
     }
 
     function read_int(StdStorage storage self) internal returns (int256) {
-        uint256 u = read_uint(self);
-        // convert from `uint` to `int`
-        if(u > uint256(INT256_MAX)) {
-            return 0 - int256(UINT256_MAX - u) - 1;
-        }
-        return int256(u);
+        return abi.decode(read(self), (int256));
     }
 
     function bytesToBytes32(bytes memory b, uint offset) public pure returns (bytes32) {

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -10,6 +10,8 @@ import "./console2.sol";
 abstract contract Test is DSTest {
     using stdStorage for StdStorage;
 
+    uint256 private constant UINT256_MAX = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+
     event WARNING_Deprecated(string msg);
 
     Vm public constant vm = Vm(HEVM_ADDRESS);
@@ -131,7 +133,7 @@ abstract contract Test is DSTest {
         {
             result = min;
         }
-        else if (size == 115792089237316195423570985008687907853269984665640564039457584007913129639935)
+        else if (size == UINT256_MAX)
         {
             result = x;
         }
@@ -624,9 +626,11 @@ library stdStorage {
 //////////////////////////////////////////////////////////////////////////*/
 
 library stdMath {
+    int256 private constant INT256_MIN = -57896044618658097711785492504343953926634992332820282019728792003956564819968;
+
     function abs(int256 a) internal pure returns (uint256) {
         // Required or it will fail when `a = type(int256).min`
-        if (a == -57896044618658097711785492504343953926634992332820282019728792003956564819968)
+        if (a == INT256_MIN)
             return 57896044618658097711785492504343953926634992332820282019728792003956564819968;
 
         return uint256(a >= 0 ? a : -a);

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -564,27 +564,23 @@ library stdStorage {
         delete self._depth;
     }
 
-    function read(StdStorage storage self) private returns (bytes32) {
+    function read_bytes32(StdStorage storage self) internal returns (bytes32) {
         address t = self._target;
         uint256 s = find(self);
         return vm_std_store.load(t, bytes32(s));
     }
 
-    function read_bytes32(StdStorage storage self) internal returns (bytes32) {
-        return read(self);
-    }
-
 
     function read_bool(StdStorage storage self) internal returns (bool) {
-        return read(self) == hex"00" ? false : true;
+        return read_bytes32(self) == hex"00" ? false : true;
     }
 
     function read_address(StdStorage storage self) internal returns (address) {
-        return address(uint160(uint256(read(self))));
+        return address(uint160(uint256(read_bytes32(self))));
     }
 
     function read_uint(StdStorage storage self) internal returns (uint256) {
-        return uint256(read(self));
+        return uint256(read_bytes32(self));
     }
 
     function read_int(StdStorage storage self) internal returns (int256) {

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -384,6 +384,9 @@ library stdStorage {
     event SlotFound(address who, bytes4 fsig, bytes32 keysHash, uint slot);
     event WARNING_UninitedSlot(address who, uint slot);
 
+    uint256 private constant UINT256_MAX = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+    int256 private constant INT256_MAX = 57896044618658097711785492504343953926634992332820282019728792003956564819967;
+
     Vm private constant vm_std_store = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
 
     function sigs(
@@ -557,6 +560,38 @@ library stdStorage {
         delete self._sig;
         delete self._keys;
         delete self._depth;
+    }
+
+    function read(StdStorage storage self) private returns (bytes32) {
+        address t = self._target;
+        uint256 s = find(self);
+        return vm_std_store.load(t, bytes32(s));
+    }
+
+    function read_bytes32(StdStorage storage self) internal returns (bytes32) {
+        return read(self);
+    }
+
+
+    function read_bool(StdStorage storage self) internal returns (bool) {
+        return read(self) == hex"00" ? false : true;
+    }
+
+    function read_address(StdStorage storage self) internal returns (address) {
+        return address(uint160(uint256(read(self))));
+    }
+
+    function read_uint(StdStorage storage self) internal returns (uint256) {
+        return uint256(read(self));
+    }
+
+    function read_int(StdStorage storage self) internal returns (int256) {
+        uint256 u = read_uint(self);
+        // convert from `uint` to `int`
+        if(u > uint256(INT256_MAX)) {
+            return 0 - int256(UINT256_MAX - u) - 1;
+        }
+        return int256(u);
     }
 
     function bytesToBytes32(bytes memory b, uint offset) public pure returns (bytes32) {

--- a/src/test/StdStorage.t.sol
+++ b/src/test/StdStorage.t.sol
@@ -217,6 +217,31 @@ contract StdStorageTest is Test {
         stdstore.target(address(test)).sig(test.tC.selector).find();
         stdstore.target(address(test)).sig(test.tD.selector).find();
     }
+
+    function testStorageReadBytes32() public {
+        bytes32 val = stdstore.target(address(test)).sig(test.tE.selector).read_bytes32();
+        assertEq(val, hex"1337");
+    }
+
+    function testStorageReadBool() public {
+        bool val = stdstore.target(address(test)).sig(test.tB.selector).read_bool();
+        assertEq(val, false);
+    }
+
+    function testStorageReadAddress() public {
+        address val = stdstore.target(address(test)).sig(test.tF.selector).read_address();
+        assertEq(val, address(1337));
+    }
+
+    function testStorageReadUint() public {
+        uint256 val = stdstore.target(address(test)).sig(test.exists.selector).read_uint();
+        assertEq(val, 1);
+    }
+
+    function testStorageReadInt() public {
+        int256 val = stdstore.target(address(test)).sig(test.tG.selector).read_int();
+        assertEq(val, type(int256).min);
+    }
 }
 
 contract StorageTest {
@@ -243,6 +268,10 @@ contract StorageTest {
     }
 
     mapping(address => bool) public map_bool;
+
+    bytes32 public tE = hex"1337";
+    address public tF = address(1337);
+    int256 public tG = type(int256).min;
 
     constructor() {
         basic = UnpackedStruct({


### PR DESCRIPTION
## Motivation

Resolve #65 

## Solution

Add the following terminator functions to `StdStorage`:

- `read_bytes32`
- `read_bool`
- `read_address`
- `read_uint`
- `read_int`

The naming style follows the DSTest convention (`_<type>`, such as `log_address`).

### Example

```solidity
// BEFORE

uint256 slot = stdstore
    .target(address(c))
    .sig(c.a.selector)
    .find();

bytes32 val = vm.load(address(c), bytes32(slot));

address a = address(uint160(uint256(val)));


// NOW

address a = stdstore
    .target(address(c))
    .sig(c.a.selector)
    .read_address();
```

Cc @itamarreif
And also let's discuss whether this is the right solution.