### PR TITLE
feat: add assertApproxEqAbsDecimal assertions

### DIFF
--- a/src/StdAssertions.sol
+++ b/src/StdAssertions.sol
@@ -124,6 +124,31 @@ abstract contract StdAssertions is DSTest {
         }
     }
 
+    function assertApproxEqAbsDecimal(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals) internal virtual {
+        uint256 delta = stdMath.delta(a, b);
+
+        if (delta > maxDelta) {
+            emit log("Error: a ~= b not satisfied [uint]");
+            emit log_named_decimal_uint("  Expected", b, decimals);
+            emit log_named_decimal_uint("    Actual", a, decimals);
+            emit log_named_decimal_uint(" Max Delta", maxDelta, decimals);
+            emit log_named_decimal_uint("     Delta", delta, decimals);
+            fail();
+        }
+    }
+
+    function assertApproxEqAbsDecimal(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals, string memory err)
+        internal
+        virtual
+    {
+        uint256 delta = stdMath.delta(a, b);
+
+        if (delta > maxDelta) {
+            emit log_named_string("Error", err);
+            assertApproxEqAbsDecimal(a, b, maxDelta, decimals);
+        }
+    }
+
     function assertApproxEqAbs(int256 a, int256 b, uint256 maxDelta) internal virtual {
         uint256 delta = stdMath.delta(a, b);
 
@@ -143,6 +168,31 @@ abstract contract StdAssertions is DSTest {
         if (delta > maxDelta) {
             emit log_named_string("Error", err);
             assertApproxEqAbs(a, b, maxDelta);
+        }
+    }
+
+    function assertApproxEqAbsDecimal(int256 a, int256 b, uint256 maxDelta, uint256 decimals) internal virtual {
+        uint256 delta = stdMath.delta(a, b);
+
+        if (delta > maxDelta) {
+            emit log("Error: a ~= b not satisfied [int]");
+            emit log_named_decimal_int("  Expected", b, decimals);
+            emit log_named_decimal_int("    Actual", a, decimals);
+            emit log_named_decimal_uint(" Max Delta", maxDelta, decimals);
+            emit log_named_decimal_uint("     Delta", delta, decimals);
+            fail();
+        }
+    }
+
+    function assertApproxEqAbsDecimal(int256 a, int256 b, uint256 maxDelta, uint256 decimals, string memory err)
+        internal
+        virtual
+    {
+        uint256 delta = stdMath.delta(a, b);
+
+        if (delta > maxDelta) {
+            emit log_named_string("Error", err);
+            assertApproxEqAbsDecimal(a, b, maxDelta, decimals);
         }
     }
 

--- a/src/StdAssertions.sol
+++ b/src/StdAssertions.sol
@@ -231,6 +231,43 @@ abstract contract StdAssertions is DSTest {
         }
     }
 
+    function assertApproxEqRelDecimal(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta, // An 18 decimal fixed point number, where 1e18 == 100%
+        uint256 decimals
+    ) internal virtual {
+        if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
+
+        uint256 percentDelta = stdMath.percentDelta(a, b);
+
+        if (percentDelta > maxPercentDelta) {
+            emit log("Error: a ~= b not satisfied [uint]");
+            emit log_named_decimal_uint("    Expected", b, decimals);
+            emit log_named_decimal_uint("      Actual", a, decimals);
+            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta, 18);
+            emit log_named_decimal_uint("     % Delta", percentDelta, 18);
+            fail();
+        }
+    }
+
+    function assertApproxEqRelDecimal(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta, // An 18 decimal fixed point number, where 1e18 == 100%
+        uint256 decimals,
+        string memory err
+    ) internal virtual {
+        if (b == 0) return assertEq(a, b, err); // If the expected is 0, actual must be too.
+
+        uint256 percentDelta = stdMath.percentDelta(a, b);
+
+        if (percentDelta > maxPercentDelta) {
+            emit log_named_string("Error", err);
+            assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals);
+        }
+    }
+
     function assertApproxEqRel(int256 a, int256 b, uint256 maxPercentDelta) internal virtual {
         if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
 
@@ -254,6 +291,35 @@ abstract contract StdAssertions is DSTest {
         if (percentDelta > maxPercentDelta) {
             emit log_named_string("Error", err);
             assertApproxEqRel(a, b, maxPercentDelta);
+        }
+    }
+
+    function assertApproxEqRelDecimal(int256 a, int256 b, uint256 maxPercentDelta, uint256 decimals) internal virtual {
+        if (b == 0) return assertEq(a, b); // If the expected is 0, actual must be too.
+
+        uint256 percentDelta = stdMath.percentDelta(a, b);
+
+        if (percentDelta > maxPercentDelta) {
+            emit log("Error: a ~= b not satisfied [int]");
+            emit log_named_decimal_int("    Expected", b, decimals);
+            emit log_named_decimal_int("      Actual", a, decimals);
+            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta, 18);
+            emit log_named_decimal_uint("     % Delta", percentDelta, 18);
+            fail();
+        }
+    }
+
+    function assertApproxEqRelDecimal(int256 a, int256 b, uint256 maxPercentDelta, uint256 decimals, string memory err)
+        internal
+        virtual
+    {
+        if (b == 0) return assertEq(a, b, err); // If the expected is 0, actual must be too.
+
+        uint256 percentDelta = stdMath.percentDelta(a, b);
+
+        if (percentDelta > maxPercentDelta) {
+            emit log_named_string("Error", err);
+            assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals);
         }
     }
 }

