### PR TITLE
Bound pragma version in Vm.sol

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Unlicense
-pragma solidity >=0.6.0;
+pragma solidity >=0.6.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 interface Vm {


### PR DESCRIPTION
Not sure if this was intentional or not, but if it wasn't, I think it'd be worth it to also bound the pragma in the `VM` contract, for consistency purposes.