### PR TITLE
feat: add IS_SCRIPT to know if a contract is a script

### DIFF
--- a/src/Script.sol
+++ b/src/Script.sol
@@ -6,6 +6,7 @@ import "./console.sol";
 import "./console2.sol";
 
 abstract contract Script {
+    bool public IS_SCRIPT = true;
     address constant private VM_ADDRESS =
         address(bytes20(uint160(uint256(keccak256('hevm cheat code')))));
 


### PR DESCRIPTION
This will be used by forge to ignore checking contract size for scripts. Currently `forge build --sizes` will error if a script exceeds the size limit so we'll update it to ignore contracts with `IS_SCRIPT`. This means test contracts will have both `IS_SCRIPT = true` and `IS_TEST = true`, which I think is ok to keep this simple, and just means that `IS_TEST` takes priority over `IS_SCRIPT`

cc @gakonst 