### PR TITLE
test(bound): add even distribution test

### DIFF
--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -7,7 +7,7 @@ abstract contract StdUtils {
     uint256 internal constant UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
-    function _bound(uint256 x, uint256 min, uint256 max) internal pure virtual returns (uint256) {
+    function _bound(uint256 x, uint256 min, uint256 max) internal pure virtual returns (uint256 result) {
         require(min <= max, "StdUtils bound(uint256,uint256,uint256): Max is less than min.");
 
         // If x is between min and max, return x directly. This is to ensure that dictionary values
@@ -26,15 +26,12 @@ abstract contract StdUtils {
             uint256 diff = x - max;
             uint256 rem = diff % size;
             if (rem == 0) return max;
-            uint256 result = min + rem - 1;
-            return result;
-        }
-        if (x < max) {
+            result = min + rem - 1;
+        } else if (x < max) {
             uint256 diff = min - x;
             uint256 rem = diff % size;
             if (rem == 0) return min;
-            uint256 result = max - rem + 1;
-            return result;
+            result = max - rem + 1;
         }
     }
 

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -31,6 +31,22 @@ contract StdUtilsTest is Test {
         assertEq(bound(type(uint256).max - 3, 50, 150), 147);
     }
 
+    function testBound_DistributionIsEven(uint256 min, uint256 size) public {
+        size = size % 100 + 1;
+        min = bound(min, UINT256_MAX / 2, UINT256_MAX / 2 + size);
+        uint256 max = min + size - 1;
+        uint256 result;
+
+        for (uint256 i = 1; i <= size * 4; ++i) {
+            // x > max
+            result = bound(max + i, min, max);
+            assertEq(result, min + (i - 1) % size);
+            // x < min
+            result = bound(min - i, min, max);
+            assertEq(result, max - (i - 1) % size);
+        }
+    }
+
     function testBound(uint256 num, uint256 min, uint256 max) public {
         if (min > max) (min, max) = (max, min);
 


### PR DESCRIPTION
## Motivation

Check programmatically that wrapped `bound` results are evenly distributed.

## Solution

- Add a test
- Fix solc warning for `_bound` unassigned return