### PR TITLE
Optimize same sign check

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -710,6 +710,7 @@ library stdMath {
 
     function delta(int256 a, int256 b) internal pure returns (uint256) {
         // a and b are of the same sign
+        // this works thanks to two's complement, the left-most bit is the sign bit
         if ((a ^ b) > -1) {
             return delta(abs(a), abs(b));
         }

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -710,7 +710,7 @@ library stdMath {
 
     function delta(int256 a, int256 b) internal pure returns (uint256) {
         // a and b are of the same sign
-        if (a >= 0 && b >= 0 || a < 0 && b < 0) {
+        if ((a ^ b) > -1) {
             return delta(abs(a), abs(b));
         }
 


### PR DESCRIPTION
See [this](https://twitter.com/PaulRBerg/status/1546957951579062272).

I was also thinking to add a comment to explain why `(a^b)>-1` works - WDYT?