### PR TITLE
feat: add keyExists helper into StdJson

### DIFF
--- a/src/StdJson.sol
+++ b/src/StdJson.sol
@@ -33,6 +33,10 @@ library stdJson {
         return vm.parseJson(json, key);
     }
 
+    function keyExists(string memory json, string memory key) internal pure returns (bool) {
+        return vm.parseJson(json, key).length > 0;
+    }
+
     function readUint(string memory json, string memory key) internal pure returns (uint256) {
         return abi.decode(vm.parseJson(json, key), (uint256));
     }


### PR DESCRIPTION
Proposing `keyExists(...)` helper that will explicitly determine if a given key exists in a JSON.

**Rationale:** For an average user, who is using the StdJson decode helpers, it is not trivial to find a way around sudden EVM reverts if requested JSON key doesn't exist.
The documentation doesn't mention what to do in such a case, and try/catch statements do not work either.
This helper can help to avoid reverts when parsing JSON.

**Implementation:** Although verifying the key exists is just checking the return length of raw `parseJson` bytes, for an average user this method is not trivial nor well documented (and also looks ugly in code).

**Testing:** Although lack of formal tests, the implementation was manually verified against an empty string (encodes as 64 bytes: 0x20 and 0x00), `null` (encoded as 32 zero bytes). Not existing key returns `0x` empty bytes array with zero length. More edge cases might need to be verified, depending on how rust JSON parser works.

**Example use case:**
Assume we use `addresses.json` containing deployment addresses, and we need to know if a contract was already deployed to a given network or we need to deploy it. `keyExists('network.ContractName')` will give us the answer.