### PR TITLE
Mark all cheats as "internal" (WIP)

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -29,54 +29,54 @@ abstract contract Test is DSTest, Script {
     //////////////////////////////////////////////////////////////////////////*/
 
     // Skip forward or rewind time by the specified number of seconds
-    function skip(uint256 time) public {
+    function skip(uint256 time) internal {
         vm.warp(block.timestamp + time);
     }
 
-    function rewind(uint256 time) public {
+    function rewind(uint256 time) internal {
         vm.warp(block.timestamp - time);
     }
 
     // Setup a prank from an address that has some ether
-    function hoax(address who) public {
+    function hoax(address who) internal {
         vm.deal(who, 1 << 128);
         vm.prank(who);
     }
 
-    function hoax(address who, uint256 give) public {
+    function hoax(address who, uint256 give) internal {
         vm.deal(who, give);
         vm.prank(who);
     }
 
-    function hoax(address who, address origin) public {
+    function hoax(address who, address origin) internal {
         vm.deal(who, 1 << 128);
         vm.prank(who, origin);
     }
 
-    function hoax(address who, address origin, uint256 give) public {
+    function hoax(address who, address origin, uint256 give) internal {
         vm.deal(who, give);
         vm.prank(who, origin);
     }
 
     // Start perpetual prank from an address that has some ether
-    function startHoax(address who) public {
+    function startHoax(address who) internal {
         vm.deal(who, 1 << 128);
         vm.startPrank(who);
     }
 
-    function startHoax(address who, uint256 give) public {
+    function startHoax(address who, uint256 give) internal {
         vm.deal(who, give);
         vm.startPrank(who);
     }
 
     // Start perpetual prank from an address that has some ether
     // tx.origin is set to the origin parameter
-    function startHoax(address who, address origin) public {
+    function startHoax(address who, address origin) internal {
         vm.deal(who, 1 << 128);
         vm.startPrank(who, origin);
     }
 
-    function startHoax(address who, address origin, uint256 give) public {
+    function startHoax(address who, address origin, uint256 give) internal {
         vm.deal(who, give);
         vm.startPrank(who, origin);
     }
@@ -87,7 +87,7 @@ abstract contract Test is DSTest, Script {
     }
 
     // DEPRECATED: Use `deal` instead
-    function tip(address token, address to, uint256 give) public {
+    function tip(address token, address to, uint256 give) internal {
         emit log_named_string("WARNING", "Test tip(address,address,uint256): The `tip` stdcheat has been deprecated. Use `deal` instead.");
         stdstore
             .target(token)
@@ -98,17 +98,17 @@ abstract contract Test is DSTest, Script {
 
     // The same as Vm's `deal`
     // Use the alternative signature for ERC20 tokens
-    function deal(address to, uint256 give) public {
+    function deal(address to, uint256 give) internal {
         vm.deal(to, give);
     }
 
     // Set the balance of an account for any ERC20 token
     // Use the alternative signature to update `totalSupply`
-    function deal(address token, address to, uint256 give) public {
+    function deal(address token, address to, uint256 give) internal {
         deal(token, to, give, false);
     }
 
-    function deal(address token, address to, uint256 give, bool adjust) public {
+    function deal(address token, address to, uint256 give, bool adjust) internal {
         // get current balance
         (, bytes memory balData) = token.call(abi.encodeWithSelector(0x70a08231, to));
         uint256 prevBal = abi.decode(balData, (uint256));
@@ -163,7 +163,7 @@ abstract contract Test is DSTest, Script {
     // the artifacts directory
     // e.g. `deployCode(code, abi.encode(arg1,arg2,arg3))`
     function deployCode(string memory what, bytes memory args)
-        public
+        internal
         returns (address addr)
     {
         bytes memory bytecode = abi.encodePacked(vm.getCode(what), args);
@@ -179,7 +179,7 @@ abstract contract Test is DSTest, Script {
     }
 
     function deployCode(string memory what)
-        public
+        internal
         returns (address addr)
     {
         bytes memory bytecode = vm.getCode(what);

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -138,9 +138,14 @@ contract StdCheatsTest is Test {
         assertEq(string(getCode(deployed)), string(getCode(address(this))));
     }
 
+    // We need this so we can call "this.deployCode" rather than "deployCode" directly
+    function deployCodeHelper(string memory what) external {
+        deployCode(what);
+    }
+    
     function testDeployCodeFail() public {
         vm.expectRevert(bytes("Test deployCode(string): Deployment failed."));
-        deployCode("StdCheats.t.sol:RevertingContract");
+        this.deployCodeHelper("StdCheats.t.sol:RevertingContract");
     }
 
     function getCode(address who) internal view returns (bytes memory o_code) {

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -140,7 +140,7 @@ contract StdCheatsTest is Test {
 
     function testDeployCodeFail() public {
         vm.expectRevert(bytes("Test deployCode(string): Deployment failed."));
-        this.deployCode("StdCheats.t.sol:RevertingContract");
+        deployCode("StdCheats.t.sol:RevertingContract");
     }
 
     function getCode(address who) internal view returns (bytes memory o_code) {


### PR DESCRIPTION
As per the discussion in https://github.com/foundry-rs/forge-std/pull/119, this PR marks all cheats as `internal`.

I have not marked the PR as ready for review though, because there's one test that is not passing anymore, `testDeployCodeFail`. The reason for that is that instead of `this.deployCode`, the test now calls just `deployCode`. This definitely has something to do with the `getCode` cheatcode which expects a relative path, but I'm not sufficiently familiar with the cheatcodes environment to know how to fix this.

**Update**: fixed this in https://github.com/foundry-rs/forge-std/pull/121/commits/190f5a19372f1b79116886ebf2fc02bd97458495. PR ready for review now.