### PR TITLE
🚑️ Fix compatibility with older solc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 cache/
 out/
+.vscode

--- a/src/Script.sol
+++ b/src/Script.sol
@@ -5,9 +5,9 @@ import "./Vm.sol";
 import "./console.sol";
 import "./console2.sol";
 
-address constant VM_ADDRESS =
-    address(bytes20(uint160(uint256(keccak256('hevm cheat code')))));
-
 abstract contract Script {
+    address constant private VM_ADDRESS =
+        address(bytes20(uint160(uint256(keccak256('hevm cheat code')))));
+
     Vm public constant vm = Vm(VM_ADDRESS);
 }


### PR DESCRIPTION
## Motivation

Hotfix compatibility issues with solc versions `<0.8.0` introduced in https://github.com/foundry-rs/forge-std/commit/cc2dee26166823ccfe1c1b928776ee340095372b.

## Solution

Move the constant `VM_ADDRESS` in `Script.sol` to contract `Script`.