### PR TITLE
feat: `deployCode` with value

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -194,6 +194,39 @@ abstract contract Test is DSTest, Script {
         );
     }
 
+    /// deploy contract with value on construction
+    function deployCode(string memory what, bytes memory args, uint256 val)
+        internal
+        returns (address addr)
+    {
+        bytes memory bytecode = abi.encodePacked(vm.getCode(what), args);
+        /// @solidity memory-safe-assembly
+        assembly {
+            addr := create(val, add(bytecode, 0x20), mload(bytecode))
+        }
+
+        require(
+            addr != address(0),
+            "Test deployCode(string,bytes,uint256): Deployment failed."
+        );
+    }
+
+    function deployCode(string memory what, uint256 val)
+        internal
+        returns (address addr)
+    {
+        bytes memory bytecode = vm.getCode(what);
+        /// @solidity memory-safe-assembly
+        assembly {
+            addr := create(val, add(bytecode, 0x20), mload(bytecode))
+        }
+
+        require(
+            addr != address(0),
+            "Test deployCode(string,uint256): Deployment failed."
+        );
+    }
+
     /*//////////////////////////////////////////////////////////////////////////
                                     STD-ASSERTIONS
     //////////////////////////////////////////////////////////////////////////*/

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -138,6 +138,25 @@ contract StdCheatsTest is Test {
         assertEq(string(getCode(deployed)), string(getCode(address(this))));
     }
 
+    // We need that payable constructor in order to send ETH on construction
+    constructor() payable {}
+
+    function testDeployCodeVal() public {
+	uint256 val = 1 ether;
+	vm.deal(address(this), val * 2);
+        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", bytes(""), val);
+        assertEq(string(getCode(deployed)), string(getCode(address(this))));
+	assertEq(deployed.balance, val);
+    }
+
+    function testDeployCodeValNoArgs() public {
+	uint256 val = 1 ether;
+	vm.deal(address(this), val * 2);
+        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", val);
+        assertEq(string(getCode(deployed)), string(getCode(address(this))));
+	assertEq(deployed.balance, val);
+    }
+
     // We need this so we can call "this.deployCode" rather than "deployCode" directly
     function deployCodeHelper(string memory what) external {
         deployCode(what);

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -142,19 +142,15 @@ contract StdCheatsTest is Test {
     constructor() payable {}
 
     function testDeployCodeVal() public {
-	uint256 val = 1 ether;
-	vm.deal(address(this), val * 2);
-        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", bytes(""), val);
+        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", bytes(""), 1 ether);
         assertEq(string(getCode(deployed)), string(getCode(address(this))));
-	assertEq(deployed.balance, val);
+	assertEq(deployed.balance, 1 ether);
     }
 
     function testDeployCodeValNoArgs() public {
-	uint256 val = 1 ether;
-	vm.deal(address(this), val * 2);
-        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", val);
+        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", 1 ether);
         assertEq(string(getCode(deployed)), string(getCode(address(this))));
-	assertEq(deployed.balance, val);
+	assertEq(deployed.balance, 1 ether);
     }
 
     // We need this so we can call "this.deployCode" rather than "deployCode" directly


### PR DESCRIPTION
Before, we couldn't use the `deployCode` cheatcode with value on contract construction.
This PR is a fix for: https://github.com/foundry-rs/forge-std/issues/131
A little PoC was done here: https://github.com/iFrostizz/deployCodeVal