### PR TITLE
Set SPDX identifier to MIT in Solidity files

### DIFF
--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,4 +1,4 @@
-Copyright (c) 2021 Brock Elmore
+Copyright (c) 2022 Brock Elmore
 
                               Apache License
                         Version 2.0, January 2004

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2021 Brock Elmore
+Copyright (c) 2022 Brock Elmore
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ This is a wrapper over miscellaneous cheatcodes that need wrappers to be more de
 #### Example usage:
 ```solidity
 
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";

--- a/src/Script.sol
+++ b/src/Script.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.6.0 <0.9.0;
 
 import "./Vm.sol";

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.6.0 <0.9.0;
 
 import "./Script.sol";

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.6.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 

--- a/src/test/Script.t.sol
+++ b/src/test/Script.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
 import "../Test.sol";

--- a/src/test/StdAssertions.t.sol
+++ b/src/test/StdAssertions.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
 import "../Test.sol";

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
 import "../Test.sol";

--- a/src/test/StdError.t.sol
+++ b/src/test/StdError.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.10 <0.9.0;
 
 import "../Test.sol";

--- a/src/test/StdMath.t.sol
+++ b/src/test/StdMath.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0 <0.9.0;
 
 import "../Test.sol";

--- a/src/test/StdStorage.t.sol
+++ b/src/test/StdStorage.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: Unlicense
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
 import "../Test.sol";


### PR DESCRIPTION
The licenses provided in the repo are [MIT](https://github.com/foundry-rs/forge-std/blob/f32dbdc3f014176539d95099cbe617968fd0b059/LICENSE-MIT) and [Apache 2.0](https://github.com/foundry-rs/forge-std/blob/master/LICENSE-APACHE), but in the Solidity files the identifier used is `Unlicense`:

https://github.com/foundry-rs/forge-std/blob/f32dbdc3f014176539d95099cbe617968fd0b059/src/Test.sol#L1

However, if that was intentional, I would still hold it that it would be a good idea to switch over to `MIT`, due to the reasons given in this [Reddit post](https://www.reddit.com/r/github/comments/hvp4k6/whats_the_difference_between_mit_and_unlicense/). Here's a Reddit user explaining the legal questionability of the `Unlicense` license:

> In a few jurisdictions (iirc Germany),they are not legally recognised, meaning that it falls back to the default All Rights Reserved. This is why many companies which interact with OSS will blanket ban ‘public domain’ software unless it’s backed with another license.

It'd be safer to just stick with `MIT`.

Also, as recommended [here](https://opensource.stackexchange.com/a/4890/17242), I have updated the year to 2022.