### PR TITLE
Add interfaces for File I/O cheatcodes to Vm.sol

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -103,4 +103,23 @@ interface Vm {
     function startBroadcast(address) external;
     // Stops collecting onchain transactions
     function stopBroadcast() external;
+    // Reads the entire content of file to string, (path) => (data)
+    function readFile(string calldata) external returns (string memory);
+    // Reads next line of file to string, (path) => (line)
+    function readLine(string calldata) external returns (string memory);
+    // Writes data to file, creating a file if it does not exist, and entirely replacing its contents if it does.
+    // (path, data) => ()
+    function writeFile(string calldata, string calldata) external;
+    // Writes line to file, creating a file if it does not exist.
+    // (path, data) => ()
+    function writeLine(string calldata, string calldata) external;
+    // Closes file for reading, resetting the offset and allowing to read it from beginning with readLine.
+    // (path) => ()
+    function closeFile(string calldata) external;
+    // Removes file. This cheatcode will revert in the following situations, but is not limited to just these cases:
+    // - Path points to a directory.
+    // - The file doesn't exist.
+    // - The user lacks permissions to remove the file.
+    // (path) => ()
+    function removeFile(string calldata) external;
 }


### PR DESCRIPTION
With File I/O capability in place, this PR adds the associated cheat codes to `Vm.sol`