### PR TITLE
Fix IERC1155 Interface name

### DIFF
--- a/src/interfaces/IERC1155.sol
+++ b/src/interfaces/IERC1155.sol
@@ -5,7 +5,7 @@ import "./IERC165.sol";
 /// @title ERC-1155 Multi Token Standard
 /// @dev See https://eips.ethereum.org/EIPS/eip-1155
 /// Note: The ERC-165 identifier for this interface is 0xd9b67a26.
-interface ERC1155 is IERC165 {
+interface IERC1155 is IERC165 {
     /// @dev
     /// - Either `TransferSingle` or `TransferBatch` MUST emit when tokens are transferred, including zero value transfers as well as minting or burning (see "Safe Transfer Rules" section of the standard).
     /// - The `_operator` argument MUST be the address of an account/contract that is approved to make the transfer (SHOULD be msg.sender).


### PR DESCRIPTION
The interface in `IERC1155.sol` is named `ERC1155`, rather than `IERC1155` 

Unfortunately this a breaking change; we could also include `interface ERC1155 is IERC1155 {}` for backwards compatibility?