### PR TITLE
assertApproxEqRel error message on zero delta

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -416,7 +416,7 @@ abstract contract Test is DSTest, Script {
         uint256 maxPercentDelta, // An 18 decimal fixed point number, where 1e18 == 100%
         string memory err
     ) internal virtual {
-        if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
+        if (b == 0) return assertEq(a, b, err); // If the expected is 0, actual must be too.
 
         uint256 percentDelta = stdMath.percentDelta(a, b);
 


### PR DESCRIPTION
`err` message was not passed to `assertEq` in `assertApproxEqRel` method. These two methods are equivalent when `maxPercentDelta` is zero.