### PR TITLE
feat: add more uint assertions

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,0 +1,2 @@
+[profile.default]
+fs_permissions = [{ access = "read-write", path = "./"}]

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -330,19 +330,7 @@ abstract contract Test is DSTest, Script {
         }
     }
 
-    function assertUint128Eq(uint128 a, uint128 b) internal {
-        assertEq(uint256(a), uint256(b));
-    }
-
-    function assertUint64Eq(uint64 a, uint64 b) internal {
-        assertEq(uint256(a), uint256(b));
-    }
-
-    function assertUint96Eq(uint96 a, uint96 b) internal {
-        assertEq(uint256(a), uint256(b));
-    }
-
-    function assertUint32Eq(uint32 a, uint32 b) internal {
+    function assertEqUint(uint256 a, uint256 b) internal {
         assertEq(uint256(a), uint256(b));
     }
 

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -330,6 +330,22 @@ abstract contract Test is DSTest, Script {
         }
     }
 
+    function assertUint128Eq(uint128 a, uint128 b) internal {
+        assertEq(uint256(a), uint256(b));
+    }
+
+    function assertUint64Eq(uint64 a, uint64 b) internal {
+        assertEq(uint256(a), uint256(b));
+    }
+
+    function assertUint96Eq(uint96 a, uint96 b) internal {
+        assertEq(uint256(a), uint256(b));
+    }
+
+    function assertUint32Eq(uint32 a, uint32 b) internal {
+        assertEq(uint256(a), uint256(b));
+    }
+
     function assertApproxEqAbs(
         uint256 a,
         uint256 b,

--- a/src/test/StdAssertions.t.sol
+++ b/src/test/StdAssertions.t.sol
@@ -13,6 +13,17 @@ contract StdAssertionsTest is Test
     TestTest t = new TestTest();
 
     /*//////////////////////////////////////////////////////////////////////////
+                                    ASSERT_EQ(UINT)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function testAssertions() public {
+        assertEqUint(uint32(1), uint32(1));
+        assertEqUint(uint64(1), uint64(1));
+        assertEqUint(uint96(1), uint96(1));
+        assertEqUint(uint128(1), uint128(1));
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
                                     FAIL(STRING)
     //////////////////////////////////////////////////////////////////////////*/
 

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -248,10 +248,10 @@ contract StdCheatsTest is Test {
     }
 
     function testAssertions() public {
-        assertUint32Eq(uint32(1), uint32(1));
-        assertUint64Eq(uint64(1), uint64(1));
-        assertUint96Eq(uint96(1), uint96(1));
-        assertUint128Eq(uint128(1), uint128(1));
+        assertEqUint(uint32(1), uint32(1));
+        assertEqUint(uint64(1), uint64(1));
+        assertEqUint(uint96(1), uint96(1));
+        assertEqUint(uint128(1), uint128(1));
     }
 
 }

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -247,6 +247,13 @@ contract StdCheatsTest is Test {
         Receipt[] memory receipts = readReceipts(path);
     }
 
+    function testAssertions() public {
+        assertUint32Eq(uint32(1), uint32(1));
+        assertUint64Eq(uint64(1), uint64(1));
+        assertUint96Eq(uint96(1), uint96(1));
+        assertUint128Eq(uint128(1), uint128(1));
+    }
+
 }
 
 contract Bar {

--- a/src/test/StdCheats.t.sol
+++ b/src/test/StdCheats.t.sol
@@ -247,13 +247,6 @@ contract StdCheatsTest is Test {
         Receipt[] memory receipts = readReceipts(path);
     }
 
-    function testAssertions() public {
-        assertEqUint(uint32(1), uint32(1));
-        assertEqUint(uint64(1), uint64(1));
-        assertEqUint(uint96(1), uint96(1));
-        assertEqUint(uint128(1), uint128(1));
-    }
-
 }
 
 contract Bar {


### PR DESCRIPTION
- Fixes #165 
- Adds `foundry.toml` to address latest `allowed_paths` error that originates from https://github.com/foundry-rs/foundry/pull/3007