### PR TITLE
Fix long compile times when using `via-ir`

### DIFF
--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -229,14 +229,14 @@ contract StdCheatsTest is Test {
 
     function testChainRpcInitialization() public {
         // RPCs specified in `foundry.toml` should be updated.
-        assertEq(stdChains.Mainnet.rpcUrl, "https://api.mycryptoapi.com/eth/");
-        assertEq(stdChains.OptimismGoerli.rpcUrl, "https://goerli.optimism.io/");
-        assertEq(stdChains.ArbitrumOneGoerli.rpcUrl, "https://goerli-rollup.arbitrum.io/rpc/");
+        assertEq(stdChains().Mainnet.rpcUrl, "https://api.mycryptoapi.com/eth/");
+        assertEq(stdChains().OptimismGoerli.rpcUrl, "https://goerli.optimism.io/");
+        assertEq(stdChains().ArbitrumOneGoerli.rpcUrl, "https://goerli-rollup.arbitrum.io/rpc/");
 
         // Other RPCs should remain unchanged.
-        assertEq(stdChains.Anvil.rpcUrl, "http://127.0.0.1:8545");
-        assertEq(stdChains.Hardhat.rpcUrl, "http://127.0.0.1:8545");
-        assertEq(stdChains.Sepolia.rpcUrl, "https://rpc.sepolia.dev");
+        assertEq(stdChains().Anvil.rpcUrl, "http://127.0.0.1:8545");
+        assertEq(stdChains().Hardhat.rpcUrl, "http://127.0.0.1:8545");
+        assertEq(stdChains().Sepolia.rpcUrl, "https://rpc.sepolia.dev");
     }
 
     // Ensure we can connect to the default RPC URL for each chain.

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -90,7 +90,7 @@ contract StdUtilsTest is Test {
     }
 
     function testAssumeNoPrecompilesL1(address addr) external {
-        assumeNoPrecompiles(addr, stdChains.Mainnet.chainId);
+        assumeNoPrecompiles(addr, stdChains().Mainnet.chainId);
         assertTrue(addr < address(1) || addr > address(9));
     }
 }


### PR DESCRIPTION
For #207.

Tested on Solady. Compiles within 2 minutes instead of 30+ minutes.