### PR TITLE
feat(assertions): add `fail(string)` that logs fail reason

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -179,6 +179,11 @@ abstract contract Test is DSTest {
                                     STD-ASSERTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
+    function fail(string memory err) internal virtual {
+        emit log_named_string("Error", err);
+        fail();
+    }
+
     function assertFalse(bool data) internal virtual {
         assertTrue(!data);
     }

--- a/src/test/StdAssertions.t.sol
+++ b/src/test/StdAssertions.t.sol
@@ -13,6 +13,16 @@ contract StdAssertionsTest is Test
     TestTest t = new TestTest();
 
     /*//////////////////////////////////////////////////////////////////////////
+                                    FAIL(STRING)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function testShouldFail(string memory err) external {
+        vm.expectEmit(true, false, false, true);
+        emit log_named_string("Error", err);
+        t._fail(err);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
                                     ASSERT_FALSE
     //////////////////////////////////////////////////////////////////////////*/
 
@@ -257,6 +267,10 @@ contract TestTest is Test
         } else {
             require(postState == false, "unexpected failure was triggered");
         }
+    }
+
+    function _fail(string memory err) external expectFailure(true) {
+        fail(err);
     }
 
     function _assertFalse(bool data, bool expectFail) external expectFailure(expectFail) {

--- a/src/test/StdAssertions.t.sol
+++ b/src/test/StdAssertions.t.sol
@@ -16,10 +16,10 @@ contract StdAssertionsTest is Test
                                     FAIL(STRING)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testShouldFail(string memory err) external {
-        vm.expectEmit(true, false, false, true);
-        emit log_named_string("Error", err);
-        t._fail(err);
+    function testShouldFail() external {
+        vm.expectEmit(false, false, false, true);
+        emit log_named_string("Error", CUSTOM_ERROR);
+        t._fail(CUSTOM_ERROR);
     }
 
     /*//////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is a small extension of the current set of assertions. I've added `fail(string)`  to provide a clean and readable way to fail tests if a certain branch or execution point is hit