### PR TITLE
Mark "changePrank" cheat as "public"

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -81,7 +81,7 @@ abstract contract Test is DSTest, Script {
         vm.startPrank(who, origin);
     }
 
-    function changePrank(address who) internal {
+    function changePrank(address who) public {
         vm.stopPrank();
         vm.startPrank(who);
     }


### PR DESCRIPTION
`changePrank` was added in https://github.com/foundry-rs/forge-std/pull/70, but we have overlooked the fact that it had been made `internal` rather than `public`, as all other cheats are.