### PR TITLE
♻️ Group Std Logs

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -8,8 +8,6 @@ import "ds-test/test.sol";
 abstract contract Test is DSTest, Script {
     using stdStorage for StdStorage;
 
-    event WARNING_Deprecated(string msg);
-
     uint256 private constant UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
@@ -88,7 +86,7 @@ abstract contract Test is DSTest, Script {
 
     // DEPRECATED: Use `deal` instead
     function tip(address token, address to, uint256 give) public {
-        emit WARNING_Deprecated("The `tip` stdcheat has been deprecated. Use `deal` instead.");
+        emit log_named_string("WARNING", "Test tip(address,address,uint256): The `tip` stdcheat has been deprecated. Use `deal` instead.");
         stdstore
             .target(token)
             .sig(0x70a08231)

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -8,15 +8,21 @@ import "ds-test/test.sol";
 abstract contract Test is DSTest, Script {
     using stdStorage for StdStorage;
 
-    uint256 private constant UINT256_MAX = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
-
     event WARNING_Deprecated(string msg);
+
+    uint256 private constant UINT256_MAX =
+        115792089237316195423570985008687907853269984665640564039457584007913129639935;
+
+    StdStorage internal stdstore;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    STD-LOGS
+    //////////////////////////////////////////////////////////////////////////*/
+
     event log_array(uint256[] val);
     event log_array(int256[] val);
     event log_named_array(string key, uint256[] val);
     event log_named_array(string key, int256[] val);
-
-    StdStorage internal stdstore;
 
     /*//////////////////////////////////////////////////////////////////////////
                                     STD-CHEATS
@@ -90,7 +96,7 @@ abstract contract Test is DSTest, Script {
             .checked_write(give);
     }
 
-    // The same as Hevm's `deal`
+    // The same as Vm's `deal`
     // Use the alternative signature for ERC20 tokens
     function deal(address to, uint256 give) public {
         vm.deal(to, give);
@@ -408,7 +414,7 @@ library stdError {
     bytes public constant indexOOBError = abi.encodeWithSignature("Panic(uint256)", 0x32);
     bytes public constant memOverflowError = abi.encodeWithSignature("Panic(uint256)", 0x41);
     bytes public constant zeroVarError = abi.encodeWithSignature("Panic(uint256)", 0x51);
-    // DEPRECATED: Use Hevm's `expectRevert` without any arguments instead
+    // DEPRECATED: Use Vm's `expectRevert` without any arguments instead
     bytes public constant lowLevelError = bytes(""); // `0x`
 }
 

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -486,7 +486,7 @@ library stdStorage {
                 emit WARNING_UninitedSlot(who, uint256(reads[0]));
             }
             if (fdat != curr) {
-                require(false, "stdStorage find(StdStorage): Packed slot. This would cause dangerous overwriting and currently isnt supported");
+                require(false, "stdStorage find(StdStorage): Packed slot. This would cause dangerous overwriting and currently isn't supported.");
             }
             emit SlotFound(who, fsig, keccak256(abi.encodePacked(ins, field_depth)), uint256(reads[0]));
             self.slots[who][fsig][keccak256(abi.encodePacked(ins, field_depth))] = uint256(reads[0]);
@@ -604,7 +604,7 @@ library stdStorage {
         bytes32 curr = vm_std_store.load(who, slot);
 
         if (fdat != curr) {
-            require(false, "stdStorage find(StdStorage): Packed slot. This would cause dangerous overwriting and currently isnt supported.");
+            require(false, "stdStorage find(StdStorage): Packed slot. This would cause dangerous overwriting and currently isn't supported.");
         }
         vm_std_store.store(who, slot, set);
         delete self._target;


### PR DESCRIPTION
## Motivation

New logs, besides those from DSTest, are available. See https://github.com/foundry-rs/forge-std/pull/85 and https://github.com/foundry-rs/foundry/pull/1916.

## Solution

Group the new logs under a dedicated header `STD-LOGS`.

Also: misc fixes