### PR TITLE
Mark UINT256_MAX as internal

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -8,7 +8,7 @@ import "ds-test/test.sol";
 abstract contract Test is DSTest, Script {
     using stdStorage for StdStorage;
 
-    uint256 private constant UINT256_MAX =
+    uint256 internal constant UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
     StdStorage internal stdstore;


### PR DESCRIPTION
I don't see any downside in marking this constant as `internal` rather than `private`.

I actually wanted to use it in my contracts when I realized that I can't use it.