### PR TITLE
feature: isFork and skip modifiers in StdCheats

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -569,4 +569,22 @@ abstract contract StdCheats is StdCheatsSafe {
             stdstore.target(token).sig(0x18160ddd).checked_write(totSup);
         }
     }
+
+    function isFork() internal virtual returns (bool status) {
+        try vm.activeFork() {
+            status = true;
+        } catch (bytes memory) {}
+    }
+
+    modifier skipForking() {
+        if (!isFork()) {
+            _;
+        }
+    }
+
+    modifier skipNonForking() {
+        if (isFork()) {
+            _;
+        }
+    }
 }

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -576,13 +576,13 @@ abstract contract StdCheats is StdCheatsSafe {
         } catch (bytes memory) {}
     }
 
-    modifier skipForking() {
+    modifier skipWhenForking() {
         if (!isFork()) {
             _;
         }
     }
 
-    modifier skipNonForking() {
+    modifier skipWhenNotForking() {
         if (isFork()) {
             _;
         }


### PR DESCRIPTION
## Motivation

Allow tests to easily change behavior (or be skipped) when running in forking or non-forking mode

## Solution

Adds convenience methods to `StdCheats`:

- `isFork` - returns the current forking status
- `skipNonForking` - run only when forked 
- `skipForking` - run only when not forked
