### PR TITLE
Add assertion error for different types

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -329,6 +329,20 @@ abstract contract Test is DSTest, Script {
             assertEq(a, b);
         }
     }
+    
+    function assertEq(uint a, int b) internal {
+        emit log                ("Error: variables have different types [type]");
+        emit log_named_string   ("  Expected int");
+        emit log_named_string   ("    Actual uint");
+        fail();
+    }    
+    
+    function assertEq(int a, uint b) internal {
+        emit log                ("Error: variables have different types [type]");
+        emit log_named_string   ("  Expected uint");
+        emit log_named_string   ("    Actual int");
+        fail();
+    }
 
     function assertEqUint(uint256 a, uint256 b) internal {
         assertEq(uint256(a), uint256(b));


### PR DESCRIPTION
When accidentally mixing uint and int in tests, the console throws a very long output. This PR corrects this by throwing a simple error.

```
error[9322]: TypeError: No matching declaration found after argument-dependent lookup.
  --> test/lib/FundingFee/Curve.t.sol:14:9:
   |
14 |         assertEq(FundingFee.curve(ONE * 1 / 10), 2 * PERCENT, "0.1");
   |         ^^^^^^^^
Note: Candidate:
   --> lib/forge-std/src/Test.sol:212:5:
    |
212 |     function assertEq(bool a, bool b) internal {
    |     ^ (Relevant source part starts here and spans across multiple lines).
Note: Candidate:
   --> lib/forge-std/src/Test.sol:221:5:
    |
221 |     function assertEq(bool a, bool b, string memory err) internal {
    |     ^ (Relevant source part starts here and spans across multiple lines).
```

<img width="679" alt="image" src="https://user-images.githubusercontent.com/10600295/192847927-2c45421f-3b71-4aa9-b17d-c0ccbed186d7.png">