### PR TITLE
Use relative imports in interfaces for VSCode linting compatibility

### DIFF
--- a/src/interfaces/IERC1155.sol
+++ b/src/interfaces/IERC1155.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.6.2;
 
-import "src/interfaces/IERC165.sol";
+import "./IERC165.sol";
 
 /// @title ERC-1155 Multi Token Standard
 /// @dev See https://eips.ethereum.org/EIPS/eip-1155

--- a/src/interfaces/IERC4626.sol
+++ b/src/interfaces/IERC4626.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.6.2;
 
-import "src/interfaces/IERC20.sol";
+import "./IERC20.sol";
 
 /// @dev Interface of the ERC4626 "Tokenized Vault Standard", as defined in
 /// https://eips.ethereum.org/EIPS/eip-4626

--- a/src/interfaces/IERC721.sol
+++ b/src/interfaces/IERC721.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.6.2;
 
-import "src/interfaces/IERC165.sol";
+import "./IERC165.sol";
 
 /// @title ERC-721 Non-Fungible Token Standard
 /// @dev See https://eips.ethereum.org/EIPS/eip-721


### PR DESCRIPTION
For some strange and frustrating reason, importing from a submodule that uses absolute imports from a common directory name seems to break Solidity linting in VSCode – even though the code compiles and runs fine. I've tried with both Juan Blanco and Hardhat Solidity extensions.

Here's an example code block:


```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.13;

import {Test} from "forge-std/Test.sol";
import {IERC721} from "forge-std/interfaces/IERC721.sol";


contract LintingTest is Test {

    function testTransact() public {
        // address payable receiver = payable(0);
        receiver.transfer(1 ether);
    }

}
```

Obviously, this won't compile as-is - but the linter (probably?) doesn't show any errors, either. Uncommenting the `receiver` declaration results in it compiling just fine.

Using relative imports will fix this behavior.

