### PR TITLE
refactor(asserts): delegate assertEq(bytes) to ds-test

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -221,19 +221,11 @@ abstract contract Test is DSTest {
     }
 
     function assertEq(bytes memory a, bytes memory b) internal {
-        if (keccak256(a) != keccak256(b)) {
-            emit log            ("Error: a == b not satisfied [bytes]");
-            emit log_named_bytes("  Expected", b);
-            emit log_named_bytes("    Actual", a);
-            fail();
-        }
+        assertEq0(a, b);
     }
 
     function assertEq(bytes memory a, bytes memory b, string memory err) internal {
-        if (keccak256(a) != keccak256(b)) {
-            emit log_named_string   ("Error", err);
-            assertEq(a, b);
-        }
+        assertEq0(a, b, err);
     }
 
     function assertApproxEqAbs(


### PR DESCRIPTION
This PR resolves the issues raised here: https://github.com/foundry-rs/forge-std/pull/71#issuecomment-1128730537

Have elected not to delete the tests as a regression guard (the tests implement keccak256 over the inputs so this is a nice protection against any accidental breakage in the future). That said, obviously your call on what the end codebase looks like