### PR TITLE
Mark "bound" cheat as "public"

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -136,7 +136,7 @@ abstract contract Test is DSTest, Script {
         }
     }
 
-    function bound(uint256 x, uint256 min, uint256 max) internal virtual returns (uint256 result) {
+    function bound(uint256 x, uint256 min, uint256 max) public virtual returns (uint256 result) {
         require(min <= max, "Test bound(uint256,uint256,uint256): Max is less than min.");
 
         uint256 size = max - min;


### PR DESCRIPTION
Just like https://github.com/foundry-rs/forge-std/pull/119 but for the `bound` cheat.