### PR TITLE
Test.sol import statement changed 

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.6.0 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import "./Script.sol";
-import "ds-test/test.sol";
+import "../lib/ds-test/src/test.sol";
 
 // Wrappers around Cheatcodes to avoid footguns
 abstract contract Test is DSTest, Script {


### PR DESCRIPTION
Import file path changed to relative path. By the way, only this line was using this type of import statement (with remappings).

If we want to different remappings or even don't want to use remappings, some checker/analyzer tools can be confused that hard to understand of remappings. Nested libraries can be problematic.

My suggestion is using relative path for libraries but I'm open too other suggestions.
