### PR TITLE
feat(stdCheats): Add runScript utility function

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -243,10 +243,10 @@ abstract contract Test is DSTest, Script {
         address scriptAddress = deployCode(what);
     
         // Allow setUp() to fail in case it does not exist
-        scriptAddress.call(abi.encodeWithSignature("setUp()"));
+        (bool success, ) = scriptAddress.call(abi.encodeWithSignature("setUp()"));
 
         // Ensure that run() succeeds
-        (bool success, ) = scriptAddress.call(abi.encodeWithSignature("run()"));
+        (success, ) = scriptAddress.call(abi.encodeWithSignature("run()"));
         require(success, "Test runScript(string): call to run() failed in script.");
     }
 

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -239,14 +239,14 @@ abstract contract Test is DSTest, Script {
         );
     }
 
-    function runScript(string memory what) internal {
+    function runScript(string memory what) internal returns (bytes memory data) {
         address scriptAddress = deployCode(what);
     
         // Allow setUp() to fail in case it does not exist
         (bool success, ) = scriptAddress.call(abi.encodeWithSignature("setUp()"));
 
-        // Ensure that run() succeeds
-        (success, ) = scriptAddress.call(abi.encodeWithSignature("run()"));
+        // Ensure that run() succeeds and return the data
+        (success, data) = scriptAddress.call(abi.encodeWithSignature("run()"));
         require(success, "Test runScript(string): call to run() failed in script.");
     }
 

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -239,6 +239,17 @@ abstract contract Test is DSTest, Script {
         );
     }
 
+    function runScript(string memory what) internal {
+        address scriptAddress = deployCode(what);
+    
+        // Allow setUp() to fail in case it does not exist
+        scriptAddress.call(abi.encodeWithSignature("setUp()"));
+
+        // Ensure that run() succeeds
+        (bool success, ) = scriptAddress.call(abi.encodeWithSignature("run()"));
+        require(success, "Test runScript(string): call to run() failed in script.");
+    }
+
     /*//////////////////////////////////////////////////////////////////////////
                                     STD-ASSERTIONS
     //////////////////////////////////////////////////////////////////////////*/

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -204,6 +204,11 @@ contract StdCheatsTest is Test {
         runScript("StdCheats.t.sol:ScriptWithoutSetup");
         assertTrue(vm.envBool("SCRIPT_RUN_CALLED"));
     }
+
+    function testRunReturnsData() public {
+        bytes memory data = runScript("StdCheats.t.sol:ScriptRunReturnsData");
+        assertEq(abi.decode(data, (uint256)), 1);
+    }
 }
 
 contract Bar {
@@ -250,5 +255,11 @@ contract ScriptWithSetup is Script {
 contract ScriptWithoutSetup is Script {
     function run() public {
         vm.setEnv("SCRIPT_RUN_CALLED", "true");
+    }
+}
+
+contract ScriptRunReturnsData is Script {
+    function run() public returns (uint256) {
+        return 1;
     }
 }

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
+import "../Script.sol";
 import "../Test.sol";
 
 contract StdCheatsTest is Test {
@@ -192,6 +193,17 @@ contract StdCheatsTest is Test {
             extcodecopy(who, add(o_code, 0x20), 0, size)
         }
     }
+
+    function testRunScriptWithSetup() public {
+        runScript("StdCheats.t.sol:ScriptWithSetup");
+        assertTrue(vm.envBool("SCRIPT_SETUP_CALLED"));
+        assertTrue(vm.envBool("SCRIPT_RUN_CALLED"));
+    }
+
+    function testRunScriptWithoutSetup() public {
+        runScript("StdCheats.t.sol:ScriptWithoutSetup");
+        assertTrue(vm.envBool("SCRIPT_RUN_CALLED"));
+    }
 }
 
 contract Bar {
@@ -222,5 +234,21 @@ contract Bar {
 contract RevertingContract {
     constructor() {
         revert();
+    }
+}
+
+contract ScriptWithSetup is Script {
+    function setUp() public {
+        vm.setEnv("SCRIPT_SETUP_CALLED", "true");
+    }
+
+    function run() public {
+        vm.setEnv("SCRIPT_RUN_CALLED", "true");
+    }
+}
+
+contract ScriptWithoutSetup is Script {
+    function run() public {
+        vm.setEnv("SCRIPT_RUN_CALLED", "true");
     }
 }


### PR DESCRIPTION
Finally getting around to writing a little blog post on the importance of testing your scripts and as part of it I had a lot of:
```solidity
Script script = new Script();
script.setUp();
script.run();
```
in my tests. I figure this utility function in `forge-std` will be helpful for others too. It means we can just write:
```solidity
runScript("Script.sol");
```