### PR TITLE
🧑‍💻 Add explanation why read_bool reverted

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -644,7 +644,10 @@ library stdStorage {
 
 
     function read_bool(StdStorage storage self) internal returns (bool) {
-        return abi.decode(read(self), (bool));
+        int256 v = read_int(self);
+        if (v == 0) return false;
+        if (v == 1) return true;
+        revert("stdStorage find(StdStorage): Cannot decode. Make sure you are reading a bool.");
     }
 
     function read_address(StdStorage storage self) internal returns (address) {

--- a/src/test/StdStorage.t.sol
+++ b/src/test/StdStorage.t.sol
@@ -223,9 +223,23 @@ contract StdStorageTest is Test {
         assertEq(val, hex"1337");
     }
 
-    function testStorageReadBool() public {
+    function testStorageReadBool_False() public {
         bool val = stdstore.target(address(test)).sig(test.tB.selector).read_bool();
         assertEq(val, false);
+    }
+
+    function testStorageReadBool_True() public {
+        bool val = stdstore.target(address(test)).sig(test.tH.selector).read_bool();
+        assertEq(val, true);
+    }
+
+    function testStorageReadBool_Revert() public {
+        vm.expectRevert("stdStorage find(StdStorage): Cannot decode. Make sure you are reading a bool.");
+        this.readNonBoolValue();
+    }
+
+    function readNonBoolValue() public {
+        stdstore.target(address(test)).sig(test.tE.selector).read_bool();
     }
 
     function testStorageReadAddress() public {
@@ -272,6 +286,7 @@ contract StorageTest {
     bytes32 public tE = hex"1337";
     address public tF = address(1337);
     int256 public tG = type(int256).min;
+    bool public tH = true;
 
     constructor() {
         basic = UnpackedStruct({


### PR DESCRIPTION
## Motivation

Improve DX.

Reading a value with Std Storage's `read_bool` reverts if the read bytes cannot be decoded to `bool`.

No explanation is provided to the dev as to what and why reverted, which is frustrating.

## Solution

Revert manually with  `stdStorage find(StdStorage): Cannot decode. Make sure you are reading a bool.`.