### PR TITLE
feat(cheats): add overloaded `mockCall` and `expectCall` cheatcodes

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -57,11 +57,16 @@ interface Vm {
     // pass a Solidity selector to the expected calldata, then the entire Solidity
     // function will be mocked.
     function mockCall(address,bytes calldata,bytes calldata) external;
+    // Mocks a call to an address with a specific msg.value, returning specified data.
+    // Calldata match takes precedence over msg.value in case of ambiguity.
+    function mockCall(address,uint256,bytes calldata,bytes calldata) external;
     // Clears all mocked calls
     function clearMockedCalls() external;
     // Expect a call to an address with the specified calldata.
     // Calldata can either be strict or a partial match
     function expectCall(address,bytes calldata) external;
+    // Expect a call to an address with the specified msg.value and calldata
+    function expectCall(address,uint256,bytes calldata) external;
     // Gets the code from an artifact file. Takes in the relative path to the json file
     function getCode(string calldata) external returns (bytes memory);
     // Labels an address in call traces


### PR DESCRIPTION
Added overloaded `mockCall` and `expectCall` methods with additional `msg.value` parameter as implemented in foundry-rs/foundry#1619