### PR TITLE
feat: reimplement `StdChains`

### DIFF
--- a/src/Components.sol
+++ b/src/Components.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.6.2 <0.9.0;
 import "./console.sol";
 import "./console2.sol";
 import "./StdAssertions.sol";
+import "./StdChains.sol";
 import "./StdCheats.sol";
 import "./StdError.sol";
 import "./StdJson.sol";

--- a/src/Script.sol
+++ b/src/Script.sol
@@ -3,12 +3,12 @@ pragma solidity >=0.6.2 <0.9.0;
 
 import {CommonBase} from "./Common.sol";
 // forgefmt: disable-next-line
-import {console, console2, StdCheatsSafe, stdJson, stdMath, StdStorage, stdStorageSafe, StdUtils, VmSafe} from "./Components.sol";
+import {console, console2, StdChains, StdCheatsSafe, stdJson, stdMath, StdStorage, stdStorageSafe, StdUtils, VmSafe} from "./Components.sol";
 
 abstract contract ScriptBase is CommonBase {
     VmSafe internal constant vmSafe = VmSafe(VM_ADDRESS);
 }
 
-abstract contract Script is ScriptBase, StdCheatsSafe, StdUtils {
+abstract contract Script is ScriptBase, StdChains, StdCheatsSafe, StdUtils {
     bool public IS_SCRIPT = true;
 }

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -20,13 +20,16 @@ abstract contract StdChains {
         string rpcUrl;
     }
 
-    // Maps from a chain's name (matching what's in the `foundry.toml` file) to chain data.
+    bool private initialized;
+
+    // Maps from a chain's key (matching the alias in the `foundry.toml` file) to chain data.
     mapping(string => Chain) private chains;
+    // Maps from a chain ID to that chain's key name
     mapping(uint256 => string) private idToKey;
 
-    function getChain(string memory name) internal virtual returns (Chain memory) {
+    function getChain(string memory key) internal virtual returns (Chain memory) {
         initialize();
-        return chains[name];
+        return chains[key];
     }
 
     function getChain(uint256 chainId) internal virtual returns (Chain memory) {
@@ -38,8 +41,6 @@ abstract contract StdChains {
         chains[key] = Chain(name, chainId, rpcUrl);
         idToKey[chainId] = key;
     }
-
-    bool private initialized;
 
     function initialize() private {
         if (initialized) return;
@@ -65,7 +66,7 @@ abstract contract StdChains {
         // Loop over RPC URLs in the config file to replace the default RPC URLs
         Vm.Rpc[] memory rpcs = vm.rpcUrlStructs();
         for (uint256 i = 0; i < rpcs.length; i++) {
-            chains[rpcs[i].name].rpcUrl = rpcs[i].url;
+            chains[rpcs[i].key].rpcUrl = rpcs[i].url;
         }
 
         initialized = true;

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -9,7 +9,7 @@ abstract contract StdChains {
     VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     struct Chain {
-        // The chain name, using underscores as the separator to match `foundry.toml` conventions.
+        // The chain name.
         string name;
         // The chain's Chain ID.
         uint256 chainId;
@@ -22,14 +22,21 @@ abstract contract StdChains {
 
     // Maps from a chain's name (matching what's in the `foundry.toml` file) to chain data.
     mapping(string => Chain) private chains;
+    mapping(uint256 => string) private idToKey;
 
     function getChain(string memory name) internal virtual returns (Chain memory) {
         initialize();
         return chains[name];
     }
 
-    function setChain(string memory name, uint256 chainId, string memory rpcUrl) internal virtual {
-        chains[name] = Chain(name, chainId, rpcUrl);
+    function getChain(uint256 chainId) internal virtual returns (Chain memory) {
+        initialize();
+        return chains[idToKey[chainId]];
+    }
+
+    function setChain(string memory key, string memory name, uint256 chainId, string memory rpcUrl) internal virtual {
+        chains[key] = Chain(name, chainId, rpcUrl);
+        idToKey[chainId] = key;
     }
 
     bool private initialized;
@@ -37,23 +44,23 @@ abstract contract StdChains {
     function initialize() private {
         if (initialized) return;
 
-        chains["anvil"] = Chain("Anvil", 31337, "http://127.0.0.1:8545");
-        chains["hardhat"] = Chain("Hardhat", 31337, "http://127.0.0.1:8545");
-        chains["mainnet"] = Chain("Mainnet", 1, "https://mainnet.infura.io/v3/6770454bc6ea42c58aac12978531b93f");
-        chains["goerli"] = Chain("Goerli", 5, "https://goerli.infura.io/v3/6770454bc6ea42c58aac12978531b93f");
-        chains["sepolia"] = Chain("Sepolia", 11155111, "https://rpc.sepolia.dev");
-        chains["optimism"] = Chain("Optimism", 10, "https://mainnet.optimism.io");
-        chains["optimism_goerli"] = Chain("Optimism Goerli", 420, "https://goerli.optimism.io");
-        chains["arbitrum_one"] = Chain("Arbitrum One", 42161, "https://arb1.arbitrum.io/rpc");
-        chains["arbitrum_one_goerli"] = Chain("Arbitrum One Goerli", 421613, "https://goerli-rollup.arbitrum.io/rpc");
-        chains["arbitrum_nova"] = Chain("Arbitrum Nova", 42170, "https://nova.arbitrum.io/rpc");
-        chains["polygon"] = Chain("Polygon", 137, "https://polygon-rpc.com");
-        chains["polygon_mumbai"] = Chain("Polygon Mumbai", 80001, "https://rpc-mumbai.matic.today");
-        chains["avalanche"] = Chain("Avalanche", 43114, "https://api.avax.network/ext/bc/C/rpc");
-        chains["avalanche_fuji"] = Chain("Avalanche Fuji", 43113, "https://api.avax-test.network/ext/bc/C/rpc");
-        chains["bnb_smart_chain"] = Chain("BNB Smart Chain", 56, "https://bsc-dataseed1.binance.org");
-        chains["bnb_smart_chain_testnet"] = Chain("BNB Smart Chain Testnet", 97, "https://data-seed-prebsc-1-s1.binance.org:8545");// forgefmt: disable-line
-        chains["gnosis_chain"] = Chain("Gnosis Chain", 100, "https://rpc.gnosischain.com");
+        setChain("anvil", "Localhost", 31337, "http://127.0.0.1:8545");
+        setChain("hardhat", "Localhost", 31337, "http://127.0.0.1:8545");
+        setChain("mainnet", "Mainnet", 1, "https://mainnet.infura.io/v3/6770454bc6ea42c58aac12978531b93f");
+        setChain("goerli", "Goerli", 5, "https://goerli.infura.io/v3/6770454bc6ea42c58aac12978531b93f");
+        setChain("sepolia", "Sepolia", 11155111, "https://rpc.sepolia.dev");
+        setChain("optimism", "Optimism", 10, "https://mainnet.optimism.io");
+        setChain("optimism_goerli", "Optimism Goerli", 420, "https://goerli.optimism.io");
+        setChain("arbitrum_one", "Arbitrum One", 42161, "https://arb1.arbitrum.io/rpc");
+        setChain("arbitrum_one_goerli", "Arbitrum One Goerli", 421613, "https://goerli-rollup.arbitrum.io/rpc");
+        setChain("arbitrum_nova", "Arbitrum Nova", 42170, "https://nova.arbitrum.io/rpc");
+        setChain("polygon", "Polygon", 137, "https://polygon-rpc.com");
+        setChain("polygon_mumbai", "Polygon Mumbai", 80001, "https://rpc-mumbai.matic.today");
+        setChain("avalanche", "Avalanche", 43114, "https://api.avax.network/ext/bc/C/rpc");
+        setChain("avalanche_fuji", "Avalanche Fuji", 43113, "https://api.avax-test.network/ext/bc/C/rpc");
+        setChain("bnb_smart_chain", "BNB Smart Chain", 56, "https://bsc-dataseed1.binance.org");
+        setChain("bnb_smart_chain_testnet", "BNB Smart Chain Testnet", 97, "https://data-seed-prebsc-1-s1.binance.org:8545");// forgefmt: disable-line
+        setChain("gnosis_chain", "Gnosis Chain", 100, "https://rpc.gnosischain.com");
 
         // Loop over RPC URLs in the config file to replace the default RPC URLs
         Vm.Rpc[] memory rpcs = vm.rpcUrlStructs();

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.2 <0.9.0;
+
+import "./Vm.sol";
+
+abstract contract StdChains {
+    VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    struct Chain {
+        // The chain name, using underscores as the separator to match `foundry.toml` conventions.
+        string name;
+        // The chain's Chain ID.
+        uint256 chainId;
+        // A default RPC endpoint for this chain.
+        // NOTE: This default RPC URL is included for convenience to facilitate quick tests and
+        // experimentation. Do not use this RPC URL for production test suites, CI, or other heavy
+        // usage as you will be throttled and this is a disservice to others who need this endpoint.
+        string rpcUrl;
+    }
+
+    // Maps from a chain's name (matching what's in the `foundry.toml` file) to chain data.
+    mapping(string => Chain) private chains;
+
+    function getChain(string memory name) internal virtual returns (Chain memory) {
+        initialize();
+        return chains[name];
+    }
+
+    function setChain(string memory name, uint256 chainId, string memory rpcUrl) internal virtual {
+        chains[name] = Chain(name, chainId, rpcUrl);
+    }
+
+    bool private initialized;
+
+    function initialize() private {
+        if (initialized) return;
+
+        chains["anvil"] = Chain("Anvil", 31337, "http://127.0.0.1:8545");
+        chains["hardhat"] = Chain("Hardhat", 31337, "http://127.0.0.1:8545");
+        chains["mainnet"] = Chain("Mainnet", 1, "https://mainnet.infura.io/v3/6770454bc6ea42c58aac12978531b93f");
+        chains["goerli"] = Chain("Goerli", 5, "https://goerli.infura.io/v3/6770454bc6ea42c58aac12978531b93f");
+        chains["sepolia"] = Chain("Sepolia", 11155111, "https://rpc.sepolia.dev");
+        chains["optimism"] = Chain("Optimism", 10, "https://mainnet.optimism.io");
+        chains["optimism_goerli"] = Chain("Optimism Goerli", 420, "https://goerli.optimism.io");
+        chains["arbitrum_one"] = Chain("Arbitrum One", 42161, "https://arb1.arbitrum.io/rpc");
+        chains["arbitrum_one_goerli"] = Chain("Arbitrum One Goerli", 421613, "https://goerli-rollup.arbitrum.io/rpc");
+        chains["arbitrum_nova"] = Chain("Arbitrum Nova", 42170, "https://nova.arbitrum.io/rpc");
+        chains["polygon"] = Chain("Polygon", 137, "https://polygon-rpc.com");
+        chains["polygon_mumbai"] = Chain("Polygon Mumbai", 80001, "https://rpc-mumbai.matic.today");
+        chains["avalanche"] = Chain("Avalanche", 43114, "https://api.avax.network/ext/bc/C/rpc");
+        chains["avalanche_fuji"] = Chain("Avalanche Fuji", 43113, "https://api.avax-test.network/ext/bc/C/rpc");
+        chains["bnb_smart_chain"] = Chain("BNB Smart Chain", 56, "https://bsc-dataseed1.binance.org");
+        chains["bnb_smart_chain_testnet"] = Chain("BNB Smart Chain Testnet", 97, "https://data-seed-prebsc-1-s1.binance.org:8545");// forgefmt: disable-line
+        chains["gnosis_chain"] = Chain("Gnosis Chain", 100, "https://rpc.gnosischain.com");
+
+        // Loop over RPC URLs in the config file to replace the default RPC URLs
+        Vm.Rpc[] memory rpcs = vm.rpcUrlStructs();
+        for (uint256 i = 0; i < rpcs.length; i++) {
+            chains[rpcs[i].name].rpcUrl = rpcs[i].url;
+        }
+
+        initialized = true;
+    }
+}

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.6.2 <0.9.0;
 
+pragma experimental ABIEncoderV2;
+
 import "./Vm.sol";
 
 abstract contract StdChains {

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -47,7 +47,7 @@ abstract contract StdChains {
                     vm.toString(chainId),
                     " already used by \"",
                     idToKey[chainId],
-                    "\""
+                    "\"."
                 )
             )
         );

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -38,6 +38,23 @@ abstract contract StdChains {
     }
 
     function setChain(string memory key, string memory name, uint256 chainId, string memory rpcUrl) internal virtual {
+        require(
+            keccak256(bytes(idToKey[chainId])) == keccak256(bytes(""))
+                || keccak256(bytes(idToKey[chainId])) == keccak256(bytes(key)),
+            string(
+                abi.encodePacked(
+                    "StdChains setChain(string,string,uint256,string): Chain ID ",
+                    vm.toString(chainId),
+                    " already used by \"",
+                    idToKey[chainId],
+                    "\""
+                )
+            )
+        );
+
+        uint256 oldChainId = chains[key].chainId;
+        delete idToKey[oldChainId];
+
         chains[key] = Chain(name, chainId, rpcUrl);
         idToKey[chainId] = key;
     }
@@ -45,8 +62,7 @@ abstract contract StdChains {
     function initialize() private {
         if (initialized) return;
 
-        setChain("anvil", "Localhost", 31337, "http://127.0.0.1:8545");
-        setChain("hardhat", "Localhost", 31337, "http://127.0.0.1:8545");
+        setChain("anvil", "Anvil", 31337, "http://127.0.0.1:8545");
         setChain("mainnet", "Mainnet", 1, "https://mainnet.infura.io/v3/6770454bc6ea42c58aac12978531b93f");
         setChain("goerli", "Goerli", 5, "https://goerli.infura.io/v3/6770454bc6ea42c58aac12978531b93f");
         setChain("sepolia", "Sepolia", 11155111, "https://rpc.sepolia.dev");

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -4,8 +4,8 @@ pragma solidity >=0.6.2 <0.9.0;
 import {CommonBase} from "./Common.sol";
 import "ds-test/test.sol";
 // forgefmt: disable-next-line
-import {console, console2, StdAssertions, StdCheats, stdError, stdJson, stdMath, StdStorage, stdStorage, StdUtils, Vm} from "./Components.sol";
+import {console, console2, StdAssertions, StdChains, StdCheats, stdError, stdJson, stdMath, StdStorage, stdStorage, StdUtils, Vm} from "./Components.sol";
 
 abstract contract TestBase is CommonBase {}
 
-abstract contract Test is TestBase, DSTest, StdAssertions, StdCheats, StdUtils {}
+abstract contract Test is TestBase, DSTest, StdAssertions, StdChains, StdCheats, StdUtils {}

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -17,7 +17,7 @@ interface VmSafe {
     }
 
     struct Rpc {
-        string name;
+        string key;
         string url;
     }
 

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -6,12 +6,12 @@ import "../src/Test.sol";
 contract StdChainsTest is Test {
     function testChainRpcInitialization() public {
         // RPCs specified in `foundry.toml` should be updated.
-        assertEq(getChain("mainnet").rpcUrl, "https://mainnet.infura.io/v3/7a8769b798b642f6933f2ed52042bd70");
+        assertEq(getChain(1).rpcUrl, "https://mainnet.infura.io/v3/7a8769b798b642f6933f2ed52042bd70");
         assertEq(getChain("optimism_goerli").rpcUrl, "https://goerli.optimism.io/");
         assertEq(getChain("arbitrum_one_goerli").rpcUrl, "https://goerli-rollup.arbitrum.io/rpc/");
 
         // Other RPCs should remain unchanged.
-        assertEq(getChain("anvil").rpcUrl, "http://127.0.0.1:8545");
+        assertEq(getChain(31337).rpcUrl, "http://127.0.0.1:8545");
         assertEq(getChain("hardhat").rpcUrl, "http://127.0.0.1:8545");
         assertEq(getChain("sepolia").rpcUrl, "https://rpc.sepolia.dev");
     }
@@ -26,10 +26,14 @@ contract StdChainsTest is Test {
     }
 
     function testSetChain() public {
-        setChain({name: "custom_chain", chainId: 123456789, rpcUrl: "https://custom.chain/"});
+        setChain({key: "custom_chain", name: "Custom Chain", chainId: 123456789, rpcUrl: "https://custom.chain/"});
         Chain memory customChain = getChain("custom_chain");
-        assertEq(customChain.name, "custom_chain");
+        assertEq(customChain.name, "Custom Chain");
         assertEq(customChain.chainId, 123456789);
         assertEq(customChain.rpcUrl, "https://custom.chain/");
+        Chain memory chainById = getChain(123456789);
+        assertEq(chainById.name, customChain.name);
+        assertEq(chainById.chainId, customChain.chainId);
+        assertEq(chainById.rpcUrl, customChain.rpcUrl);
     }
 }

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -28,7 +28,7 @@ contract StdChainsTest is Test {
         setChain({key: "custom_chain", name: "Custom Chain", chainId: 123456789, rpcUrl: "https://custom.chain/"});
 
         vm.expectRevert(
-            'StdChains setChain(string,string,uint256,string): Chain ID 123456789 already used by "custom_chain"'
+            'StdChains setChain(string,string,uint256,string): Chain ID 123456789 already used by "custom_chain".'
         );
 
         setChain({key: "another_custom_chain", name: "", chainId: 123456789, rpcUrl: ""});

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+
+import "../src/Test.sol";
+
+contract StdChainsTest is Test {
+    function testChainRpcInitialization() public {
+        // RPCs specified in `foundry.toml` should be updated.
+        assertEq(getChain("mainnet").rpcUrl, "https://mainnet.infura.io/v3/7a8769b798b642f6933f2ed52042bd70");
+        assertEq(getChain("optimism_goerli").rpcUrl, "https://goerli.optimism.io/");
+        assertEq(getChain("arbitrum_one_goerli").rpcUrl, "https://goerli-rollup.arbitrum.io/rpc/");
+
+        // Other RPCs should remain unchanged.
+        assertEq(getChain("anvil").rpcUrl, "http://127.0.0.1:8545");
+        assertEq(getChain("hardhat").rpcUrl, "http://127.0.0.1:8545");
+        assertEq(getChain("sepolia").rpcUrl, "https://rpc.sepolia.dev");
+    }
+
+    // Ensure we can connect to the default RPC URL for each chain.
+    function testRpcs() public {
+        (string[2][] memory rpcs) = vm.rpcUrls();
+        for (uint256 i = 0; i < rpcs.length; i++) {
+            ( /* string memory name */ , string memory rpcUrl) = (rpcs[i][0], rpcs[i][1]);
+            vm.createSelectFork(rpcUrl);
+        }
+    }
+
+    function testSetChain() public {
+        setChain({name: "custom_chain", chainId: 123456789, rpcUrl: "https://custom.chain/"});
+        Chain memory customChain = getChain("custom_chain");
+        assertEq(customChain.name, "custom_chain");
+        assertEq(customChain.chainId, 123456789);
+        assertEq(customChain.rpcUrl, "https://custom.chain/");
+    }
+}

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -227,29 +227,8 @@ contract StdCheatsTest is Test {
         return number;
     }
 
-    function testChainRpcInitialization() public {
-        // RPCs specified in `foundry.toml` should be updated.
-        assertEq(stdChains["mainnet"].rpcUrl, "https://mainnet.infura.io/v3/7a8769b798b642f6933f2ed52042bd70");
-        assertEq(stdChains["optimism_goerli"].rpcUrl, "https://goerli.optimism.io/");
-        assertEq(stdChains["arbitrum_one_goerli"].rpcUrl, "https://goerli-rollup.arbitrum.io/rpc/");
-
-        // Other RPCs should remain unchanged.
-        assertEq(stdChains["anvil"].rpcUrl, "http://127.0.0.1:8545");
-        assertEq(stdChains["hardhat"].rpcUrl, "http://127.0.0.1:8545");
-        assertEq(stdChains["sepolia"].rpcUrl, "https://rpc.sepolia.dev");
-    }
-
-    // Ensure we can connect to the default RPC URL for each chain.
-    function testRpcs() public {
-        (string[2][] memory rpcs) = vm.rpcUrls();
-        for (uint256 i = 0; i < rpcs.length; i++) {
-            ( /* string memory name */ , string memory rpcUrl) = (rpcs[i][0], rpcs[i][1]);
-            vm.createSelectFork(rpcUrl);
-        }
-    }
-
     function testAssumeNoPrecompiles(address addr) external {
-        assumeNoPrecompiles(addr, stdChains["optimism_goerli"].chainId);
+        assumeNoPrecompiles(addr, getChain("optimism_goerli").chainId);
         assertTrue(
             addr < address(1) || (addr > address(9) && addr < address(0x4200000000000000000000000000000000000000))
                 || addr > address(0x4200000000000000000000000000000000000800)


### PR DESCRIPTION
## Motivation

Resolve #225, #232

## Solution

Lazy-initialize chains.

Tested on [Uniswap / permit2](https://github.com/Uniswap/permit2). Takes the same time to compile as the pre-V1 Forge-Std version used there.
@marktoda, could you please test the changes on your end?

### What's new

- Add `StdChains` Component
- **BREAKING:** Add `getChain` and `setChain` functions
- **BREAKING:** `Vm.Rpc.name` -> `Vm.Rpc.key`

@mds1, please let me know what you think about the design decisions.