### PR TITLE
Fix unexpected condition in `bound`

### DIFF
--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -27,7 +27,7 @@ abstract contract StdUtils {
             uint256 rem = diff % size;
             if (rem == 0) return max;
             result = min + rem - 1;
-        } else if (x < max) {
+        } else if (x < min) {
             uint256 diff = min - x;
             uint256 rem = diff % size;
             if (rem == 0) return min;


### PR DESCRIPTION
This is not causing a bug because it's expected that if `x < max` then `x < min` thanks to the condition met earlier in the function's execution: `x < min || x > max` (otherwise it would have returned `x`)

But this PR is for code clarity