### PR TITLE
fix: remove `StdChains` from `StdCheatsSafe`

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -3,11 +3,10 @@ pragma solidity >=0.6.2 <0.9.0;
 
 pragma experimental ABIEncoderV2;
 
-import "./StdChains.sol";
 import "./StdStorage.sol";
 import "./Vm.sol";
 
-abstract contract StdCheatsSafe is StdChains {
+abstract contract StdCheatsSafe {
     VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     // Data structures to parse Transaction objects from the broadcast artifact
@@ -204,13 +203,13 @@ abstract contract StdCheatsSafe is StdChains {
         vm.assume(addr < address(0x1) || addr > address(0x9));
 
         // forgefmt: disable-start
-        if (chainId == getChain("optimism").chainId || chainId == getChain("optimism_goerli").chainId) {
+        if (chainId == 10 || chainId == 420) {
             // https://github.com/ethereum-optimism/optimism/blob/eaa371a0184b56b7ca6d9eb9cb0a2b78b2ccd864/op-bindings/predeploys/addresses.go#L6-L21
             vm.assume(addr < address(0x4200000000000000000000000000000000000000) || addr > address(0x4200000000000000000000000000000000000800));
-        } else if (chainId == getChain("arbitrum_one").chainId || chainId == getChain("arbitrum_one_goerli").chainId) {
+        } else if (chainId == 42161 || chainId == 421613) {
             // https://developer.arbitrum.io/useful-addresses#arbitrum-precompiles-l2-same-on-all-arb-chains
             vm.assume(addr < address(0x0000000000000000000000000000000000000064) || addr > address(0x0000000000000000000000000000000000000068));
-        } else if (chainId == getChain("avalanche").chainId || chainId == getChain("avalanche_fuji").chainId) {
+        } else if (chainId == 43114 || chainId == 43113) {
             // https://github.com/ava-labs/subnet-evm/blob/47c03fd007ecaa6de2c52ea081596e0a88401f58/precompile/params.go#L18-L59
             vm.assume(addr < address(0x0100000000000000000000000000000000000000) || addr > address(0x01000000000000000000000000000000000000ff));
             vm.assume(addr < address(0x0200000000000000000000000000000000000000) || addr > address(0x02000000000000000000000000000000000000FF));


### PR DESCRIPTION
## Motivation

Do not include `StdChains` in `StdCheatsSafe` (and `StdCheats`), because it breaks modularity.

## Solution

Hardcode the chain IDs in `assumeNoPrecompile` instead of calling `getChain`.

This is safe because chain IDs will rarely (if ever) change.