### PR TITLE
fix: ds-test imports + compiler warnings

### DIFF
--- a/src/StdAssertions.sol
+++ b/src/StdAssertions.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.6.2 <0.9.0;
 
-import "../lib/ds-test/src/test.sol";
+import "ds-test/test.sol";
 import "./StdMath.sol";
 
 abstract contract StdAssertions is DSTest {

--- a/src/StdJson.sol
+++ b/src/StdJson.sol
@@ -9,63 +9,63 @@ import "./Vm.sol";
 library stdJson {
     VmSafe private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    function parseRaw(string memory json, string memory key) internal returns (bytes memory) {
+    function parseRaw(string memory json, string memory key) internal pure returns (bytes memory) {
         return vm.parseJson(json, key);
     }
 
-    function readUint(string memory json, string memory key) internal returns (uint256) {
+    function readUint(string memory json, string memory key) internal pure returns (uint256) {
         return abi.decode(vm.parseJson(json, key), (uint256));
     }
 
-    function readUintArray(string memory json, string memory key) internal returns (uint256[] memory) {
+    function readUintArray(string memory json, string memory key) internal pure returns (uint256[] memory) {
         return abi.decode(vm.parseJson(json, key), (uint256[]));
     }
 
-    function readInt(string memory json, string memory key) internal returns (int256) {
+    function readInt(string memory json, string memory key) internal pure returns (int256) {
         return abi.decode(vm.parseJson(json, key), (int256));
     }
 
-    function readIntArray(string memory json, string memory key) internal returns (int256[] memory) {
+    function readIntArray(string memory json, string memory key) internal pure returns (int256[] memory) {
         return abi.decode(vm.parseJson(json, key), (int256[]));
     }
 
-    function readBytes32(string memory json, string memory key) internal returns (bytes32) {
+    function readBytes32(string memory json, string memory key) internal pure returns (bytes32) {
         return abi.decode(vm.parseJson(json, key), (bytes32));
     }
 
-    function readBytes32Array(string memory json, string memory key) internal returns (bytes32[] memory) {
+    function readBytes32Array(string memory json, string memory key) internal pure returns (bytes32[] memory) {
         return abi.decode(vm.parseJson(json, key), (bytes32[]));
     }
 
-    function readString(string memory json, string memory key) internal returns (string memory) {
+    function readString(string memory json, string memory key) internal pure returns (string memory) {
         return abi.decode(vm.parseJson(json, key), (string));
     }
 
-    function readStringArray(string memory json, string memory key) internal returns (string[] memory) {
+    function readStringArray(string memory json, string memory key) internal pure returns (string[] memory) {
         return abi.decode(vm.parseJson(json, key), (string[]));
     }
 
-    function readAddress(string memory json, string memory key) internal returns (address) {
+    function readAddress(string memory json, string memory key) internal pure returns (address) {
         return abi.decode(vm.parseJson(json, key), (address));
     }
 
-    function readAddressArray(string memory json, string memory key) internal returns (address[] memory) {
+    function readAddressArray(string memory json, string memory key) internal pure returns (address[] memory) {
         return abi.decode(vm.parseJson(json, key), (address[]));
     }
 
-    function readBool(string memory json, string memory key) internal returns (bool) {
+    function readBool(string memory json, string memory key) internal pure returns (bool) {
         return abi.decode(vm.parseJson(json, key), (bool));
     }
 
-    function readBoolArray(string memory json, string memory key) internal returns (bool[] memory) {
+    function readBoolArray(string memory json, string memory key) internal pure returns (bool[] memory) {
         return abi.decode(vm.parseJson(json, key), (bool[]));
     }
 
-    function readBytes(string memory json, string memory key) internal returns (bytes memory) {
+    function readBytes(string memory json, string memory key) internal pure returns (bytes memory) {
         return abi.decode(vm.parseJson(json, key), (bytes));
     }
 
-    function readBytesArray(string memory json, string memory key) internal returns (bytes[] memory) {
+    function readBytesArray(string memory json, string memory key) internal pure returns (bytes[] memory) {
         return abi.decode(vm.parseJson(json, key), (bytes[]));
     }
 }

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.6.2 <0.9.0;
 
 import {CommonBase} from "./Common.sol";
-import "../lib/ds-test/src/test.sol";
+import "ds-test/test.sol";
 // forgefmt: disable-next-line
 import {console, console2, StdAssertions, StdCheats, stdError, stdJson, stdMath, StdStorage, stdStorage, StdUtils, Vm} from "./Components.sol";
 


### PR DESCRIPTION
- Changes ds-test imports back to absolute paths, per #208 
- Updates visibility to remove compiler warnings, which resulted from #205