--- a/test/StdAssertions.t.sol
+++ b/test/StdAssertions.t.sol
@@ -485,6 +485,50 @@ contract StdAssertionsTest is Test {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
+                                    APPROX_EQ_REL_DECIMAL(UINT)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function testAssertApproxEqRelDecimal_Uint_Pass(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
+        external
+    {
+        vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
+        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_PASS);
+    }
+
+    function testAssertApproxEqRelDecimal_Uint_Fail(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
+        external
+    {
+        vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
+        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
+
+        vm.expectEmit(false, false, false, true);
+        emit log("Error: a ~= b not satisfied [uint]");
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_FAIL);
+    }
+
+    function testAssertApproxEqRelDecimal_UintErr_Pass(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
+        external
+    {
+        vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
+        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
+    }
+
+    function testAssertApproxEqRelDecimal_UintErr_Fail(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
+        external
+    {
+        vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
+        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
+
+        vm.expectEmit(false, false, false, true);
+        emit log_named_string("Error", CUSTOM_ERROR);
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_FAIL);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
                                     APPROX_EQ_REL(INT)
     //////////////////////////////////////////////////////////////////////////*/
 
@@ -518,6 +562,50 @@ contract StdAssertionsTest is Test {
         vm.expectEmit(false, false, false, true);
         emit log_named_string("Error", CUSTOM_ERROR);
         t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_FAIL);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    APPROX_EQ_REL_DECIMAL(INT)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function testAssertApproxEqRelDecimal_Int_Pass(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
+        external
+    {
+        vm.assume(b != 0);
+        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_PASS);
+    }
+
+    function testAssertApproxEqRelDecimal_Int_Fail(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
+        external
+    {
+        vm.assume(b != 0);
+        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
+
+        vm.expectEmit(false, false, false, true);
+        emit log("Error: a ~= b not satisfied [int]");
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_FAIL);
+    }
+
+    function testAssertApproxEqRelDecimal_IntErr_Pass(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
+        external
+    {
+        vm.assume(b != 0);
+        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
+    }
+
+    function testAssertApproxEqRelDecimal_IntErr_Fail(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
+        external
+    {
+        vm.assume(b != 0);
+        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
+
+        vm.expectEmit(false, false, false, true);
+        emit log_named_string("Error", CUSTOM_ERROR);
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_FAIL);
     }
 }
 
@@ -683,6 +771,24 @@ contract TestTest is Test {
         assertApproxEqRel(a, b, maxPercentDelta, err);
     }
 
+    function _assertApproxEqRelDecimal(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals, bool expectFail)
+        external
+        expectFailure(expectFail)
+    {
+        assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals);
+    }
+
+    function _assertApproxEqRelDecimal(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta,
+        uint256 decimals,
+        string memory err,
+        bool expectFail
+    ) external expectFailure(expectFail) {
+        assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, err);
+    }
+
     function _assertApproxEqRel(int256 a, int256 b, uint256 maxPercentDelta, bool expectFail)
         external
         expectFailure(expectFail)
@@ -695,5 +801,23 @@ contract TestTest is Test {
         expectFailure(expectFail)
     {
         assertApproxEqRel(a, b, maxPercentDelta, err);
+    }
+
+    function _assertApproxEqRelDecimal(int256 a, int256 b, uint256 maxPercentDelta, uint256 decimals, bool expectFail)
+        external
+        expectFailure(expectFail)
+    {
+        assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals);
+    }
+
+    function _assertApproxEqRelDecimal(
+        int256 a,
+        int256 b,
+        uint256 maxPercentDelta,
+        uint256 decimals,
+        string memory err,
+        bool expectFail
+    ) external expectFailure(expectFail) {
+        assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, err);
     }
 }

