### PR TITLE
feat: makeAddr and makeAddrAndKey

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -88,7 +88,7 @@ abstract contract Test is DSTest, Script {
 
     // creates a labeled address and the corresponding private key
     function makeAddrAndKey(string memory name) internal returns(address addr, uint256 privateKey) {
-        privateKey = uint256(keccak256(bytes(abi.encodePacked(name))));
+        privateKey = uint256(keccak256(abi.encodePacked(name)));
         addr = vm.addr(privateKey);
         vm.label(addr, name);
     }

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -86,6 +86,18 @@ abstract contract Test is DSTest, Script {
         vm.startPrank(who);
     }
 
+    // creates a labeled address and the corresponding private key
+    function makeAddrAndKey(string memory name) internal returns(address addr, uint256 privateKey) {
+        privateKey = uint256(keccak256(bytes(abi.encodePacked(name))));
+        addr = vm.addr(privateKey);
+        vm.label(addr, name);
+    }
+
+    // creates a labeled address
+    function makeAddr(string memory name) internal returns(address addr) {
+        (addr,) = makeAddrAndKey(name);
+    }
+
     // DEPRECATED: Use `deal` instead
     function tip(address token, address to, uint256 give) internal {
         emit log_named_string("WARNING", "Test tip(address,address,uint256): The `tip` stdcheat has been deprecated. Use `deal` instead.");

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -63,6 +63,19 @@ contract StdCheatsTest is Test {
         vm.stopPrank();
     }
 
+    function testMakeAddrEquivalence() public {
+        (address addr, ) = makeAddrAndKey("1337");
+        assertEq(makeAddr("1337"), addr);
+    }
+
+    function testMakeAddrSigning() public {
+        (address addr, uint256 key) = makeAddrAndKey("1337");
+        bytes32 hash = keccak256("some_message");
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(key, hash);
+        assertEq(ecrecover(hash, v, r, s), addr);
+    }
+
     function testDeal() public {
         deal(address(this), 1 ether);
         assertEq(address(this).balance, 1 ether);
@@ -157,7 +170,7 @@ contract StdCheatsTest is Test {
     function deployCodeHelper(string memory what) external {
         deployCode(what);
     }
-    
+
     function testDeployCodeFail() public {
         vm.expectRevert(bytes("Test deployCode(string): Deployment failed."));
         this.deployCodeHelper("StdCheats.t.sol:RevertingContract");


### PR DESCRIPTION
Two small quality-of-life functions to easily create labeled addresses.

Inspired by https://twitter.com/eth_call/status/1549792921976803328

Addresses https://github.com/foundry-rs/forge-std/issues/135