### PR TITLE
feat: make `Script` safer

### DIFF
--- a/src/Assertions.sol
+++ b/src/Assertions.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.6.0 <0.9.0;
 import "ds-test/test.sol";
 import "./Math.sol";
 
-contract Assertions is DSTest {
+abstract contract Assertions is DSTest {
     event log_array(uint256[] val);
     event log_array(int256[] val);
     event log_array(address[] val);

--- a/src/Cheats.sol
+++ b/src/Cheats.sol
@@ -4,8 +4,80 @@ pragma solidity >=0.6.0 <0.9.0;
 import "./Storage.sol";
 import "./Vm.sol";
 
+abstract contract CheatsSafe {
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    // Deploy a contract by fetching the contract bytecode from
+    // the artifacts directory
+    // e.g. `deployCode(code, abi.encode(arg1,arg2,arg3))`
+    function deployCode(string memory what, bytes memory args)
+        internal virtual
+        returns (address addr)
+    {
+        bytes memory bytecode = abi.encodePacked(vm.getCode(what), args);
+        /// @solidity memory-safe-assembly
+        assembly {
+            addr := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+
+        require(
+            addr != address(0),
+            "Test deployCode(string,bytes): Deployment failed."
+        );
+    }
+
+    function deployCode(string memory what)
+        internal virtual
+        returns (address addr)
+    {
+        bytes memory bytecode = vm.getCode(what);
+        /// @solidity memory-safe-assembly
+        assembly {
+            addr := create(0, add(bytecode, 0x20), mload(bytecode))
+        }
+
+        require(
+            addr != address(0),
+            "Test deployCode(string): Deployment failed."
+        );
+    }
+
+    /// @dev deploy contract with value on construction
+    function deployCode(string memory what, bytes memory args, uint256 val)
+        internal virtual
+        returns (address addr)
+    {
+        bytes memory bytecode = abi.encodePacked(vm.getCode(what), args);
+        /// @solidity memory-safe-assembly
+        assembly {
+            addr := create(val, add(bytecode, 0x20), mload(bytecode))
+        }
+
+        require(
+            addr != address(0),
+            "Test deployCode(string,bytes,uint256): Deployment failed."
+        );
+    }
+
+    function deployCode(string memory what, uint256 val)
+        internal virtual
+        returns (address addr)
+    {
+        bytes memory bytecode = vm.getCode(what);
+        /// @solidity memory-safe-assembly
+        assembly {
+            addr := create(val, add(bytecode, 0x20), mload(bytecode))
+        }
+
+        require(
+            addr != address(0),
+            "Test deployCode(string,uint256): Deployment failed."
+        );
+    }
+}
+
 // Wrappers around Cheats to avoid footguns
-abstract contract Cheats {
+abstract contract Cheats is CheatsSafe {
     using stdStorage for StdStorage;
 
     StdStorage private stdstore;
@@ -108,73 +180,5 @@ abstract contract Cheats {
                 .sig(0x18160ddd)
                 .checked_write(totSup);
         }
-    }
-
-    // Deploy a contract by fetching the contract bytecode from
-    // the artifacts directory
-    // e.g. `deployCode(code, abi.encode(arg1,arg2,arg3))`
-    function deployCode(string memory what, bytes memory args)
-        internal virtual
-        returns (address addr)
-    {
-        bytes memory bytecode = abi.encodePacked(vm.getCode(what), args);
-        /// @solidity memory-safe-assembly
-        assembly {
-            addr := create(0, add(bytecode, 0x20), mload(bytecode))
-        }
-
-        require(
-            addr != address(0),
-            "Test deployCode(string,bytes): Deployment failed."
-        );
-    }
-
-    function deployCode(string memory what)
-        internal virtual
-        returns (address addr)
-    {
-        bytes memory bytecode = vm.getCode(what);
-        /// @solidity memory-safe-assembly
-        assembly {
-            addr := create(0, add(bytecode, 0x20), mload(bytecode))
-        }
-
-        require(
-            addr != address(0),
-            "Test deployCode(string): Deployment failed."
-        );
-    }
-
-    /// @dev deploy contract with value on construction
-    function deployCode(string memory what, bytes memory args, uint256 val)
-        internal virtual
-        returns (address addr)
-    {
-        bytes memory bytecode = abi.encodePacked(vm.getCode(what), args);
-        /// @solidity memory-safe-assembly
-        assembly {
-            addr := create(val, add(bytecode, 0x20), mload(bytecode))
-        }
-
-        require(
-            addr != address(0),
-            "Test deployCode(string,bytes,uint256): Deployment failed."
-        );
-    }
-
-    function deployCode(string memory what, uint256 val)
-        internal virtual
-        returns (address addr)
-    {
-        bytes memory bytecode = vm.getCode(what);
-        /// @solidity memory-safe-assembly
-        assembly {
-            addr := create(val, add(bytecode, 0x20), mload(bytecode))
-        }
-
-        require(
-            addr != address(0),
-            "Test deployCode(string,uint256): Deployment failed."
-        );
     }
 }

--- a/src/Cheats.sol
+++ b/src/Cheats.sol
@@ -5,7 +5,7 @@ import "./Storage.sol";
 import "./Vm.sol";
 
 abstract contract CheatsSafe {
-    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     // Deploy a contract by fetching the contract bytecode from
     // the artifacts directory

--- a/src/Cheats.sol
+++ b/src/Cheats.sol
@@ -5,7 +5,7 @@ import "./Storage.sol";
 import "./Vm.sol";
 
 // Wrappers around Cheats to avoid footguns
-contract Cheats {
+abstract contract Cheats {
     using stdStorage for StdStorage;
 
     StdStorage private stdstore;

--- a/src/Script.sol
+++ b/src/Script.sol
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.6.0 <0.9.0;
 
-import {Cheats, console, console2, stdMath, stdStorage, StdStorage, Utils, Vm} from "./Components.sol";
+import {CheatsSafe, console, console2, stdMath, stdStorageSafe, StdStorage, Utils, VmSafe} from "./Components.sol";
 
 abstract contract ScriptBase {
     address internal constant VM_ADDRESS = address(uint160(uint256(keccak256("hevm cheat code"))));
-    Vm internal constant vm = Vm(VM_ADDRESS);
+
+    StdStorage internal stdstore;
+    VmSafe internal constant vm = VmSafe(VM_ADDRESS);
 }
 
-abstract contract Script is ScriptBase, Cheats, Utils {
+abstract contract Script is ScriptBase, CheatsSafe, Utils {
     bool public IS_SCRIPT = true;
 }

--- a/src/Utils.sol
+++ b/src/Utils.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.6.0 <0.9.0;
 
 import "./console2.sol";
 
-contract Utils {
+abstract contract Utils {
     uint256 internal constant UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
 

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -2,6 +2,108 @@
 pragma solidity >=0.6.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
+interface VmSafe {
+    struct Log {
+        bytes32[] topics;
+        bytes data;
+    }
+
+    // Loads a storage slot from an address (who, slot)
+    function load(address,bytes32) external returns (bytes32);
+    // Signs data, (privateKey, digest) => (v, r, s)
+    function sign(uint256,bytes32) external returns (uint8,bytes32,bytes32);
+    // Gets the address for a given private key, (privateKey) => (address)
+    function addr(uint256) external returns (address);
+    // Gets the nonce of an account
+    function getNonce(address) external returns (uint64);
+    // Performs a foreign function call via the terminal, (stringInputs) => (result)
+    function ffi(string[] calldata) external returns (bytes memory);
+    // Sets environment variables, (name, value)
+    function setEnv(string calldata, string calldata) external;
+    // Reads environment variables, (name) => (value)
+    function envBool(string calldata) external returns (bool);
+    function envUint(string calldata) external returns (uint256);
+    function envInt(string calldata) external returns (int256);
+    function envAddress(string calldata) external returns (address);
+    function envBytes32(string calldata) external returns (bytes32);
+    function envString(string calldata) external returns (string memory);
+    function envBytes(string calldata) external returns (bytes memory);
+    // Reads environment variables as arrays, (name, delim) => (value[])
+    function envBool(string calldata, string calldata) external returns (bool[] memory);
+    function envUint(string calldata, string calldata) external returns (uint256[] memory);
+    function envInt(string calldata, string calldata) external returns (int256[] memory);
+    function envAddress(string calldata, string calldata) external returns (address[] memory);
+    function envBytes32(string calldata, string calldata) external returns (bytes32[] memory);
+    function envString(string calldata, string calldata) external returns (string[] memory);
+    function envBytes(string calldata, string calldata) external returns (bytes[] memory);
+    // Expects an error on next call
+    function expectRevert(bytes calldata) external;
+    function expectRevert(bytes4) external;
+    function expectRevert() external;
+    // Records all storage reads and writes
+    function record() external;
+    // Gets all accessed reads and write slot from a recording session, for a given address
+    function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
+    // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
+    // Call this function, then emit an event, then call a function. Internally after the call, we check if
+    // logs were emitted in the expected order with the expected topics and data (as specified by the booleans)
+    function expectEmit(bool,bool,bool,bool) external;
+    function expectEmit(bool,bool,bool,bool,address) external;
+    // Expects a call to an address with the specified calldata.
+    // Calldata can either be a strict or a partial match
+    function expectCall(address,bytes calldata) external;
+    // Expects a call to an address with the specified msg.value and calldata
+    function expectCall(address,uint256,bytes calldata) external;
+    // Gets the code from an artifact file. Takes in the relative path to the json file
+    function getCode(string calldata) external returns (bytes memory);
+    // Labels an address in call traces
+    function label(address, string calldata) external;
+    // Using the address that calls the test contract, has the next call (at this call depth only) create a transaction that can later be signed and sent onchain
+    function broadcast() external;
+    // Has the next call (at this call depth only) create a transaction with the address provided as the sender that can later be signed and sent onchain
+    function broadcast(address) external;
+    // Using the address that calls the test contract, has all subsequent calls (at this call depth only) create transactions that can later be signed and sent onchain
+    function startBroadcast() external;
+    // Has all subsequent calls (at this call depth only) create transactions that can later be signed and sent onchain
+    function startBroadcast(address) external;
+    // Stops collecting onchain transactions
+    function stopBroadcast() external;
+    // Reads the entire content of file to string, (path) => (data)
+    function readFile(string calldata) external returns (string memory);
+    // Reads next line of file to string, (path) => (line)
+    function readLine(string calldata) external returns (string memory);
+    // Writes data to file, creating a file if it does not exist, and entirely replacing its contents if it does.
+    // (path, data) => ()
+    function writeFile(string calldata, string calldata) external;
+    // Writes line to file, creating a file if it does not exist.
+    // (path, data) => ()
+    function writeLine(string calldata, string calldata) external;
+    // Closes file for reading, resetting the offset and allowing to read it from beginning with readLine.
+    // (path) => ()
+    function closeFile(string calldata) external;
+    // Removes file. This cheatcode will revert in the following situations, but is not limited to just these cases:
+    // - Path points to a directory.
+    // - The file doesn't exist.
+    // - The user lacks permissions to remove the file.
+    // (path) => ()
+    function removeFile(string calldata) external;
+    // Convert values to a string, (value) => (stringified value)
+    function toString(address) external returns(string memory);
+    function toString(bytes calldata) external returns(string memory);
+    function toString(bytes32) external returns(string memory);
+    function toString(bool) external returns(string memory);
+    function toString(uint256) external returns(string memory);
+    function toString(int256) external returns(string memory);
+    // Record all the transaction logs
+    function recordLogs() external;
+    // Gets all the recorded logs, () => (logs)
+    function getRecordedLogs() external returns (Log[] memory);
+    // Derive a private key from a provided mnenomic string (or mnenomic file path) at the derivation path m/44'/60'/0'/0/{index}
+    function deriveKey(string calldata, uint32) external returns (uint256);
+    // Derive a private key from a provided mnenomic string (or mnenomic file path) at the derivation path {path}{index}
+    function deriveKey(string calldata, string calldata, uint32) external returns (uint256);
+}
+
 interface Vm {
     struct Log {
         bytes32[] topics;

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -88,27 +88,24 @@ contract StdCheatsTest is Test {
     }
 
     function testDeployCode() public {
-        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", bytes(""));
-        assertEq(string(getCode(deployed)), string(getCode(address(this))));
+        address deployed = deployCode("StdCheats.t.sol:Bar", bytes(""));
+        assertEq(string(getCode(deployed)), string(getCode(address(test))));
     }
 
     function testDeployCodeNoArgs() public {
-        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest");
-        assertEq(string(getCode(deployed)), string(getCode(address(this))));
+        address deployed = deployCode("StdCheats.t.sol:Bar");
+        assertEq(string(getCode(deployed)), string(getCode(address(test))));
     }
 
-    // We need the payable constructor in order to send ETH on construction
-    constructor() payable {}
-
     function testDeployCodeVal() public {
-        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", bytes(""), 1 ether);
-        assertEq(string(getCode(deployed)), string(getCode(address(this))));
+        address deployed = deployCode("StdCheats.t.sol:Bar", bytes(""), 1 ether);
+        assertEq(string(getCode(deployed)), string(getCode(address(test))));
         assertEq(deployed.balance, 1 ether);
     }
 
     function testDeployCodeValNoArgs() public {
-        address deployed = deployCode("StdCheats.t.sol:StdCheatsTest", 1 ether);
-        assertEq(string(getCode(deployed)), string(getCode(address(this))));
+        address deployed = deployCode("StdCheats.t.sol:Bar", 1 ether);
+        assertEq(string(getCode(deployed)), string(getCode(address(test))));
         assertEq(deployed.balance, 1 ether);
     }
 
@@ -141,7 +138,7 @@ contract StdCheatsTest is Test {
 }
 
 contract Bar {
-    constructor() {
+    constructor() payable {
         /// `DEAL` STDCHEAT
         totalSupply = 10000e18;
         balanceOf[address(this)] = totalSupply;


### PR DESCRIPTION
## Motivation

Fix #78 

**Note**: Merging into `v0.3`

## Solution

### Changes

- Add `stdStorageSafe` without `checked_write`
- Add `CheatsSafe` with only `deployCode`
- Add `VmSafe` with only read-only cheatcodes
- Update `Script`
- Make all components `abstract`
- Update `deployCode` tests

### Notes

- `stdStorage` delegates some functions to `stdStorageSafe`. This solution works for Solidity 0.6.0 and requires minimal code duplication:

```solidity
stdStorageSafe {
    safeFun() {
        implementation
    }
}

stdStorage {
    safeFun() {
        return stdStorageSafe.safeFun()
    }

    unsafeFun() {
        implementation
    }
}
```

- Interfaces cannot inherit in Solidity 0.6.0, so, `VmSafe` contains duplicate code. Someone should check if I removed any necessary cheatcodes in `VmSafe`.

## Breaking changes

- Only Cheats from `CheatsSafe` will be accessible in `Script` by default
- Only cheatcodes from `VmSafe` will be accessible from `vm` in `Script` by default

<br>

Link #139