--- a/test/StdAssertions.t.sol
+++ b/test/StdAssertions.t.sol
@@ -341,6 +341,46 @@ contract StdAssertionsTest is Test {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
+                                    APPROX_EQ_ABS_DECIMAL(UINT)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function testAssertApproxEqAbsDecimal_Uint_Pass(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
+        external
+    {
+        vm.assume(stdMath.delta(a, b) <= maxDelta);
+
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_PASS);
+    }
+
+    function testAssertApproxEqAbsDecimal_Uint_Fail(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
+        external
+    {
+        vm.assume(stdMath.delta(a, b) > maxDelta);
+
+        vm.expectEmit(false, false, false, true);
+        emit log("Error: a ~= b not satisfied [uint]");
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_FAIL);
+    }
+
+    function testAssertApproxEqAbsDecimal_UintErr_Pass(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
+        external
+    {
+        vm.assume(stdMath.delta(a, b) <= maxDelta);
+
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
+    }
+
+    function testAssertApproxEqAbsDecimal_UintErr_Fail(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
+        external
+    {
+        vm.assume(stdMath.delta(a, b) > maxDelta);
+
+        vm.expectEmit(false, false, false, true);
+        emit log_named_string("Error", CUSTOM_ERROR);
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT_FAIL);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
                                     APPROX_EQ_ABS(INT)
     //////////////////////////////////////////////////////////////////////////*/
 
@@ -370,6 +410,42 @@ contract StdAssertionsTest is Test {
         vm.expectEmit(false, false, false, true);
         emit log_named_string("Error", CUSTOM_ERROR);
         t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_FAIL);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    APPROX_EQ_ABS_DECIMAL(INT)
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function testAssertApproxEqAbsDecimal_Int_Pass(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
+        vm.assume(stdMath.delta(a, b) <= maxDelta);
+
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_PASS);
+    }
+
+    function testAssertApproxEqAbsDecimal_Int_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
+        vm.assume(stdMath.delta(a, b) > maxDelta);
+
+        vm.expectEmit(false, false, false, true);
+        emit log("Error: a ~= b not satisfied [int]");
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_FAIL);
+    }
+
+    function testAssertApproxEqAbsDecimal_IntErr_Pass(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
+        external
+    {
+        vm.assume(stdMath.delta(a, b) <= maxDelta);
+
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
+    }
+
+    function testAssertApproxEqAbsDecimal_IntErr_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
+        external
+    {
+        vm.assume(stdMath.delta(a, b) > maxDelta);
+
+        vm.expectEmit(false, false, false, true);
+        emit log_named_string("Error", CUSTOM_ERROR);
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT_FAIL);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -543,6 +619,24 @@ contract TestTest is Test {
         assertApproxEqAbs(a, b, maxDelta, err);
     }
 
+    function _assertApproxEqAbsDecimal(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals, bool expectFail)
+        external
+        expectFailure(expectFail)
+    {
+        assertApproxEqAbsDecimal(a, b, maxDelta, decimals);
+    }
+
+    function _assertApproxEqAbsDecimal(
+        uint256 a,
+        uint256 b,
+        uint256 maxDelta,
+        uint256 decimals,
+        string memory err,
+        bool expectFail
+    ) external expectFailure(expectFail) {
+        assertApproxEqAbsDecimal(a, b, maxDelta, decimals, err);
+    }
+
     function _assertApproxEqAbs(int256 a, int256 b, uint256 maxDelta, bool expectFail)
         external
         expectFailure(expectFail)
@@ -555,6 +649,24 @@ contract TestTest is Test {
         expectFailure(expectFail)
     {
         assertApproxEqAbs(a, b, maxDelta, err);
+    }
+
+    function _assertApproxEqAbsDecimal(int256 a, int256 b, uint256 maxDelta, uint256 decimals, bool expectFail)
+        external
+        expectFailure(expectFail)
+    {
+        assertApproxEqAbsDecimal(a, b, maxDelta, decimals);
+    }
+
+    function _assertApproxEqAbsDecimal(
+        int256 a,
+        int256 b,
+        uint256 maxDelta,
+        uint256 decimals,
+        string memory err,
+        bool expectFail
+    ) external expectFailure(expectFail) {
+        assertApproxEqAbsDecimal(a, b, maxDelta, decimals, err);
     }
 
     function _assertApproxEqRel(uint256 a, uint256 b, uint256 maxPercentDelta, bool expectFail)


### PR DESCRIPTION
Adding decimal formatting support for the `assertApproxEqAbs` assertions. Since it's a small one I figured I'd just PR instead of opening an issue, let me know if I need to create one