### PR TITLE
feat: add getEnv vm.env helpers with default fallbacks

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -466,6 +466,146 @@ abstract contract StdCheatsSafe {
         who = vm.rememberKey(privateKey);
     }
 
+    function getEnvBool(string memory name, bool _default) internal virtual returns (bool) {
+        try vm.envBool(name) returns (bool _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvUint(string memory name, uint256 _default) internal virtual returns (uint256) {
+        try vm.envUint(name) returns (uint256 _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvInt(string memory name, int256 _default) internal virtual returns (int256) {
+        try vm.envInt(name) returns (int256 _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvAddress(string memory name, address _default) internal virtual returns (address) {
+        try vm.envAddress(name) returns (address _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvBytes32(string memory name, bytes32 _default) internal virtual returns (bytes32) {
+        try vm.envBytes32(name) returns (bytes32 _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvString(string memory name, string memory _default) internal virtual returns (string memory) {
+        try vm.envString(name) returns (string memory _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvBytes(string memory name, bytes memory _default) internal virtual returns (bytes memory) {
+        try vm.envBytes(name) returns (bytes memory _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvBool(string memory name, string memory delim, bool[] memory _default)
+        internal
+        virtual
+        returns (bool[] memory)
+    {
+        try vm.envBool(name, delim) returns (bool[] memory _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvUint(string memory name, string memory delim, uint256[] memory _default)
+        internal
+        virtual
+        returns (uint256[] memory)
+    {
+        try vm.envUint(name, delim) returns (uint256[] memory _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvInt(string memory name, string memory delim, int256[] memory _default)
+        internal
+        virtual
+        returns (int256[] memory)
+    {
+        try vm.envInt(name, delim) returns (int256[] memory _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvAddress(string memory name, string memory delim, address[] memory _default)
+        internal
+        virtual
+        returns (address[] memory)
+    {
+        try vm.envAddress(name, delim) returns (address[] memory _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvBytes32(string memory name, string memory delim, bytes32[] memory _default)
+        internal
+        virtual
+        returns (bytes32[] memory)
+    {
+        try vm.envBytes32(name, delim) returns (bytes32[] memory _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvString(string memory name, string memory delim, string[] memory _default)
+        internal
+        virtual
+        returns (string[] memory)
+    {
+        try vm.envString(name, delim) returns (string[] memory _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
+    function getEnvBytes(string memory name, string memory delim, bytes[] memory _default)
+        internal
+        virtual
+        returns (bytes[] memory)
+    {
+        try vm.envBytes(name, delim) returns (bytes[] memory _returned) {
+            return _returned;
+        } catch (bytes memory) {
+            return _default;
+        }
+    }
+
     function _bytesToUint(bytes memory b) private pure returns (uint256) {
         require(b.length <= 32, "StdCheats _bytesToUint(bytes): Bytes length exceeds 32.");
         return abi.decode(abi.encodePacked(new bytes(32 - b.length), b), (uint256));

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -135,6 +135,112 @@ contract StdCheatsTest is Test {
         this.deployCodeHelper("StdCheats.t.sol:RevertingContract");
     }
 
+    function testGetEnvBool() public {
+        assertFalse(getEnvBool(".invalid.name", false));
+        assertTrue(getEnvBool(".invalid.name", true));
+    }
+
+    function testGetEnvUint() public {
+        assertEq(getEnvUint(".invalid.name", 1337), 1337);
+    }
+
+    function testGetEnvInt() public {
+        assertEq(getEnvInt(".invalid.name", -1337), -1337);
+    }
+
+    function testGetEnvAddress() public {
+        assertEq(getEnvAddress(".invalid.name", address(1337)), address(1337));
+    }
+
+    function testGetEnvBytes32() public {
+        assertEq(getEnvBytes32(".invalid.name", bytes32(bytes2(0x1337))), bytes32(bytes2(0x1337)));
+    }
+
+    function testGetEnvString() public {
+        assertEq(getEnvString(".invalid.name", "1337"), "1337");
+    }
+
+    function testGetEnvBytes() public {
+        assertEq(getEnvBytes(".invalid.name", "1337"), "1337");
+    }
+
+    function testGetEnvBoolArray() public {
+        bool[] memory expected = new bool[](2);
+        expected[0] = true;
+        expected[1] = false;
+        bool[] memory result = getEnvBool(".invalid.name", ",", expected);
+        assertEq(result.length, 2);
+        for (uint256 i = 0; i < result.length; i++) {
+            assertEq(result[i], expected[i]);
+        }
+    }
+
+    function testGetEnvUintArray() public {
+        uint256[] memory expected = new uint[](2);
+        expected[0] = 1;
+        expected[1] = 2;
+        uint256[] memory result = getEnvUint(".invalid.name", ",", expected);
+        assertEq(result.length, 2);
+        for (uint256 i = 0; i < result.length; i++) {
+            assertEq(result[i], expected[i]);
+        }
+    }
+
+    function testGetEnvIntArray() public {
+        int256[] memory expected = new int[](2);
+        expected[0] = 1;
+        expected[1] = -2;
+        int256[] memory result = getEnvInt(".invalid.name", ",", expected);
+        assertEq(result.length, 2);
+        for (uint256 i = 0; i < result.length; i++) {
+            assertEq(result[i], expected[i]);
+        }
+    }
+
+    function testGetEnvAddressArray() public {
+        address[] memory expected = new address[](2);
+        expected[0] = address(1);
+        expected[1] = address(2);
+        address[] memory result = getEnvAddress(".invalid.name", ",", expected);
+        assertEq(result.length, 2);
+        for (uint256 i = 0; i < result.length; i++) {
+            assertEq(result[i], expected[i]);
+        }
+    }
+
+    function testGetEnvBytes32Array() public {
+        bytes32[] memory expected = new bytes32[](2);
+        expected[0] = bytes32(bytes2(0x1337));
+        expected[1] = bytes32(bytes2(0x1338));
+        bytes32[] memory result = getEnvBytes32(".invalid.name", ",", expected);
+        assertEq(result.length, 2);
+        for (uint256 i = 0; i < result.length; i++) {
+            assertEq(result[i], expected[i]);
+        }
+    }
+
+    function testGetEnvStringArray() public {
+        string[] memory expected = new string[](2);
+        expected[0] = "1337";
+        expected[1] = "1338";
+        string[] memory result = getEnvString(".invalid.name", ",", expected);
+        assertEq(result.length, 2);
+        for (uint256 i = 0; i < result.length; i++) {
+            assertEq(result[i], expected[i]);
+        }
+    }
+
+    function testGetEnvBytesArray() public {
+        bytes[] memory expected = new bytes[](2);
+        expected[0] = "1337";
+        expected[1] = "1338";
+        bytes[] memory result = getEnvBytes(".invalid.name", ",", expected);
+        assertEq(result.length, 2);
+        for (uint256 i = 0; i < result.length; i++) {
+            assertEq(result[i], expected[i]);
+        }
+    }
+
     function getCode(address who) internal view returns (bytes memory o_code) {
         /// @solidity memory-safe-assembly
         assembly {


### PR DESCRIPTION
Added a suite of `getEnvX` functions to `stdCheats` – let me know if this is not a good place for them.

They're potentially useful for publishing repos with configurable tests or scripts (where someone who initially pulls may not have an `.env` set up), or where adding secrets to a repo doesn't necessarily make sense. 