### PR TITLE
fix: CapWords naming style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cache/
 out/
+.idea

--- a/README.md
+++ b/README.md
@@ -222,25 +222,25 @@ Expand upon the assertion functions from the `DSTest` library.
 ### `console.log`
 
 Usage follows the same format as [Hardhat](https://hardhat.org/hardhat-network/reference/#console-log).
-It's recommended to use `console2.sol` as shown below, as this will show the decoded logs in Forge traces.
+It's recommended to use `Console2.sol` as shown below, as this will show the decoded logs in Forge traces.
 
 ```solidity
 // import it indirectly via Test.sol
 import "forge-std/Test.sol";
 // or directly import it
-import "forge-std/console2.sol";
+import "forge-std/Console2.sol";
 ...
 console2.log(someValue);
 ```
 
-If you need compatibility with Hardhat, you must use the standard `console.sol` instead.
-Due to a bug in `console.sol`, logs that use `uint256` or `int256` types will not be properly decoded in Forge traces.
+If you need compatibility with Hardhat, you must use the standard `Console.sol` instead.
+Due to a bug in `Console.sol`, logs that use `uint256` or `int256` types will not be properly decoded in Forge traces.
 
 ```solidity
 // import it indirectly via Test.sol
 import "forge-std/Test.sol";
 // or directly import it
-import "forge-std/console.sol";
+import "forge-std/Console.sol";
 ...
 console.log(someValue);
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ contract TestContract is Test {
     }
 
     function testExpectArithmetic() public {
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert(StdError.arithmeticError);
         test.arithmeticError(10);
     }
 }

--- a/src/Console.sol
+++ b/src/Console.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.4.22 <0.9.0;
 
-library console {
+library Console {
     address constant CONSOLE_ADDRESS = address(0x000000000000000000636F6e736F6c652e6c6f67);
 
     function _sendLogPayload(bytes memory payload) private view {

--- a/src/Console2.sol
+++ b/src/Console2.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.4.22 <0.9.0;
 
-// The orignal console.sol uses `int` and `uint` for computing function selectors, but it should
+// The original Console.sol uses `int` and `uint` for computing function selectors, but it should
 // use `int256` and `uint256`. This modified version fixes that. This version is recommended
-// over `console.sol` if you don't need compatibility with Hardhat as the logs will show up in
-// forge stack traces. If you do need compatibility with Hardhat, you must use `console.sol`.
+// over `Console.sol` if you don't need compatibility with Hardhat as the logs will show up in
+// forge stack traces. If you do need compatibility with Hardhat, you must use `Console.sol`.
 // Reference: https://github.com/NomicFoundation/hardhat/issues/2178
 
-library console2 {
+library Console2 {
     address constant CONSOLE_ADDRESS = address(0x000000000000000000636F6e736F6c652e6c6f67);
 
     function _sendLogPayload(bytes memory payload) private view {

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -8,12 +8,12 @@ import "./Console2.sol";
 
 // Wrappers around Cheatcodes to avoid footguns
 abstract contract Test is DSTest {
-    using stdStorage for StdStorage;
+    using StdStorage for StdStore;
 
     event WARNING_Deprecated(string msg);
 
     Vm public constant vm = Vm(HEVM_ADDRESS);
-    StdStorage internal stdstore;
+    StdStore internal stdstore;
 
     /*//////////////////////////////////////////////////////////////////////////
                                     STD-CHEATS
@@ -369,7 +369,7 @@ library StdError {
                                 STD-STORAGE
 //////////////////////////////////////////////////////////////////////////*/
 
-struct StdStorage {
+struct StdStore {
     mapping (address => mapping(bytes4 => mapping(bytes32 => uint256))) slots;
     mapping (address => mapping(bytes4 =>  mapping(bytes32 => bool))) finds;
 
@@ -380,7 +380,7 @@ struct StdStorage {
     bytes32 _set;
 }
 
-library stdStorage {
+library StdStorage {
     event SlotFound(address who, bytes4 fsig, bytes32 keysHash, uint slot);
     event WARNING_UninitedSlot(address who, uint slot);
 
@@ -403,7 +403,7 @@ library stdStorage {
     //  if deep map, will be keccak256(abi.encode(key1, keccak256(abi.encode(key0, uint(slot)))));
     //  if map struct, will be bytes32(uint256(keccak256(abi.encode(key1, keccak256(abi.encode(key0, uint(slot)))))) + structFieldDepth);
     function find(
-        StdStorage storage self
+        StdStore storage self
     )
         internal
         returns (uint256)
@@ -476,49 +476,49 @@ library stdStorage {
         return self.slots[who][fsig][keccak256(abi.encodePacked(ins, field_depth))];
     }
 
-    function target(StdStorage storage self, address _target) internal returns (StdStorage storage) {
+    function target(StdStore storage self, address _target) internal returns (StdStore storage) {
         self._target = _target;
         return self;
     }
 
-    function sig(StdStorage storage self, bytes4 _sig) internal returns (StdStorage storage) {
+    function sig(StdStore storage self, bytes4 _sig) internal returns (StdStore storage) {
         self._sig = _sig;
         return self;
     }
 
-    function sig(StdStorage storage self, string memory _sig) internal returns (StdStorage storage) {
+    function sig(StdStore storage self, string memory _sig) internal returns (StdStore storage) {
         self._sig = sigs(_sig);
         return self;
     }
 
-    function with_key(StdStorage storage self, address who) internal returns (StdStorage storage) {
+    function with_key(StdStore storage self, address who) internal returns (StdStore storage) {
         self._keys.push(bytes32(uint256(uint160(who))));
         return self;
     }
 
-    function with_key(StdStorage storage self, uint256 amt) internal returns (StdStorage storage) {
+    function with_key(StdStore storage self, uint256 amt) internal returns (StdStore storage) {
         self._keys.push(bytes32(amt));
         return self;
     }
-    function with_key(StdStorage storage self, bytes32 key) internal returns (StdStorage storage) {
+    function with_key(StdStore storage self, bytes32 key) internal returns (StdStore storage) {
         self._keys.push(key);
         return self;
     }
 
-    function depth(StdStorage storage self, uint256 _depth) internal returns (StdStorage storage) {
+    function depth(StdStore storage self, uint256 _depth) internal returns (StdStore storage) {
         self._depth = _depth;
         return self;
     }
 
-    function checked_write(StdStorage storage self, address who) internal {
+    function checked_write(StdStore storage self, address who) internal {
         checked_write(self, bytes32(uint256(uint160(who))));
     }
 
-    function checked_write(StdStorage storage self, uint256 amt) internal {
+    function checked_write(StdStore storage self, uint256 amt) internal {
         checked_write(self, bytes32(amt));
     }
 
-    function checked_write(StdStorage storage self, bool write) internal {
+    function checked_write(StdStore storage self, bool write) internal {
         bytes32 t;
         /// @solidity memory-safe-assembly
         assembly {
@@ -528,7 +528,7 @@ library stdStorage {
     }
 
     function checked_write(
-        StdStorage storage self,
+        StdStore storage self,
         bytes32 set
     ) internal {
         address who = self._target;

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.6.0 <0.9.0;
 
 import "./Vm.sol";
 import "ds-test/test.sol";
-import "./console.sol";
-import "./console2.sol";
+import "./Console.sol";
+import "./Console2.sol";
 
 // Wrappers around Cheatcodes to avoid footguns
 abstract contract Test is DSTest {

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -351,7 +351,7 @@ abstract contract Test is DSTest {
                                 STD-ERRORS
 //////////////////////////////////////////////////////////////////////////*/
 
-library stdError {
+library StdError {
     bytes public constant assertionError = abi.encodeWithSignature("Panic(uint256)", 0x01);
     bytes public constant arithmeticError = abi.encodeWithSignature("Panic(uint256)", 0x11);
     bytes public constant divisionError = abi.encodeWithSignature("Panic(uint256)", 0x12);

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -219,7 +219,7 @@ abstract contract Test is DSTest {
         uint256 b,
         uint256 maxDelta
     ) internal virtual {
-        uint256 delta = stdMath.delta(a, b);
+        uint256 delta = StdMath.delta(a, b);
 
         if (delta > maxDelta) {
             emit log            ("Error: a ~= b not satisfied [uint]");
@@ -237,7 +237,7 @@ abstract contract Test is DSTest {
         uint256 maxDelta,
         string memory err
     ) internal virtual {
-        uint256 delta = stdMath.delta(a, b);
+        uint256 delta = StdMath.delta(a, b);
 
         if (delta > maxDelta) {
             emit log_named_string   ("Error", err);
@@ -250,7 +250,7 @@ abstract contract Test is DSTest {
         int256 b,
         uint256 maxDelta
     ) internal virtual {
-        uint256 delta = stdMath.delta(a, b);
+        uint256 delta = StdMath.delta(a, b);
 
         if (delta > maxDelta) {
             emit log            ("Error: a ~= b not satisfied [int]");
@@ -268,7 +268,7 @@ abstract contract Test is DSTest {
         uint256 maxDelta,
         string memory err
     ) internal virtual {
-        uint256 delta = stdMath.delta(a, b);
+        uint256 delta = StdMath.delta(a, b);
 
         if (delta > maxDelta) {
             emit log_named_string   ("Error", err);
@@ -283,7 +283,7 @@ abstract contract Test is DSTest {
     ) internal virtual {
         if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
 
-        uint256 percentDelta = stdMath.percentDelta(a, b);
+        uint256 percentDelta = StdMath.percentDelta(a, b);
 
         if (percentDelta > maxPercentDelta) {
             emit log                    ("Error: a ~= b not satisfied [uint]");
@@ -303,7 +303,7 @@ abstract contract Test is DSTest {
     ) internal virtual {
         if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
 
-        uint256 percentDelta = stdMath.percentDelta(a, b);
+        uint256 percentDelta = StdMath.percentDelta(a, b);
 
         if (percentDelta > maxPercentDelta) {
             emit log_named_string       ("Error", err);
@@ -318,7 +318,7 @@ abstract contract Test is DSTest {
     ) internal virtual {
         if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
 
-        uint256 percentDelta = stdMath.percentDelta(a, b);
+        uint256 percentDelta = StdMath.percentDelta(a, b);
 
         if (percentDelta > maxPercentDelta) {
             emit log                   ("Error: a ~= b not satisfied [int]");
@@ -338,7 +338,7 @@ abstract contract Test is DSTest {
     ) internal virtual {
         if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
 
-        uint256 percentDelta = stdMath.percentDelta(a, b);
+        uint256 percentDelta = StdMath.percentDelta(a, b);
 
         if (percentDelta > maxPercentDelta) {
             emit log_named_string      ("Error", err);
@@ -588,7 +588,7 @@ library stdStorage {
                                 STD-MATH
 //////////////////////////////////////////////////////////////////////////*/
 
-library stdMath {
+library StdMath {
     function abs(int256 a) internal pure returns (uint256) {
         // Required or it will fail when `a = type(int256).min`
         if (a == -57896044618658097711785492504343953926634992332820282019728792003956564819968)

--- a/src/test/StdAssertions.t.sol
+++ b/src/test/StdAssertions.t.sol
@@ -105,13 +105,13 @@ contract StdAssertionsTest is Test
     //////////////////////////////////////////////////////////////////////////*/
 
     function testAssertApproxEqAbs_Uint_Pass(uint256 a, uint256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) <= maxDelta);
+        vm.assume(StdMath.delta(a, b) <= maxDelta);
 
         t._assertApproxEqAbs(a, b, maxDelta, EXPECT_PASS);
     }
 
     function testAssertApproxEqAbs_Uint_Fail(uint256 a, uint256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) > maxDelta);
+        vm.assume(StdMath.delta(a, b) > maxDelta);
 
         vm.expectEmit(false, false, false, true);
         emit log("Error: a ~= b not satisfied [uint]");
@@ -119,13 +119,13 @@ contract StdAssertionsTest is Test
     }
 
     function testAssertApproxEqAbs_UintErr_Pass(uint256 a, uint256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) <= maxDelta);
+        vm.assume(StdMath.delta(a, b) <= maxDelta);
 
         t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testAssertApproxEqAbs_UintErr_Fail(uint256 a, uint256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) > maxDelta);
+        vm.assume(StdMath.delta(a, b) > maxDelta);
 
         vm.expectEmit(true, false, false, true);
         emit log_named_string("Error", CUSTOM_ERROR);
@@ -137,13 +137,13 @@ contract StdAssertionsTest is Test
     //////////////////////////////////////////////////////////////////////////*/
 
     function testAssertApproxEqAbs_Int_Pass(int256 a, int256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) <= maxDelta);
+        vm.assume(StdMath.delta(a, b) <= maxDelta);
 
         t._assertApproxEqAbs(a, b, maxDelta, EXPECT_PASS);
     }
 
     function testAssertApproxEqAbs_Int_Fail(int256 a, int256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) > maxDelta);
+        vm.assume(StdMath.delta(a, b) > maxDelta);
 
         vm.expectEmit(false, false, false, true);
         emit log("Error: a ~= b not satisfied [int]");
@@ -151,13 +151,13 @@ contract StdAssertionsTest is Test
     }
 
     function testAssertApproxEqAbs_IntErr_Pass(int256 a, int256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) <= maxDelta);
+        vm.assume(StdMath.delta(a, b) <= maxDelta);
 
         t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testAssertApproxEqAbs_IntErr_Fail(int256 a, int256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) > maxDelta);
+        vm.assume(StdMath.delta(a, b) > maxDelta);
 
         vm.expectEmit(true, false, false, true);
         emit log_named_string("Error", CUSTOM_ERROR);
@@ -170,14 +170,14 @@ contract StdAssertionsTest is Test
 
     function testAssertApproxEqRel_Uint_Pass(uint256 a, uint256 b, uint256 maxPercentDelta) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
-        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+        vm.assume(StdMath.percentDelta(a, b) <= maxPercentDelta);
 
         t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_PASS);
     }
 
     function testAssertApproxEqRel_Uint_Fail(uint256 a, uint256 b, uint256 maxPercentDelta) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
-        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
+        vm.assume(StdMath.percentDelta(a, b) > maxPercentDelta);
 
         vm.expectEmit(false, false, false, true);
         emit log("Error: a ~= b not satisfied [uint]");
@@ -186,14 +186,14 @@ contract StdAssertionsTest is Test
 
     function testAssertApproxEqRel_UintErr_Pass(uint256 a, uint256 b, uint256 maxPercentDelta) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
-        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+        vm.assume(StdMath.percentDelta(a, b) <= maxPercentDelta);
 
         t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testAssertApproxEqRel_UintErr_Fail(uint256 a, uint256 b, uint256 maxPercentDelta) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
-        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
+        vm.assume(StdMath.percentDelta(a, b) > maxPercentDelta);
 
         vm.expectEmit(true, false, false, true);
         emit log_named_string("Error", CUSTOM_ERROR);
@@ -206,14 +206,14 @@ contract StdAssertionsTest is Test
 
     function testAssertApproxEqRel_Int_Pass(int128 a, int128 b, uint128 maxPercentDelta) external {
         vm.assume(b != 0);
-        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+        vm.assume(StdMath.percentDelta(a, b) <= maxPercentDelta);
 
         t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_PASS);
     }
 
     function testAssertApproxEqRel_Int_Fail(int128 a, int128 b, uint128 maxPercentDelta) external {
         vm.assume(b != 0);
-        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
+        vm.assume(StdMath.percentDelta(a, b) > maxPercentDelta);
 
         vm.expectEmit(false, false, false, true);
         emit log("Error: a ~= b not satisfied [int]");
@@ -222,14 +222,14 @@ contract StdAssertionsTest is Test
 
     function testAssertApproxEqRel_IntErr_Pass(int128 a, int128 b, uint128 maxPercentDelta) external {
         vm.assume(b != 0);
-        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+        vm.assume(StdMath.percentDelta(a, b) <= maxPercentDelta);
 
         t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testAssertApproxEqRel_IntErr_Fail(int128 a, int128 b, uint128 maxPercentDelta) external {
         vm.assume(b != 0);
-        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
+        vm.assume(StdMath.percentDelta(a, b) > maxPercentDelta);
 
         vm.expectEmit(true, false, false, true);
         emit log_named_string("Error", CUSTOM_ERROR);

--- a/src/test/StdError.t.sol
+++ b/src/test/StdError.t.sol
@@ -11,57 +11,57 @@ contract StdErrorsTest is Test {
     }
 
     function testExpectAssertion() public {
-        vm.expectRevert(stdError.assertionError);
+        vm.expectRevert(StdError.assertionError);
         test.assertionError();
     }
 
     function testExpectArithmetic() public {
-        vm.expectRevert(stdError.arithmeticError);
+        vm.expectRevert(StdError.arithmeticError);
         test.arithmeticError(10);
     }
 
     function testExpectDiv() public {
-        vm.expectRevert(stdError.divisionError);
+        vm.expectRevert(StdError.divisionError);
         test.divError(0);
     }
 
     function testExpectMod() public {
-        vm.expectRevert(stdError.divisionError);
+        vm.expectRevert(StdError.divisionError);
         test.modError(0);
     }
 
     function testExpectEnum() public {
-        vm.expectRevert(stdError.enumConversionError);
+        vm.expectRevert(StdError.enumConversionError);
         test.enumConversion(1);
     }
 
     function testExpectEncodeStg() public {
-        vm.expectRevert(stdError.encodeStorageError);
+        vm.expectRevert(StdError.encodeStorageError);
         test.encodeStgError();
     }
 
     function testExpectPop() public {
-        vm.expectRevert(stdError.popError);
+        vm.expectRevert(StdError.popError);
         test.pop();
     }
 
     function testExpectOOB() public {
-        vm.expectRevert(stdError.indexOOBError);
+        vm.expectRevert(StdError.indexOOBError);
         test.indexOOBError(1);
     }
 
     function testExpectMem() public {
-        vm.expectRevert(stdError.memOverflowError);
+        vm.expectRevert(StdError.memOverflowError);
         test.mem();
     }
 
     function testExpectIntern() public {
-        vm.expectRevert(stdError.zeroVarError);
+        vm.expectRevert(StdError.zeroVarError);
         test.intern();
     }
 
     function testExpectLowLvl() public {
-        vm.expectRevert(stdError.lowLevelError);
+        vm.expectRevert(StdError.lowLevelError);
         test.someArr(0);
     }
 }

--- a/src/test/StdMath.t.sol
+++ b/src/test/StdMath.t.sol
@@ -6,39 +6,39 @@ import "../Test.sol";
 contract StdMathTest is Test
 {
     function testGetAbs() external {
-        assertEq(stdMath.abs(-50),      50);
-        assertEq(stdMath.abs(50),       50);
-        assertEq(stdMath.abs(-1337),    1337);
-        assertEq(stdMath.abs(0),        0);
+        assertEq(StdMath.abs(-50),      50);
+        assertEq(StdMath.abs(50),       50);
+        assertEq(StdMath.abs(-1337),    1337);
+        assertEq(StdMath.abs(0),        0);
 
-        assertEq(stdMath.abs(type(int256).min), (type(uint256).max >> 1) + 1);
-        assertEq(stdMath.abs(type(int256).max), (type(uint256).max >> 1));
+        assertEq(StdMath.abs(type(int256).min), (type(uint256).max >> 1) + 1);
+        assertEq(StdMath.abs(type(int256).max), (type(uint256).max >> 1));
     }
 
     function testGetAbs_Fuzz(int256 a) external {
         uint256 manualAbs = getAbs(a);
 
-        uint256 abs = stdMath.abs(a);
+        uint256 abs = StdMath.abs(a);
 
         assertEq(abs, manualAbs);
     }
 
     function testGetDelta_Uint() external {
-        assertEq(stdMath.delta(uint256(0),          uint256(0)),        0);
-        assertEq(stdMath.delta(uint256(0),          uint256(1337)),     1337);
-        assertEq(stdMath.delta(uint256(0),          type(uint64).max),  type(uint64).max);
-        assertEq(stdMath.delta(uint256(0),          type(uint128).max), type(uint128).max);
-        assertEq(stdMath.delta(uint256(0),          type(uint256).max), type(uint256).max);
+        assertEq(StdMath.delta(uint256(0),          uint256(0)),        0);
+        assertEq(StdMath.delta(uint256(0),          uint256(1337)),     1337);
+        assertEq(StdMath.delta(uint256(0),          type(uint64).max),  type(uint64).max);
+        assertEq(StdMath.delta(uint256(0),          type(uint128).max), type(uint128).max);
+        assertEq(StdMath.delta(uint256(0),          type(uint256).max), type(uint256).max);
 
-        assertEq(stdMath.delta(0,                   uint256(0)),        0);
-        assertEq(stdMath.delta(1337,                uint256(0)),        1337);
-        assertEq(stdMath.delta(type(uint64).max,    uint256(0)),        type(uint64).max);
-        assertEq(stdMath.delta(type(uint128).max,   uint256(0)),        type(uint128).max);
-        assertEq(stdMath.delta(type(uint256).max,   uint256(0)),        type(uint256).max);
+        assertEq(StdMath.delta(0,                   uint256(0)),        0);
+        assertEq(StdMath.delta(1337,                uint256(0)),        1337);
+        assertEq(StdMath.delta(type(uint64).max,    uint256(0)),        type(uint64).max);
+        assertEq(StdMath.delta(type(uint128).max,   uint256(0)),        type(uint128).max);
+        assertEq(StdMath.delta(type(uint256).max,   uint256(0)),        type(uint256).max);
 
-        assertEq(stdMath.delta(1337,                uint256(1337)),     0);
-        assertEq(stdMath.delta(type(uint256).max,   type(uint256).max), 0);
-        assertEq(stdMath.delta(5000,                uint256(1250)),     3750);
+        assertEq(StdMath.delta(1337,                uint256(1337)),     0);
+        assertEq(StdMath.delta(type(uint256).max,   type(uint256).max), 0);
+        assertEq(StdMath.delta(5000,                uint256(1250)),     3750);
     }
 
     function testGetDelta_Uint_Fuzz(uint256 a, uint256 b) external {
@@ -49,41 +49,41 @@ contract StdMathTest is Test
             manualDelta = b - a;
         }
 
-        uint256 delta = stdMath.delta(a, b);
+        uint256 delta = StdMath.delta(a, b);
 
         assertEq(delta, manualDelta);
     }
 
     function testGetDelta_Int() external {
-        assertEq(stdMath.delta(int256(0),           int256(0)),         0);
-        assertEq(stdMath.delta(int256(0),           int256(1337)),      1337);
-        assertEq(stdMath.delta(int256(0),           type(int64).max),   type(uint64).max >> 1);
-        assertEq(stdMath.delta(int256(0),           type(int128).max),  type(uint128).max >> 1);
-        assertEq(stdMath.delta(int256(0),           type(int256).max),  type(uint256).max >> 1);
+        assertEq(StdMath.delta(int256(0),           int256(0)),         0);
+        assertEq(StdMath.delta(int256(0),           int256(1337)),      1337);
+        assertEq(StdMath.delta(int256(0),           type(int64).max),   type(uint64).max >> 1);
+        assertEq(StdMath.delta(int256(0),           type(int128).max),  type(uint128).max >> 1);
+        assertEq(StdMath.delta(int256(0),           type(int256).max),  type(uint256).max >> 1);
 
-        assertEq(stdMath.delta(0,                   int256(0)),         0);
-        assertEq(stdMath.delta(1337,                int256(0)),         1337);
-        assertEq(stdMath.delta(type(int64).max,     int256(0)),         type(uint64).max >> 1);
-        assertEq(stdMath.delta(type(int128).max,    int256(0)),         type(uint128).max >> 1);
-        assertEq(stdMath.delta(type(int256).max,    int256(0)),         type(uint256).max >> 1);
+        assertEq(StdMath.delta(0,                   int256(0)),         0);
+        assertEq(StdMath.delta(1337,                int256(0)),         1337);
+        assertEq(StdMath.delta(type(int64).max,     int256(0)),         type(uint64).max >> 1);
+        assertEq(StdMath.delta(type(int128).max,    int256(0)),         type(uint128).max >> 1);
+        assertEq(StdMath.delta(type(int256).max,    int256(0)),         type(uint256).max >> 1);
 
-        assertEq(stdMath.delta(-0,                  int256(0)),         0);
-        assertEq(stdMath.delta(-1337,               int256(0)),         1337);
-        assertEq(stdMath.delta(type(int64).min,     int256(0)),         (type(uint64).max >> 1) + 1);
-        assertEq(stdMath.delta(type(int128).min,    int256(0)),         (type(uint128).max >> 1) + 1);
-        assertEq(stdMath.delta(type(int256).min,    int256(0)),         (type(uint256).max >> 1) + 1);
+        assertEq(StdMath.delta(-0,                  int256(0)),         0);
+        assertEq(StdMath.delta(-1337,               int256(0)),         1337);
+        assertEq(StdMath.delta(type(int64).min,     int256(0)),         (type(uint64).max >> 1) + 1);
+        assertEq(StdMath.delta(type(int128).min,    int256(0)),         (type(uint128).max >> 1) + 1);
+        assertEq(StdMath.delta(type(int256).min,    int256(0)),         (type(uint256).max >> 1) + 1);
 
-        assertEq(stdMath.delta(int256(0),           -0),                0);
-        assertEq(stdMath.delta(int256(0),           -1337),             1337);
-        assertEq(stdMath.delta(int256(0),           type(int64).min),   (type(uint64).max >> 1) + 1);
-        assertEq(stdMath.delta(int256(0),           type(int128).min),  (type(uint128).max >> 1) + 1);
-        assertEq(stdMath.delta(int256(0),           type(int256).min),  (type(uint256).max >> 1) + 1);
+        assertEq(StdMath.delta(int256(0),           -0),                0);
+        assertEq(StdMath.delta(int256(0),           -1337),             1337);
+        assertEq(StdMath.delta(int256(0),           type(int64).min),   (type(uint64).max >> 1) + 1);
+        assertEq(StdMath.delta(int256(0),           type(int128).min),  (type(uint128).max >> 1) + 1);
+        assertEq(StdMath.delta(int256(0),           type(int256).min),  (type(uint256).max >> 1) + 1);
 
-        assertEq(stdMath.delta(1337,                int256(1337)),      0);
-        assertEq(stdMath.delta(type(int256).max,    type(int256).max),  0);
-        assertEq(stdMath.delta(type(int256).min,    type(int256).min),  0);
-        assertEq(stdMath.delta(type(int256).min,    type(int256).max),  type(uint256).max);
-        assertEq(stdMath.delta(5000,                int256(1250)),      3750);
+        assertEq(StdMath.delta(1337,                int256(1337)),      0);
+        assertEq(StdMath.delta(type(int256).max,    type(int256).max),  0);
+        assertEq(StdMath.delta(type(int256).min,    type(int256).min),  0);
+        assertEq(StdMath.delta(type(int256).min,    type(int256).max),  type(uint256).max);
+        assertEq(StdMath.delta(5000,                int256(1250)),      3750);
     }
 
     function testGetDelta_Int_Fuzz(int256 a, int256 b) external {
@@ -102,26 +102,26 @@ contract StdMathTest is Test
             manualDelta = absA + absB;
         }
 
-        uint256 delta = stdMath.delta(a, b);
+        uint256 delta = StdMath.delta(a, b);
 
         assertEq(delta, manualDelta);
     }
 
     function testGetPercentDelta_Uint() external {
-        assertEq(stdMath.percentDelta(uint256(0),           uint256(1337)),     1e18);
-        assertEq(stdMath.percentDelta(uint256(0),           type(uint64).max),  1e18);
-        assertEq(stdMath.percentDelta(uint256(0),           type(uint128).max), 1e18);
-        assertEq(stdMath.percentDelta(uint256(0),           type(uint192).max), 1e18);
+        assertEq(StdMath.percentDelta(uint256(0),           uint256(1337)),     1e18);
+        assertEq(StdMath.percentDelta(uint256(0),           type(uint64).max),  1e18);
+        assertEq(StdMath.percentDelta(uint256(0),           type(uint128).max), 1e18);
+        assertEq(StdMath.percentDelta(uint256(0),           type(uint192).max), 1e18);
 
-        assertEq(stdMath.percentDelta(1337,                 uint256(1337)),     0);
-        assertEq(stdMath.percentDelta(type(uint192).max,    type(uint192).max), 0);
-        assertEq(stdMath.percentDelta(0,                    uint256(2500)),     1e18);
-        assertEq(stdMath.percentDelta(2500,                 uint256(2500)),     0);
-        assertEq(stdMath.percentDelta(5000,                 uint256(2500)),     1e18);
-        assertEq(stdMath.percentDelta(7500,                 uint256(2500)),     2e18);
+        assertEq(StdMath.percentDelta(1337,                 uint256(1337)),     0);
+        assertEq(StdMath.percentDelta(type(uint192).max,    type(uint192).max), 0);
+        assertEq(StdMath.percentDelta(0,                    uint256(2500)),     1e18);
+        assertEq(StdMath.percentDelta(2500,                 uint256(2500)),     0);
+        assertEq(StdMath.percentDelta(5000,                 uint256(2500)),     1e18);
+        assertEq(StdMath.percentDelta(7500,                 uint256(2500)),     2e18);
 
         vm.expectRevert(StdError.divisionError);
-        stdMath.percentDelta(uint256(1), 0);
+        StdMath.percentDelta(uint256(1), 0);
     }
 
     function testGetPercentDelta_Uint_Fuzz(uint192 a, uint192 b) external {
@@ -134,34 +134,34 @@ contract StdMathTest is Test
         }
 
         uint256 manualPercentDelta = manualDelta * 1e18 / b;
-        uint256 percentDelta = stdMath.percentDelta(a, b);
+        uint256 percentDelta = StdMath.percentDelta(a, b);
 
         assertEq(percentDelta, manualPercentDelta);
     }
 
     function testGetPercentDelta_Int() external {
-        assertEq(stdMath.percentDelta(int256(0),        int256(1337)),      1e18);
-        assertEq(stdMath.percentDelta(int256(0),        -1337),             1e18);
-        assertEq(stdMath.percentDelta(int256(0),        type(int64).min),   1e18);
-        assertEq(stdMath.percentDelta(int256(0),        type(int128).min),  1e18);
-        assertEq(stdMath.percentDelta(int256(0),        type(int192).min),  1e18);
-        assertEq(stdMath.percentDelta(int256(0),        type(int64).max),   1e18);
-        assertEq(stdMath.percentDelta(int256(0),        type(int128).max),  1e18);
-        assertEq(stdMath.percentDelta(int256(0),        type(int192).max),  1e18);
+        assertEq(StdMath.percentDelta(int256(0),        int256(1337)),      1e18);
+        assertEq(StdMath.percentDelta(int256(0),        -1337),             1e18);
+        assertEq(StdMath.percentDelta(int256(0),        type(int64).min),   1e18);
+        assertEq(StdMath.percentDelta(int256(0),        type(int128).min),  1e18);
+        assertEq(StdMath.percentDelta(int256(0),        type(int192).min),  1e18);
+        assertEq(StdMath.percentDelta(int256(0),        type(int64).max),   1e18);
+        assertEq(StdMath.percentDelta(int256(0),        type(int128).max),  1e18);
+        assertEq(StdMath.percentDelta(int256(0),        type(int192).max),  1e18);
 
-        assertEq(stdMath.percentDelta(1337,             int256(1337)),      0);
-        assertEq(stdMath.percentDelta(type(int192).max, type(int192).max),  0);
-        assertEq(stdMath.percentDelta(type(int192).min, type(int192).min),  0);
+        assertEq(StdMath.percentDelta(1337,             int256(1337)),      0);
+        assertEq(StdMath.percentDelta(type(int192).max, type(int192).max),  0);
+        assertEq(StdMath.percentDelta(type(int192).min, type(int192).min),  0);
 
-        assertEq(stdMath.percentDelta(type(int192).min, type(int192).max),  2e18); // rounds the 1 wei diff down
-        assertEq(stdMath.percentDelta(type(int192).max, type(int192).min),  2e18 - 1); // rounds the 1 wei diff down
-        assertEq(stdMath.percentDelta(0,                int256(2500)),      1e18);
-        assertEq(stdMath.percentDelta(2500,             int256(2500)),      0);
-        assertEq(stdMath.percentDelta(5000,             int256(2500)),      1e18);
-        assertEq(stdMath.percentDelta(7500,             int256(2500)),      2e18);
+        assertEq(StdMath.percentDelta(type(int192).min, type(int192).max),  2e18); // rounds the 1 wei diff down
+        assertEq(StdMath.percentDelta(type(int192).max, type(int192).min),  2e18 - 1); // rounds the 1 wei diff down
+        assertEq(StdMath.percentDelta(0,                int256(2500)),      1e18);
+        assertEq(StdMath.percentDelta(2500,             int256(2500)),      0);
+        assertEq(StdMath.percentDelta(5000,             int256(2500)),      1e18);
+        assertEq(StdMath.percentDelta(7500,             int256(2500)),      2e18);
 
         vm.expectRevert(StdError.divisionError);
-        stdMath.percentDelta(int256(1), 0);
+        StdMath.percentDelta(int256(1), 0);
     }
 
     function testGetPercentDelta_Int_Fuzz(int192 a, int192 b) external {
@@ -182,7 +182,7 @@ contract StdMathTest is Test
         }
 
         uint256 manualPercentDelta = manualDelta * 1e18 / absB;
-        uint256 percentDelta = stdMath.percentDelta(a, b);
+        uint256 percentDelta = StdMath.percentDelta(a, b);
 
         assertEq(percentDelta, manualPercentDelta);
     }

--- a/src/test/StdMath.t.sol
+++ b/src/test/StdMath.t.sol
@@ -120,7 +120,7 @@ contract StdMathTest is Test
         assertEq(stdMath.percentDelta(5000,                 uint256(2500)),     1e18);
         assertEq(stdMath.percentDelta(7500,                 uint256(2500)),     2e18);
 
-        vm.expectRevert(stdError.divisionError);
+        vm.expectRevert(StdError.divisionError);
         stdMath.percentDelta(uint256(1), 0);
     }
 
@@ -160,7 +160,7 @@ contract StdMathTest is Test
         assertEq(stdMath.percentDelta(5000,             int256(2500)),      1e18);
         assertEq(stdMath.percentDelta(7500,             int256(2500)),      2e18);
 
-        vm.expectRevert(stdError.divisionError);
+        vm.expectRevert(StdError.divisionError);
         stdMath.percentDelta(int256(1), 0);
     }
 

--- a/src/test/StdStorage.t.sol
+++ b/src/test/StdStorage.t.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "../Test.sol";
 
 contract StdStorageTest is Test {
-    using stdStorage for StdStorage;
+    using StdStorage for StdStore;
 
     StorageTest test;
 


### PR DESCRIPTION
issue: https://github.com/foundry-rs/forge-std/issues/13

Not sure if the issue is still relevant haha

Regarding test
- I saw that ci does forge test -vvv
https://github.com/foundry-rs/forge-std/blob/37a3fe48c3a4d8239cda93445f0b5e76b1507436/.github/workflows/tests.yml#L20-L21

Are there other things I should be doing for testing?
