### PR TITLE
Name arguments in Vm.sol

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -68,13 +68,27 @@ interface VmSafe {
     function envOr(string calldata name, string calldata defaultValue) external returns (string memory value);
     function envOr(string calldata name, bytes calldata defaultValue) external returns (bytes memory value);
     // Read environment variables as arrays with default value, (name, value[]) => (value[])
-    function envOr(string calldata name, string calldata, bool[] calldata defaultValue) external returns (bool[] memory value);
-    function envOr(string calldata name, string calldata, uint256[] calldata defaultValue) external returns (uint256[] memory value);
-    function envOr(string calldata name, string calldata, int256[] calldata defaultValue) external returns (int256[] memory value);
-    function envOr(string calldata name, string calldata, address[] calldata defaultValue) external returns (address[] memory value);
-    function envOr(string calldata name, string calldata, bytes32[] calldata defaultValue) external returns (bytes32[] memory value);
-    function envOr(string calldata name, string calldata, string[] calldata defaultValue) external returns (string[] memory value);
-    function envOr(string calldata name, string calldata, bytes[] calldata defaultValue) external returns (bytes[] memory value);
+    function envOr(string calldata name, string calldata, bool[] calldata defaultValue)
+        external
+        returns (bool[] memory value);
+    function envOr(string calldata name, string calldata, uint256[] calldata defaultValue)
+        external
+        returns (uint256[] memory value);
+    function envOr(string calldata name, string calldata, int256[] calldata defaultValue)
+        external
+        returns (int256[] memory value);
+    function envOr(string calldata name, string calldata, address[] calldata defaultValue)
+        external
+        returns (address[] memory value);
+    function envOr(string calldata name, string calldata, bytes32[] calldata defaultValue)
+        external
+        returns (bytes32[] memory value);
+    function envOr(string calldata name, string calldata, string[] calldata defaultValue)
+        external
+        returns (string[] memory value);
+    function envOr(string calldata name, string calldata, bytes[] calldata defaultValue)
+        external
+        returns (bytes[] memory value);
     // Records all storage reads and writes
     function record() external;
     // Gets all accessed reads and write slot from a recording session, for a given address
@@ -322,7 +336,7 @@ interface Vm is VmSafe {
     // Revert the state of the EVM to a previous snapshot
     // Takes the snapshot id to revert to.
     // This deletes the snapshot and all snapshots taken after the given snapshot id.
-    function revertTo(uint256 snapshotId) external returns (bool result);
+    function revertTo(uint256 snapshotId) external returns (bool success);
     // Creates a new fork with the given endpoint and block and returns the identifier of the fork
     function createFork(string calldata endpoint, uint256 blockNumber) external returns (uint256 forkId);
     // Creates a new fork with the given endpoint and the _latest_ block and returns the identifier of the fork

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -4,8 +4,8 @@ pragma solidity >=0.6.2 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 // Cheatcodes are marked as view/pure/none using the following rules:
-// 0. A call's observable behaviour includes its return value, logs, reverts and state writes.
-// 1. If you can influence a later call's observable behaviour, you're neither `view` nor `pure` (you are modifying some state be it the EVM, interpreter, filesystem, etc),
+// 0. A call's observable behaviour includes its return value, logs, reverts and state writes,
+// 1. If you can influence a later call's observable behaviour, you're neither `view` nor `pure (you are modifying some state be it the EVM, interpreter, filesystem, etc),
 // 2. Otherwise if you can be influenced by an earlier call, or if reading some state, you're `view`,
 // 3. Otherwise you're `pure`.
 
@@ -32,57 +32,57 @@ interface VmSafe {
     }
 
     // Loads a storage slot from an address (who, slot)
-    function load(address, bytes32) external view returns (bytes32);
+    function load(address who, bytes32 slot) external view returns (bytes32);
     // Signs data, (privateKey, digest) => (v, r, s)
-    function sign(uint256, bytes32) external pure returns (uint8, bytes32, bytes32);
+    function sign(uint256 privateKey, bytes32 digest) external pure returns (uint8, bytes32, bytes32);
     // Gets the address for a given private key, (privateKey) => (address)
-    function addr(uint256) external pure returns (address);
+    function addr(uint256 privateKey) external pure returns (address);
     // Gets the nonce of an account
-    function getNonce(address) external view returns (uint64);
+    function getNonce(address account) external view returns (uint64);
     // Performs a foreign function call via the terminal, (stringInputs) => (result)
-    function ffi(string[] calldata) external returns (bytes memory);
+    function ffi(string[] calldata stringInputs) external returns (bytes memory);
     // Sets environment variables, (name, value)
-    function setEnv(string calldata, string calldata) external;
+    function setEnv(string calldata name, string calldata value) external;
     // Reads environment variables, (name) => (value)
-    function envBool(string calldata) external view returns (bool);
-    function envUint(string calldata) external view returns (uint256);
-    function envInt(string calldata) external view returns (int256);
-    function envAddress(string calldata) external view returns (address);
-    function envBytes32(string calldata) external view returns (bytes32);
-    function envString(string calldata) external view returns (string memory);
-    function envBytes(string calldata) external view returns (bytes memory);
-    // Reads environment variables as arrays, (name, delim) => (value[])
-    function envBool(string calldata, string calldata) external view returns (bool[] memory);
-    function envUint(string calldata, string calldata) external view returns (uint256[] memory);
-    function envInt(string calldata, string calldata) external view returns (int256[] memory);
-    function envAddress(string calldata, string calldata) external view returns (address[] memory);
-    function envBytes32(string calldata, string calldata) external view returns (bytes32[] memory);
-    function envString(string calldata, string calldata) external view returns (string[] memory);
-    function envBytes(string calldata, string calldata) external view returns (bytes[] memory);
-    // Read environment variables with default value, (name, value) => (value)
-    function envOr(string calldata, bool) external returns (bool);
-    function envOr(string calldata, uint256) external returns (uint256);
-    function envOr(string calldata, int256) external returns (int256);
-    function envOr(string calldata, address) external returns (address);
-    function envOr(string calldata, bytes32) external returns (bytes32);
-    function envOr(string calldata, string calldata) external returns (string memory);
-    function envOr(string calldata, bytes calldata) external returns (bytes memory);
+    function envBool(string calldata name) external view returns (bool);
+    function envUint(string calldata name) external view returns (uint256);
+    function envInt(string calldata name) external view returns (int256);
+    function envAddress(string calldata name) external view returns (address);
+    function envBytes32(string calldata name) external view returns (bytes32);
+    function envString(string calldata name) external view returns (string memory);
+    function envBytes(string calldata name) external view returns (bytes memory);
+    // Reads environment variables as arrays
+    function envBool(string calldata name, string calldata delim) external view returns (bool[] memory);
+    function envUint(string calldata name, string calldata delim) external view returns (uint256[] memory);
+    function envInt(string calldata name, string calldata delim) external view returns (int256[] memory);
+    function envAddress(string calldata name, string calldata delim) external view returns (address[] memory);
+    function envBytes32(string calldata name, string calldata delim) external view returns (bytes32[] memory);
+    function envString(string calldata name, string calldata delim) external view returns (string[] memory);
+    function envBytes(string calldata name, string calldata delim) external view returns (bytes[] memory);
+    // Read environment variables with default value
+    function envOr(string calldata name, bool defaultValue) external returns (bool value);
+    function envOr(string calldata name, uint256 defaultValue) external returns (uint256 value);
+    function envOr(string calldata name, int256 defaultValue) external returns (int256 value);
+    function envOr(string calldata name, address defaultValue) external returns (address value);
+    function envOr(string calldata name, bytes32 defaultValue) external returns (bytes32 value);
+    function envOr(string calldata name, string calldata defaultValue) external returns (string memory value);
+    function envOr(string calldata name, bytes calldata defaultValue) external returns (bytes memory value);
     // Read environment variables as arrays with default value, (name, value[]) => (value[])
-    function envOr(string calldata, string calldata, bool[] calldata) external returns (bool[] memory);
-    function envOr(string calldata, string calldata, uint256[] calldata) external returns (uint256[] memory);
-    function envOr(string calldata, string calldata, int256[] calldata) external returns (int256[] memory);
-    function envOr(string calldata, string calldata, address[] calldata) external returns (address[] memory);
-    function envOr(string calldata, string calldata, bytes32[] calldata) external returns (bytes32[] memory);
-    function envOr(string calldata, string calldata, string[] calldata) external returns (string[] memory);
-    function envOr(string calldata, string calldata, bytes[] calldata) external returns (bytes[] memory);
+    function envOr(string calldata name, string calldata, bool[] calldata defaultValue) external returns (bool[] memory value);
+    function envOr(string calldata name, string calldata, uint256[] calldata defaultValue) external returns (uint256[] memory value);
+    function envOr(string calldata name, string calldata, int256[] calldata defaultValue) external returns (int256[] memory value);
+    function envOr(string calldata name, string calldata, address[] calldata defaultValue) external returns (address[] memory value);
+    function envOr(string calldata name, string calldata, bytes32[] calldata defaultValue) external returns (bytes32[] memory value);
+    function envOr(string calldata name, string calldata, string[] calldata defaultValue) external returns (string[] memory value);
+    function envOr(string calldata name, string calldata, bytes[] calldata defaultValue) external returns (bytes[] memory value);
     // Records all storage reads and writes
     function record() external;
     // Gets all accessed reads and write slot from a recording session, for a given address
-    function accesses(address) external returns (bytes32[] memory reads, bytes32[] memory writes);
+    function accesses(address who) external returns (bytes32[] memory reads, bytes32[] memory writes);
     // Gets the _creation_ bytecode from an artifact file. Takes in the relative path to the json file
-    function getCode(string calldata) external view returns (bytes memory);
+    function getCode(string calldata path) external view returns (bytes memory);
     // Gets the _deployed_ bytecode from an artifact file. Takes in the relative path to the json file
-    function getDeployedCode(string calldata) external view returns (bytes memory);
+    function getDeployedCode(string calldata path) external view returns (bytes memory);
     // Labels an address in call traces
     function label(address, string calldata) external;
     // Using the address that calls the test contract, has the next call (at this call depth only) create a transaction that can later be signed and sent onchain
@@ -94,70 +94,70 @@ interface VmSafe {
     // Using the address that calls the test contract, has all subsequent calls (at this call depth only) create transactions that can later be signed and sent onchain
     function startBroadcast() external;
     // Has all subsequent calls (at this call depth only) create transactions with the address provided that can later be signed and sent onchain
-    function startBroadcast(address) external;
+    function startBroadcast(address broadcaster) external;
     // Has all subsequent calls (at this call depth only) create transactions with the private key provided that can later be signed and sent onchain
-    function startBroadcast(uint256) external;
+    function startBroadcast(uint256 privateKey) external;
     // Stops collecting onchain transactions
     function stopBroadcast() external;
     // Reads the entire content of file to string, (path) => (data)
-    function readFile(string calldata) external view returns (string memory);
+    function readFile(string calldata path) external view returns (string memory);
     // Reads the entire content of file as binary. Path is relative to the project root. (path) => (data)
-    function readFileBinary(string calldata) external view returns (bytes memory);
+    function readFileBinary(string calldata path) external view returns (bytes memory);
     // Get the path of the current project root
     function projectRoot() external view returns (string memory);
     // Get the metadata for a file/directory
     function fsMetadata(string calldata fileOrDir) external returns (FsMetadata memory metadata);
     // Reads next line of file to string, (path) => (line)
-    function readLine(string calldata) external view returns (string memory);
+    function readLine(string calldata path) external view returns (string memory);
     // Writes data to file, creating a file if it does not exist, and entirely replacing its contents if it does.
     // (path, data) => ()
-    function writeFile(string calldata, string calldata) external;
+    function writeFile(string calldata path, string calldata data) external;
     // Writes binary data to a file, creating a file if it does not exist, and entirely replacing its contents if it does.
     // Path is relative to the project root. (path, data) => ()
-    function writeFileBinary(string calldata, bytes calldata) external;
+    function writeFileBinary(string calldata path, bytes calldata data) external;
     // Writes line to file, creating a file if it does not exist.
     // (path, data) => ()
-    function writeLine(string calldata, string calldata) external;
+    function writeLine(string calldata path, string calldata data) external;
     // Closes file for reading, resetting the offset and allowing to read it from beginning with readLine.
     // (path) => ()
-    function closeFile(string calldata) external;
+    function closeFile(string calldata path) external;
     // Removes file. This cheatcode will revert in the following situations, but is not limited to just these cases:
     // - Path points to a directory.
     // - The file doesn't exist.
     // - The user lacks permissions to remove the file.
     // (path) => ()
-    function removeFile(string calldata) external;
+    function removeFile(string calldata path) external;
     // Convert values to a string, (value) => (stringified value)
-    function toString(address) external pure returns (string memory);
-    function toString(bytes calldata) external pure returns (string memory);
-    function toString(bytes32) external pure returns (string memory);
-    function toString(bool) external pure returns (string memory);
-    function toString(uint256) external pure returns (string memory);
-    function toString(int256) external pure returns (string memory);
+    function toString(address value) external pure returns (string memory);
+    function toString(bytes calldata value) external pure returns (string memory);
+    function toString(bytes32 value) external pure returns (string memory);
+    function toString(bool value) external pure returns (string memory);
+    function toString(uint256 value) external pure returns (string memory);
+    function toString(int256 value) external pure returns (string memory);
     // Convert values from a string, (string) => (parsed value)
-    function parseBytes(string calldata) external pure returns (bytes memory);
-    function parseAddress(string calldata) external pure returns (address);
-    function parseUint(string calldata) external pure returns (uint256);
-    function parseInt(string calldata) external pure returns (int256);
-    function parseBytes32(string calldata) external pure returns (bytes32);
-    function parseBool(string calldata) external pure returns (bool);
+    function parseBytes(string calldata value) external pure returns (bytes memory);
+    function parseAddress(string calldata value) external pure returns (address);
+    function parseUint(string calldata value) external pure returns (uint256);
+    function parseInt(string calldata value) external pure returns (int256);
+    function parseBytes32(string calldata value) external pure returns (bytes32);
+    function parseBool(string calldata value) external pure returns (bool);
     // Record all the transaction logs
     function recordLogs() external;
     // Gets all the recorded logs, () => (logs)
     function getRecordedLogs() external returns (Log[] memory);
     // Derive a private key from a provided mnenomic string (or mnenomic file path) at the derivation path m/44'/60'/0'/0/{index}
-    function deriveKey(string calldata, uint32) external pure returns (uint256);
+    function deriveKey(string calldata mnemonic, uint32 index) external pure returns (uint256);
     // Derive a private key from a provided mnenomic string (or mnenomic file path) at the derivation path {path}{index}
-    function deriveKey(string calldata, string calldata, uint32) external pure returns (uint256);
+    function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index) external pure returns (uint256);
     // Adds a private key to the local forge wallet and returns the address
-    function rememberKey(uint256) external returns (address);
+    function rememberKey(uint256 privateKey) external returns (address);
     //
     // parseJson
     //
     // ----
     // In case the returned value is a JSON object, it's encoded as a ABI-encoded tuple. As JSON objects
     // don't have the notion of ordered, but tuples do, they JSON object is encoded with it's fields ordered in
-    // ALPHABETICAL ordser. That means that in order to succesfully decode the tuple, we need to define a tuple that
+    // ALPHABETICAL order. That means that in order to successfully decode the tuple, we need to define a tuple that
     // encodes the fields in the same order, which is alphabetical. In the case of Solidity structs, they are encoded
     // as tuples, with the attributes in the order in which they are defined.
     // For example: json = { 'a': 1, 'b': 0xa4tb......3xs}
@@ -169,8 +169,8 @@ interface VmSafe {
     // decode the tuple in that order, and thus fail.
     // ----
     // Given a string of JSON, return it as ABI-encoded, (stringified json, key) => (ABI-encoded data)
-    function parseJson(string calldata, string calldata) external pure returns (bytes memory);
-    function parseJson(string calldata) external pure returns (bytes memory);
+    function parseJson(string calldata json, string calldata key) external pure returns (bytes memory);
+    function parseJson(string calldata json) external pure returns (bytes memory);
     //
     // writeJson
     //
@@ -195,40 +195,39 @@ interface VmSafe {
     //  json1 and json2 are simply keys used by the backend to keep track of the objects. So vm.serializeJson(json1,..)
     //  will find the object in-memory that is keyed by "some key".   // writeJson
     // ----
-    // Serialize a key and value to a JSON object stored in-memory that can be latery written to a file
+    // Serialize a key and value to a JSON object stored in-memory that can be later written to a file
     // It returns the stringified version of the specific JSON file up to that moment.
-    // (object_key, value_key, value) => (stringified JSON)
-    function serializeBool(string calldata, string calldata, bool) external returns (string memory);
-    function serializeUint(string calldata, string calldata, uint256) external returns (string memory);
-    function serializeInt(string calldata, string calldata, int256) external returns (string memory);
-    function serializeAddress(string calldata, string calldata, address) external returns (string memory);
-    function serializeBytes32(string calldata, string calldata, bytes32) external returns (string memory);
-    function serializeString(string calldata, string calldata, string calldata) external returns (string memory);
-    function serializeBytes(string calldata, string calldata, bytes calldata) external returns (string memory);
+    // (objectKey, valueKey, value) => (stringified JSON)
+    function serializeBool(string calldata objectKey, string calldata valueKey, bool value) external returns (string memory);
+    function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value) external returns (string memory);
+    function serializeInt(string calldata objectKey, string calldata valueKey, int256 value) external returns (string memory);
+    function serializeAddress(string calldata objectKey, string calldata valueKey, address value) external returns (string memory);
+    function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32 value) external returns (string memory);
+    function serializeString(string calldata objectKey, string calldata valueKey, string calldata value) external returns (string memory);
+    function serializeBytes(string calldata objectKey, string calldata valueKey, bytes calldata value) external returns (string memory);
 
-    function serializeBool(string calldata, string calldata, bool[] calldata) external returns (string memory);
-    function serializeUint(string calldata, string calldata, uint256[] calldata) external returns (string memory);
-    function serializeInt(string calldata, string calldata, int256[] calldata) external returns (string memory);
-    function serializeAddress(string calldata, string calldata, address[] calldata) external returns (string memory);
-    function serializeBytes32(string calldata, string calldata, bytes32[] calldata) external returns (string memory);
-    function serializeString(string calldata, string calldata, string[] calldata) external returns (string memory);
-    function serializeBytes(string calldata, string calldata, bytes[] calldata) external returns (string memory);
+    function serializeBool(string calldata objectKey, string calldata valueKey, bool[] calldata values) external returns (string memory);
+    function serializeUint(string calldata objectKey, string calldata valueKey, uint256[] calldata values) external returns (string memory);
+    function serializeInt(string calldata objectKey, string calldata valueKey, int256[] calldata values) external returns (string memory);
+    function serializeAddress(string calldata objectKey, string calldata valueKey, address[] calldata values)  external returns (string memory);
+    function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32[] calldata values) external returns (string memory);
+    function serializeString(string calldata objectKey, string calldata valueKey, string[] calldata values) external returns (string memory);
+    function serializeBytes(string calldata objectKey, string calldata valueKey, bytes[] calldata values) external returns (string memory);
     // Write a serialized JSON object to a file. If the file exists, it will be overwritten.
     // (stringified_json, path)
-    function writeJson(string calldata, string calldata) external;
+    function writeJson(string calldata json, string calldata path) external;
     // Write a serialized JSON object to an **existing** JSON file, replacing a value with key = <value_key>
     // This is useful to replace a specific value of a JSON file, without having to parse the entire thing
     // (stringified_json, path, value_key)
-    function writeJson(string calldata, string calldata, string calldata) external;
+    function writeJson(string calldata json, string calldata path, string calldata valueKey) external;
     // Returns the RPC url for the given alias
-    function rpcUrl(string calldata) external view returns (string memory);
+    function rpcUrl(string calldata rpcAlias) external view returns (string memory);
     // Returns all rpc urls and their aliases `[alias, url][]`
     function rpcUrls() external view returns (string[2][] memory);
     // Returns all rpc urls and their aliases as structs.
     function rpcUrlStructs() external view returns (Rpc[] memory);
     // If the condition is false, discard this run's fuzz inputs and generate new ones.
-    function assume(bool) external pure;
-
+    function assume(bool condition) external pure;
     // Pauses gas metering (i.e. gas usage is not counted). Noop if already paused.
     function pauseGasMetering() external;
     // Resumes gas metering (i.e. gas usage is counted again). Noop if already on.
@@ -237,109 +236,109 @@ interface VmSafe {
 
 interface Vm is VmSafe {
     // Sets block.timestamp (newTimestamp)
-    function warp(uint256) external;
+    function warp(uint256 newTimestamp) external;
     // Sets block.height (newHeight)
-    function roll(uint256) external;
+    function roll(uint256 newHeight) external;
     // Sets block.basefee (newBasefee)
-    function fee(uint256) external;
+    function fee(uint256 newBasefee) external;
     // Sets block.difficulty (newDifficulty)
-    function difficulty(uint256) external;
+    function difficulty(uint256 newDifficulty) external;
     // Sets block.chainid
-    function chainId(uint256) external;
+    function chainId(uint256 newChainId) external;
     // Stores a value to an address' storage slot, (who, slot, value)
-    function store(address, bytes32, bytes32) external;
+    function store(address who, bytes32 slot, bytes32 value) external;
     // Sets the nonce of an account; must be higher than the current nonce of the account
-    function setNonce(address, uint64) external;
+    function setNonce(address account, uint64 newNonce) external;
     // Sets the *next* call's msg.sender to be the input address
-    function prank(address) external;
+    function prank(address newCaller) external;
     // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called
-    function startPrank(address) external;
+    function startPrank(address newCaller) external;
     // Sets the *next* call's msg.sender to be the input address, and the tx.origin to be the second input
-    function prank(address, address) external;
+    function prank(address newCaller, address newTxOrigin) external;
     // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called, and the tx.origin to be the second input
-    function startPrank(address, address) external;
+    function startPrank(address newCaller, address newTxOrigin) external;
     // Resets subsequent calls' msg.sender to be `address(this)`
     function stopPrank() external;
     // Sets an address' balance, (who, newBalance)
-    function deal(address, uint256) external;
+    function deal(address who, uint256 newBalance) external;
     // Sets an address' code, (who, newCode)
-    function etch(address, bytes calldata) external;
+    function etch(address who, bytes calldata newCode) external;
     // Expects an error on next call
-    function expectRevert(bytes calldata) external;
-    function expectRevert(bytes4) external;
+    function expectRevert(bytes calldata revertdata) external;
+    function expectRevert(bytes4 revertdata) external;
     function expectRevert() external;
     // Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData).
     // Call this function, then emit an event, then call a function. Internally after the call, we check if
     // logs were emitted in the expected order with the expected topics and data (as specified by the booleans)
-    function expectEmit(bool, bool, bool, bool) external;
-    function expectEmit(bool, bool, bool, bool, address) external;
+    function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;
+    function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;
     // Mocks a call to an address, returning specified data.
     // Calldata can either be strict or a partial match, e.g. if you only
     // pass a Solidity selector to the expected calldata, then the entire Solidity
     // function will be mocked.
-    function mockCall(address, bytes calldata, bytes calldata) external;
+    function mockCall(address callee, bytes calldata passedData, bytes calldata returnedData) external;
     // Mocks a call to an address with a specific msg.value, returning specified data.
     // Calldata match takes precedence over msg.value in case of ambiguity.
-    function mockCall(address, uint256, bytes calldata, bytes calldata) external;
+    function mockCall(address callee, uint256 passedMsgValue, bytes calldata passedData, bytes calldata returnedData) external;
     // Clears all mocked calls
     function clearMockedCalls() external;
     // Expects a call to an address with the specified calldata.
     // Calldata can either be a strict or a partial match
-    function expectCall(address, bytes calldata) external;
+    function expectCall(address callee, bytes calldata expectedCalldata) external;
     // Expects a call to an address with the specified msg.value and calldata
-    function expectCall(address, uint256, bytes calldata) external;
+    function expectCall(address callee, uint256 expectedMsgValue, bytes calldata expectedCalldata) external;
     // Sets block.coinbase (who)
-    function coinbase(address) external;
+    function coinbase(address who) external;
     // Snapshot the current state of the evm.
     // Returns the id of the snapshot that was created.
     // To revert a snapshot use `revertTo`
     function snapshot() external returns (uint256);
-    // Revert the state of the evm to a previous snapshot
+    // Revert the state of the EVM to a previous snapshot
     // Takes the snapshot id to revert to.
     // This deletes the snapshot and all snapshots taken after the given snapshot id.
-    function revertTo(uint256) external returns (bool);
+    function revertTo(uint256 snapshotId) external returns (bool);
     // Creates a new fork with the given endpoint and block and returns the identifier of the fork
-    function createFork(string calldata, uint256) external returns (uint256);
+    function createFork(string calldata endpoint, uint256 blockNumber) external returns (uint256);
     // Creates a new fork with the given endpoint and the _latest_ block and returns the identifier of the fork
-    function createFork(string calldata) external returns (uint256);
+    function createFork(string calldata endpoint) external returns (uint256);
     // Creates a new fork with the given endpoint and at the block the given transaction was mined in, and replays all transaction mined in the block before the transaction
-    function createFork(string calldata, bytes32) external returns (uint256);
+    function createFork(string calldata endpoint, bytes32 txid) external returns (uint256);
     // Creates _and_ also selects a new fork with the given endpoint and block and returns the identifier of the fork
-    function createSelectFork(string calldata, uint256) external returns (uint256);
+    function createSelectFork(string calldata endpoint, uint256 blockNumber) external returns (uint256);
     // Creates _and_ also selects new fork with the given endpoint and at the block the given transaction was mined in, and replays all transaction mined in the block before the transaction
-    function createSelectFork(string calldata, bytes32) external returns (uint256);
+    function createSelectFork(string calldata endpoint, bytes32 txid) external returns (uint256);
     // Creates _and_ also selects a new fork with the given endpoint and the latest block and returns the identifier of the fork
-    function createSelectFork(string calldata) external returns (uint256);
+    function createSelectFork(string calldata endpoint) external returns (uint256);
     // Takes a fork identifier created by `createFork` and sets the corresponding forked state as active.
-    function selectFork(uint256) external;
+    function selectFork(uint256 forkId) external;
     /// Returns the currently active fork
     /// Reverts if no fork is currently active
     function activeFork() external view returns (uint256);
     // Updates the currently active fork to given block number
     // This is similar to `roll` but for the currently active fork
-    function rollFork(uint256) external;
+    function rollFork(uint256 blockNumber) external;
     // Updates the currently active fork to given transaction
     // this will `rollFork` with the number of the block the transaction was mined in and replays all transaction mined before it in the block
-    function rollFork(bytes32) external;
+    function rollFork(bytes32 txid) external;
     // Updates the given fork to given block number
     function rollFork(uint256 forkId, uint256 blockNumber) external;
     // Updates the given fork to block number of the given transaction and replays all transaction mined before it in the block
     function rollFork(uint256 forkId, bytes32 transaction) external;
     // Marks that the account(s) should use persistent storage across fork swaps in a multifork setup
     // Meaning, changes made to the state of this account will be kept when switching forks
-    function makePersistent(address) external;
-    function makePersistent(address, address) external;
-    function makePersistent(address, address, address) external;
-    function makePersistent(address[] calldata) external;
+    function makePersistent(address account) external;
+    function makePersistent(address account0, address account1) external;
+    function makePersistent(address account0, address account1, address account2) external;
+    function makePersistent(address[] calldata accounts) external;
     // Revokes persistent status from the address, previously added via `makePersistent`
-    function revokePersistent(address) external;
-    function revokePersistent(address[] calldata) external;
+    function revokePersistent(address account) external;
+    function revokePersistent(address[] calldata accounts) external;
     // Returns true if the account is marked as persistent
     function isPersistent(address) external view returns (bool);
     // In forking mode, explicitly grant the given address cheatcode access
-    function allowCheatcodes(address) external;
+    function allowCheatcodes(address account) external;
     // Fetches the given transaction from the active fork and executes it on the current state
-    function transact(bytes32 txHash) external;
+    function transact(bytes32 txid) external;
     // Fetches the given transaction from the given fork and executes it on the current state
-    function transact(uint256 forkId, bytes32 txHash) external;
+    function transact(uint256 forkId, bytes32 txid) external;
 }

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -44,21 +44,21 @@ interface VmSafe {
     // Sets environment variables
     function setEnv(string calldata name, string calldata value) external;
     // Reads environment variables, (name) => (value)
-    function envBool(string calldata name) external view returns (bool);
-    function envUint(string calldata name) external view returns (uint256);
-    function envInt(string calldata name) external view returns (int256);
-    function envAddress(string calldata name) external view returns (address);
-    function envBytes32(string calldata name) external view returns (bytes32);
-    function envString(string calldata name) external view returns (string memory);
-    function envBytes(string calldata name) external view returns (bytes memory);
+    function envBool(string calldata name) external view returns (bool value);
+    function envUint(string calldata name) external view returns (uint256 value);
+    function envInt(string calldata name) external view returns (int256 value);
+    function envAddress(string calldata name) external view returns (address value);
+    function envBytes32(string calldata name) external view returns (bytes32 value);
+    function envString(string calldata name) external view returns (string memory value);
+    function envBytes(string calldata name) external view returns (bytes memory value);
     // Reads environment variables as arrays
-    function envBool(string calldata name, string calldata delim) external view returns (bool[] memory);
-    function envUint(string calldata name, string calldata delim) external view returns (uint256[] memory);
-    function envInt(string calldata name, string calldata delim) external view returns (int256[] memory);
-    function envAddress(string calldata name, string calldata delim) external view returns (address[] memory);
-    function envBytes32(string calldata name, string calldata delim) external view returns (bytes32[] memory);
-    function envString(string calldata name, string calldata delim) external view returns (string[] memory);
-    function envBytes(string calldata name, string calldata delim) external view returns (bytes[] memory);
+    function envBool(string calldata name, string calldata delim) external view returns (bool[] memory value);
+    function envUint(string calldata name, string calldata delim) external view returns (uint256[] memory value);
+    function envInt(string calldata name, string calldata delim) external view returns (int256[] memory value);
+    function envAddress(string calldata name, string calldata delim) external view returns (address[] memory value);
+    function envBytes32(string calldata name, string calldata delim) external view returns (bytes32[] memory value);
+    function envString(string calldata name, string calldata delim) external view returns (string[] memory value);
+    function envBytes(string calldata name, string calldata delim) external view returns (bytes[] memory value);
     // Read environment variables with default value
     function envOr(string calldata name, bool defaultValue) external returns (bool value);
     function envOr(string calldata name, uint256 defaultValue) external returns (uint256 value);

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -148,7 +148,10 @@ interface VmSafe {
     // Derive a private key from a provided mnenomic string (or mnenomic file path) at the derivation path m/44'/60'/0'/0/{index}
     function deriveKey(string calldata mnemonic, uint32 index) external pure returns (uint256);
     // Derive a private key from a provided mnenomic string (or mnenomic file path) at the derivation path {path}{index}
-    function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index) external pure returns (uint256);
+    function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index)
+        external
+        pure
+        returns (uint256);
     // Adds a private key to the local forge wallet and returns the address
     function rememberKey(uint256 privateKey) external returns (address);
     //
@@ -198,21 +201,49 @@ interface VmSafe {
     // Serialize a key and value to a JSON object stored in-memory that can be later written to a file
     // It returns the stringified version of the specific JSON file up to that moment.
     // (objectKey, valueKey, value) => (stringified JSON)
-    function serializeBool(string calldata objectKey, string calldata valueKey, bool value) external returns (string memory);
-    function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value) external returns (string memory);
-    function serializeInt(string calldata objectKey, string calldata valueKey, int256 value) external returns (string memory);
-    function serializeAddress(string calldata objectKey, string calldata valueKey, address value) external returns (string memory);
-    function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32 value) external returns (string memory);
-    function serializeString(string calldata objectKey, string calldata valueKey, string calldata value) external returns (string memory);
-    function serializeBytes(string calldata objectKey, string calldata valueKey, bytes calldata value) external returns (string memory);
+    function serializeBool(string calldata objectKey, string calldata valueKey, bool value)
+        external
+        returns (string memory);
+    function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value)
+        external
+        returns (string memory);
+    function serializeInt(string calldata objectKey, string calldata valueKey, int256 value)
+        external
+        returns (string memory);
+    function serializeAddress(string calldata objectKey, string calldata valueKey, address value)
+        external
+        returns (string memory);
+    function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32 value)
+        external
+        returns (string memory);
+    function serializeString(string calldata objectKey, string calldata valueKey, string calldata value)
+        external
+        returns (string memory);
+    function serializeBytes(string calldata objectKey, string calldata valueKey, bytes calldata value)
+        external
+        returns (string memory);
 
-    function serializeBool(string calldata objectKey, string calldata valueKey, bool[] calldata values) external returns (string memory);
-    function serializeUint(string calldata objectKey, string calldata valueKey, uint256[] calldata values) external returns (string memory);
-    function serializeInt(string calldata objectKey, string calldata valueKey, int256[] calldata values) external returns (string memory);
-    function serializeAddress(string calldata objectKey, string calldata valueKey, address[] calldata values)  external returns (string memory);
-    function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32[] calldata values) external returns (string memory);
-    function serializeString(string calldata objectKey, string calldata valueKey, string[] calldata values) external returns (string memory);
-    function serializeBytes(string calldata objectKey, string calldata valueKey, bytes[] calldata values) external returns (string memory);
+    function serializeBool(string calldata objectKey, string calldata valueKey, bool[] calldata values)
+        external
+        returns (string memory);
+    function serializeUint(string calldata objectKey, string calldata valueKey, uint256[] calldata values)
+        external
+        returns (string memory);
+    function serializeInt(string calldata objectKey, string calldata valueKey, int256[] calldata values)
+        external
+        returns (string memory);
+    function serializeAddress(string calldata objectKey, string calldata valueKey, address[] calldata values)
+        external
+        returns (string memory);
+    function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32[] calldata values)
+        external
+        returns (string memory);
+    function serializeString(string calldata objectKey, string calldata valueKey, string[] calldata values)
+        external
+        returns (string memory);
+    function serializeBytes(string calldata objectKey, string calldata valueKey, bytes[] calldata values)
+        external
+        returns (string memory);
     // Write a serialized JSON object to a file. If the file exists, it will be overwritten.
     // (stringified_json, path)
     function writeJson(string calldata json, string calldata path) external;
@@ -271,7 +302,8 @@ interface Vm is VmSafe {
     // Call this function, then emit an event, then call a function. Internally after the call, we check if
     // logs were emitted in the expected order with the expected topics and data (as specified by the booleans)
     function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;
-    function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter) external;
+    function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData, address emitter)
+        external;
     // Mocks a call to an address, returning specified data.
     // Calldata can either be strict or a partial match, e.g. if you only
     // pass a Solidity selector to the expected calldata, then the entire Solidity
@@ -279,7 +311,8 @@ interface Vm is VmSafe {
     function mockCall(address callee, bytes calldata passedData, bytes calldata returnedData) external;
     // Mocks a call to an address with a specific msg.value, returning specified data.
     // Calldata match takes precedence over msg.value in case of ambiguity.
-    function mockCall(address callee, uint256 passedMsgValue, bytes calldata passedData, bytes calldata returnedData) external;
+    function mockCall(address callee, uint256 passedMsgValue, bytes calldata passedData, bytes calldata returnedData)
+        external;
     // Clears all mocked calls
     function clearMockedCalls() external;
     // Expects a call to an address with the specified calldata.
@@ -302,11 +335,11 @@ interface Vm is VmSafe {
     // Creates a new fork with the given endpoint and the _latest_ block and returns the identifier of the fork
     function createFork(string calldata endpoint) external returns (uint256);
     // Creates a new fork with the given endpoint and at the block the given transaction was mined in, and replays all transaction mined in the block before the transaction
-    function createFork(string calldata endpoint, bytes32 txid) external returns (uint256);
+    function createFork(string calldata endpoint, bytes32 txHash) external returns (uint256);
     // Creates _and_ also selects a new fork with the given endpoint and block and returns the identifier of the fork
     function createSelectFork(string calldata endpoint, uint256 blockNumber) external returns (uint256);
     // Creates _and_ also selects new fork with the given endpoint and at the block the given transaction was mined in, and replays all transaction mined in the block before the transaction
-    function createSelectFork(string calldata endpoint, bytes32 txid) external returns (uint256);
+    function createSelectFork(string calldata endpoint, bytes32 txHash) external returns (uint256);
     // Creates _and_ also selects a new fork with the given endpoint and the latest block and returns the identifier of the fork
     function createSelectFork(string calldata endpoint) external returns (uint256);
     // Takes a fork identifier created by `createFork` and sets the corresponding forked state as active.
@@ -319,7 +352,7 @@ interface Vm is VmSafe {
     function rollFork(uint256 blockNumber) external;
     // Updates the currently active fork to given transaction
     // this will `rollFork` with the number of the block the transaction was mined in and replays all transaction mined before it in the block
-    function rollFork(bytes32 txid) external;
+    function rollFork(bytes32 txHash) external;
     // Updates the given fork to given block number
     function rollFork(uint256 forkId, uint256 blockNumber) external;
     // Updates the given fork to block number of the given transaction and replays all transaction mined before it in the block
@@ -338,7 +371,7 @@ interface Vm is VmSafe {
     // In forking mode, explicitly grant the given address cheatcode access
     function allowCheatcodes(address account) external;
     // Fetches the given transaction from the active fork and executes it on the current state
-    function transact(bytes32 txid) external;
+    function transact(bytes32 txHash) external;
     // Fetches the given transaction from the given fork and executes it on the current state
-    function transact(uint256 forkId, bytes32 txid) external;
+    function transact(uint256 forkId, bytes32 txHash) external;
 }

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -31,17 +31,17 @@ interface VmSafe {
         uint256 created;
     }
 
-    // Loads a storage slot from an address (who, slot)
-    function load(address who, bytes32 slot) external view returns (bytes32);
-    // Signs data, (privateKey, digest) => (v, r, s)
-    function sign(uint256 privateKey, bytes32 digest) external pure returns (uint8, bytes32, bytes32);
-    // Gets the address for a given private key, (privateKey) => (address)
-    function addr(uint256 privateKey) external pure returns (address);
+    // Loads a storage slot from an address
+    function load(address who, bytes32 slot) external view returns (bytes32 data);
+    // Signs data
+    function sign(uint256 privateKey, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
+    // Gets the address for a given private key
+    function addr(uint256 privateKey) external pure returns (address addr);
     // Gets the nonce of an account
-    function getNonce(address account) external view returns (uint64);
-    // Performs a foreign function call via the terminal, (stringInputs) => (result)
-    function ffi(string[] calldata stringInputs) external returns (bytes memory);
-    // Sets environment variables, (name, value)
+    function getNonce(address account) external view returns (uint64 nonce);
+    // Performs a foreign function call via the terminal
+    function ffi(string[] calldata stringInputs) external returns (bytes memory result);
+    // Sets environment variables
     function setEnv(string calldata name, string calldata value) external;
     // Reads environment variables, (name) => (value)
     function envBool(string calldata name) external view returns (bool);
@@ -80,9 +80,9 @@ interface VmSafe {
     // Gets all accessed reads and write slot from a recording session, for a given address
     function accesses(address who) external returns (bytes32[] memory reads, bytes32[] memory writes);
     // Gets the _creation_ bytecode from an artifact file. Takes in the relative path to the json file
-    function getCode(string calldata path) external view returns (bytes memory);
+    function getCode(string calldata path) external view returns (bytes memory bytecode);
     // Gets the _deployed_ bytecode from an artifact file. Takes in the relative path to the json file
-    function getDeployedCode(string calldata path) external view returns (bytes memory);
+    function getDeployedCode(string calldata path) external view returns (bytes memory bytecode);
     // Labels an address in call traces
     function label(address, string calldata) external;
     // Using the address that calls the test contract, has the next call (at this call depth only) create a transaction that can later be signed and sent onchain
@@ -99,16 +99,16 @@ interface VmSafe {
     function startBroadcast(uint256 privateKey) external;
     // Stops collecting onchain transactions
     function stopBroadcast() external;
-    // Reads the entire content of file to string, (path) => (data)
-    function readFile(string calldata path) external view returns (string memory);
-    // Reads the entire content of file as binary. Path is relative to the project root. (path) => (data)
-    function readFileBinary(string calldata path) external view returns (bytes memory);
+    // Reads the entire content of file to string
+    function readFile(string calldata path) external view returns (string memory data);
+    // Reads the entire content of file as binary. Path is relative to the project root.
+    function readFileBinary(string calldata path) external view returns (bytes memory data);
     // Get the path of the current project root
-    function projectRoot() external view returns (string memory);
+    function projectRoot() external view returns (string memory rootPath);
     // Get the metadata for a file/directory
     function fsMetadata(string calldata fileOrDir) external returns (FsMetadata memory metadata);
-    // Reads next line of file to string, (path) => (line)
-    function readLine(string calldata path) external view returns (string memory);
+    // Reads next line of file to string
+    function readLine(string calldata path) external view returns (string memory line);
     // Writes data to file, creating a file if it does not exist, and entirely replacing its contents if it does.
     // (path, data) => ()
     function writeFile(string calldata path, string calldata data) external;
@@ -127,33 +127,33 @@ interface VmSafe {
     // - The user lacks permissions to remove the file.
     // (path) => ()
     function removeFile(string calldata path) external;
-    // Convert values to a string, (value) => (stringified value)
-    function toString(address value) external pure returns (string memory);
-    function toString(bytes calldata value) external pure returns (string memory);
-    function toString(bytes32 value) external pure returns (string memory);
-    function toString(bool value) external pure returns (string memory);
-    function toString(uint256 value) external pure returns (string memory);
-    function toString(int256 value) external pure returns (string memory);
-    // Convert values from a string, (string) => (parsed value)
-    function parseBytes(string calldata value) external pure returns (bytes memory);
-    function parseAddress(string calldata value) external pure returns (address);
-    function parseUint(string calldata value) external pure returns (uint256);
-    function parseInt(string calldata value) external pure returns (int256);
-    function parseBytes32(string calldata value) external pure returns (bytes32);
-    function parseBool(string calldata value) external pure returns (bool);
+    // Convert values to a string
+    function toString(address value) external pure returns (string memory stringValue);
+    function toString(bytes calldata value) external pure returns (string memory stringValue);
+    function toString(bytes32 value) external pure returns (string memory stringValue);
+    function toString(bool value) external pure returns (string memory stringValue);
+    function toString(uint256 value) external pure returns (string memory stringValue);
+    function toString(int256 value) external pure returns (string memory stringValue);
+    // Convert values from a string
+    function parseBytes(string calldata value) external pure returns (bytes memory parsedValue);
+    function parseAddress(string calldata value) external pure returns (address parsedValue);
+    function parseUint(string calldata value) external pure returns (uint256 parsedValue);
+    function parseInt(string calldata value) external pure returns (int256 parsedValue);
+    function parseBytes32(string calldata value) external pure returns (bytes32 parsedValue);
+    function parseBool(string calldata value) external pure returns (bool parsedValue);
     // Record all the transaction logs
     function recordLogs() external;
-    // Gets all the recorded logs, () => (logs)
-    function getRecordedLogs() external returns (Log[] memory);
+    // Gets all the recorded logs
+    function getRecordedLogs() external returns (Log[] memory logs);
     // Derive a private key from a provided mnenomic string (or mnenomic file path) at the derivation path m/44'/60'/0'/0/{index}
-    function deriveKey(string calldata mnemonic, uint32 index) external pure returns (uint256);
-    // Derive a private key from a provided mnenomic string (or mnenomic file path) at the derivation path {path}{index}
+    function deriveKey(string calldata mnemonic, uint32 index) external pure returns (uint256 privateKey);
+    // Derive a private key from a provided mnenomic string (or mnenomic file path) at {derivationPath}{index}
     function deriveKey(string calldata mnemonic, string calldata derivationPath, uint32 index)
         external
         pure
-        returns (uint256);
+        returns (uint256 privateKey);
     // Adds a private key to the local forge wallet and returns the address
-    function rememberKey(uint256 privateKey) external returns (address);
+    function rememberKey(uint256 privateKey) external returns (address addr);
     //
     // parseJson
     //
@@ -171,9 +171,9 @@ interface VmSafe {
     // If we defined a json struct with the opposite order, meaning placing the address b first, it would try to
     // decode the tuple in that order, and thus fail.
     // ----
-    // Given a string of JSON, return it as ABI-encoded, (stringified json, key) => (ABI-encoded data)
-    function parseJson(string calldata json, string calldata key) external pure returns (bytes memory);
-    function parseJson(string calldata json) external pure returns (bytes memory);
+    // Given a string of JSON, return it as ABI-encoded
+    function parseJson(string calldata json, string calldata key) external pure returns (bytes memory abiEncodedData);
+    function parseJson(string calldata json) external pure returns (bytes memory abiEncodedData);
     //
     // writeJson
     //
@@ -200,63 +200,60 @@ interface VmSafe {
     // ----
     // Serialize a key and value to a JSON object stored in-memory that can be later written to a file
     // It returns the stringified version of the specific JSON file up to that moment.
-    // (objectKey, valueKey, value) => (stringified JSON)
     function serializeBool(string calldata objectKey, string calldata valueKey, bool value)
         external
-        returns (string memory);
+        returns (string memory json);
     function serializeUint(string calldata objectKey, string calldata valueKey, uint256 value)
         external
-        returns (string memory);
+        returns (string memory json);
     function serializeInt(string calldata objectKey, string calldata valueKey, int256 value)
         external
-        returns (string memory);
+        returns (string memory json);
     function serializeAddress(string calldata objectKey, string calldata valueKey, address value)
         external
-        returns (string memory);
+        returns (string memory json);
     function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32 value)
         external
-        returns (string memory);
+        returns (string memory json);
     function serializeString(string calldata objectKey, string calldata valueKey, string calldata value)
         external
-        returns (string memory);
+        returns (string memory json);
     function serializeBytes(string calldata objectKey, string calldata valueKey, bytes calldata value)
         external
-        returns (string memory);
+        returns (string memory json);
 
     function serializeBool(string calldata objectKey, string calldata valueKey, bool[] calldata values)
         external
-        returns (string memory);
+        returns (string memory json);
     function serializeUint(string calldata objectKey, string calldata valueKey, uint256[] calldata values)
         external
-        returns (string memory);
+        returns (string memory json);
     function serializeInt(string calldata objectKey, string calldata valueKey, int256[] calldata values)
         external
-        returns (string memory);
+        returns (string memory json);
     function serializeAddress(string calldata objectKey, string calldata valueKey, address[] calldata values)
         external
-        returns (string memory);
+        returns (string memory json);
     function serializeBytes32(string calldata objectKey, string calldata valueKey, bytes32[] calldata values)
         external
-        returns (string memory);
+        returns (string memory json);
     function serializeString(string calldata objectKey, string calldata valueKey, string[] calldata values)
         external
-        returns (string memory);
+        returns (string memory json);
     function serializeBytes(string calldata objectKey, string calldata valueKey, bytes[] calldata values)
         external
-        returns (string memory);
+        returns (string memory json);
     // Write a serialized JSON object to a file. If the file exists, it will be overwritten.
-    // (stringified_json, path)
     function writeJson(string calldata json, string calldata path) external;
     // Write a serialized JSON object to an **existing** JSON file, replacing a value with key = <value_key>
     // This is useful to replace a specific value of a JSON file, without having to parse the entire thing
-    // (stringified_json, path, value_key)
     function writeJson(string calldata json, string calldata path, string calldata valueKey) external;
     // Returns the RPC url for the given alias
-    function rpcUrl(string calldata rpcAlias) external view returns (string memory);
+    function rpcUrl(string calldata rpcAlias) external view returns (string memory json);
     // Returns all rpc urls and their aliases `[alias, url][]`
-    function rpcUrls() external view returns (string[2][] memory);
+    function rpcUrls() external view returns (string[2][] memory urls);
     // Returns all rpc urls and their aliases as structs.
-    function rpcUrlStructs() external view returns (Rpc[] memory);
+    function rpcUrlStructs() external view returns (Rpc[] memory urls);
     // If the condition is false, discard this run's fuzz inputs and generate new ones.
     function assume(bool condition) external pure;
     // Pauses gas metering (i.e. gas usage is not counted). Noop if already paused.
@@ -325,28 +322,30 @@ interface Vm is VmSafe {
     // Snapshot the current state of the evm.
     // Returns the id of the snapshot that was created.
     // To revert a snapshot use `revertTo`
-    function snapshot() external returns (uint256);
+    function snapshot() external returns (uint256 snapshotId);
     // Revert the state of the EVM to a previous snapshot
     // Takes the snapshot id to revert to.
     // This deletes the snapshot and all snapshots taken after the given snapshot id.
-    function revertTo(uint256 snapshotId) external returns (bool);
+    function revertTo(uint256 snapshotId) external returns (bool result);
     // Creates a new fork with the given endpoint and block and returns the identifier of the fork
-    function createFork(string calldata endpoint, uint256 blockNumber) external returns (uint256);
+    function createFork(string calldata endpoint, uint256 blockNumber) external returns (uint256 forkId);
     // Creates a new fork with the given endpoint and the _latest_ block and returns the identifier of the fork
-    function createFork(string calldata endpoint) external returns (uint256);
-    // Creates a new fork with the given endpoint and at the block the given transaction was mined in, and replays all transaction mined in the block before the transaction
-    function createFork(string calldata endpoint, bytes32 txHash) external returns (uint256);
+    function createFork(string calldata endpoint) external returns (uint256 forkId);
+    // Creates a new fork with the given endpoint and at the block the given transaction was mined in, replays all transaction mined in the block before the transaction,
+    // and returns the identifier of the fork
+    function createFork(string calldata endpoint, bytes32 txHash) external returns (uint256 forkId);
     // Creates _and_ also selects a new fork with the given endpoint and block and returns the identifier of the fork
-    function createSelectFork(string calldata endpoint, uint256 blockNumber) external returns (uint256);
-    // Creates _and_ also selects new fork with the given endpoint and at the block the given transaction was mined in, and replays all transaction mined in the block before the transaction
-    function createSelectFork(string calldata endpoint, bytes32 txHash) external returns (uint256);
+    function createSelectFork(string calldata endpoint, uint256 blockNumber) external returns (uint256 forkId);
+    // Creates _and_ also selects new fork with the given endpoint and at the block the given transaction was mined in, replays all transaction mined in the block before
+    // the transaction, returns the identifier of the fork
+    function createSelectFork(string calldata endpoint, bytes32 txHash) external returns (uint256 forkId);
     // Creates _and_ also selects a new fork with the given endpoint and the latest block and returns the identifier of the fork
-    function createSelectFork(string calldata endpoint) external returns (uint256);
+    function createSelectFork(string calldata endpoint) external returns (uint256 forkId);
     // Takes a fork identifier created by `createFork` and sets the corresponding forked state as active.
     function selectFork(uint256 forkId) external;
     /// Returns the currently active fork
     /// Reverts if no fork is currently active
-    function activeFork() external view returns (uint256);
+    function activeFork() external view returns (uint256 forkId);
     // Updates the currently active fork to given block number
     // This is similar to `roll` but for the currently active fork
     function rollFork(uint256 blockNumber) external;
@@ -367,7 +366,7 @@ interface Vm is VmSafe {
     function revokePersistent(address account) external;
     function revokePersistent(address[] calldata accounts) external;
     // Returns true if the account is marked as persistent
-    function isPersistent(address) external view returns (bool);
+    function isPersistent(address) external view returns (bool persistent);
     // In forking mode, explicitly grant the given address cheatcode access
     function allowCheatcodes(address account) external;
     // Fetches the given transaction from the active fork and executes it on the current state

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -67,7 +67,7 @@ interface VmSafe {
     function envOr(string calldata name, bytes32 defaultValue) external returns (bytes32 value);
     function envOr(string calldata name, string calldata defaultValue) external returns (string memory value);
     function envOr(string calldata name, bytes calldata defaultValue) external returns (bytes memory value);
-    // Read environment variables as arrays with default value, (name, value[]) => (value[])
+    // Read environment variables as arrays with default value
     function envOr(string calldata name, string calldata, bool[] calldata defaultValue)
         external
         returns (bool[] memory value);

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -32,7 +32,7 @@ interface VmSafe {
     }
 
     // Loads a storage slot from an address
-    function load(address who, bytes32 slot) external view returns (bytes32 data);
+    function load(address target, bytes32 slot) external view returns (bytes32 data);
     // Signs data
     function sign(uint256 privateKey, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
     // Gets the address for a given private key
@@ -40,7 +40,7 @@ interface VmSafe {
     // Gets the nonce of an account
     function getNonce(address account) external view returns (uint64 nonce);
     // Performs a foreign function call via the terminal
-    function ffi(string[] calldata stringInputs) external returns (bytes memory result);
+    function ffi(string[] calldata commandInput) external returns (bytes memory result);
     // Sets environment variables
     function setEnv(string calldata name, string calldata value) external;
     // Reads environment variables, (name) => (value)
@@ -68,47 +68,47 @@ interface VmSafe {
     function envOr(string calldata name, string calldata defaultValue) external returns (string memory value);
     function envOr(string calldata name, bytes calldata defaultValue) external returns (bytes memory value);
     // Read environment variables as arrays with default value
-    function envOr(string calldata name, string calldata, bool[] calldata defaultValue)
+    function envOr(string calldata name, string calldata delim, bool[] calldata defaultValue)
         external
         returns (bool[] memory value);
-    function envOr(string calldata name, string calldata, uint256[] calldata defaultValue)
+    function envOr(string calldata name, string calldata delim, uint256[] calldata defaultValue)
         external
         returns (uint256[] memory value);
-    function envOr(string calldata name, string calldata, int256[] calldata defaultValue)
+    function envOr(string calldata name, string calldata delim, int256[] calldata defaultValue)
         external
         returns (int256[] memory value);
-    function envOr(string calldata name, string calldata, address[] calldata defaultValue)
+    function envOr(string calldata name, string calldata delim, address[] calldata defaultValue)
         external
         returns (address[] memory value);
-    function envOr(string calldata name, string calldata, bytes32[] calldata defaultValue)
+    function envOr(string calldata name, string calldata delim, bytes32[] calldata defaultValue)
         external
         returns (bytes32[] memory value);
-    function envOr(string calldata name, string calldata, string[] calldata defaultValue)
+    function envOr(string calldata name, string calldata delim, string[] calldata defaultValue)
         external
         returns (string[] memory value);
-    function envOr(string calldata name, string calldata, bytes[] calldata defaultValue)
+    function envOr(string calldata name, string calldata delim, bytes[] calldata defaultValue)
         external
         returns (bytes[] memory value);
     // Records all storage reads and writes
     function record() external;
     // Gets all accessed reads and write slot from a recording session, for a given address
-    function accesses(address who) external returns (bytes32[] memory reads, bytes32[] memory writes);
+    function accesses(address target) external returns (bytes32[] memory readSlots, bytes32[] memory writeSlots);
     // Gets the _creation_ bytecode from an artifact file. Takes in the relative path to the json file
-    function getCode(string calldata artifactPath) external view returns (bytes memory bytecode);
+    function getCode(string calldata artifactPath) external view returns (bytes memory creationBytecode);
     // Gets the _deployed_ bytecode from an artifact file. Takes in the relative path to the json file
-    function getDeployedCode(string calldata artifactPath) external view returns (bytes memory bytecode);
+    function getDeployedCode(string calldata artifactPath) external view returns (bytes memory runtimeBytecode);
     // Labels an address in call traces
-    function label(address who, string calldata newLabel) external;
+    function label(address account, string calldata newLabel) external;
     // Using the address that calls the test contract, has the next call (at this call depth only) create a transaction that can later be signed and sent onchain
     function broadcast() external;
     // Has the next call (at this call depth only) create a transaction with the address provided as the sender that can later be signed and sent onchain
-    function broadcast(address broadcaster) external;
+    function broadcast(address signer) external;
     // Has the next call (at this call depth only) create a transaction with the private key provided as the sender that can later be signed and sent onchain
     function broadcast(uint256 privateKey) external;
     // Using the address that calls the test contract, has all subsequent calls (at this call depth only) create transactions that can later be signed and sent onchain
     function startBroadcast() external;
     // Has all subsequent calls (at this call depth only) create transactions with the address provided that can later be signed and sent onchain
-    function startBroadcast(address broadcaster) external;
+    function startBroadcast(address signer) external;
     // Has all subsequent calls (at this call depth only) create transactions with the private key provided that can later be signed and sent onchain
     function startBroadcast(uint256 privateKey) external;
     // Stops collecting onchain transactions
@@ -118,7 +118,7 @@ interface VmSafe {
     // Reads the entire content of file as binary. Path is relative to the project root.
     function readFileBinary(string calldata path) external view returns (bytes memory data);
     // Get the path of the current project root
-    function projectRoot() external view returns (string memory rootPath);
+    function projectRoot() external view returns (string memory path);
     // Get the metadata for a file/directory
     function fsMetadata(string calldata fileOrDir) external returns (FsMetadata memory metadata);
     // Reads next line of file to string
@@ -138,19 +138,19 @@ interface VmSafe {
     // - The user lacks permissions to remove the file.
     function removeFile(string calldata path) external;
     // Convert values to a string
-    function toString(address value) external pure returns (string memory stringValue);
-    function toString(bytes calldata value) external pure returns (string memory stringValue);
-    function toString(bytes32 value) external pure returns (string memory stringValue);
-    function toString(bool value) external pure returns (string memory stringValue);
-    function toString(uint256 value) external pure returns (string memory stringValue);
-    function toString(int256 value) external pure returns (string memory stringValue);
+    function toString(address value) external pure returns (string memory stringifiedValue);
+    function toString(bytes calldata value) external pure returns (string memory stringifiedValue);
+    function toString(bytes32 value) external pure returns (string memory stringifiedValue);
+    function toString(bool value) external pure returns (string memory stringifiedValue);
+    function toString(uint256 value) external pure returns (string memory stringifiedValue);
+    function toString(int256 value) external pure returns (string memory stringifiedValue);
     // Convert values from a string
-    function parseBytes(string calldata value) external pure returns (bytes memory parsedValue);
-    function parseAddress(string calldata value) external pure returns (address parsedValue);
-    function parseUint(string calldata value) external pure returns (uint256 parsedValue);
-    function parseInt(string calldata value) external pure returns (int256 parsedValue);
-    function parseBytes32(string calldata value) external pure returns (bytes32 parsedValue);
-    function parseBool(string calldata value) external pure returns (bool parsedValue);
+    function parseBytes(string calldata stringifiedValue) external pure returns (bytes memory parsedValue);
+    function parseAddress(string calldata stringifiedValue) external pure returns (address parsedValue);
+    function parseUint(string calldata stringifiedValue) external pure returns (uint256 parsedValue);
+    function parseInt(string calldata stringifiedValue) external pure returns (int256 parsedValue);
+    function parseBytes32(string calldata stringifiedValue) external pure returns (bytes32 parsedValue);
+    function parseBool(string calldata stringifiedValue) external pure returns (bool parsedValue);
     // Record all the transaction logs
     function recordLogs() external;
     // Gets all the recorded logs
@@ -285,7 +285,7 @@ interface Vm is VmSafe {
     // Sets block.chainid
     function chainId(uint256 newChainId) external;
     // Stores a value to an address' storage slot.
-    function store(address who, bytes32 slot, bytes32 value) external;
+    function store(address target, bytes32 slot, bytes32 value) external;
     // Sets the nonce of an account; must be higher than the current nonce of the account
     function setNonce(address account, uint64 newNonce) external;
     // Sets the *next* call's msg.sender to be the input address
@@ -299,9 +299,9 @@ interface Vm is VmSafe {
     // Resets subsequent calls' msg.sender to be `address(this)`
     function stopPrank() external;
     // Sets an address' balance
-    function deal(address who, uint256 newBalance) external;
+    function deal(address account, uint256 newBalance) external;
     // Sets an address' code
-    function etch(address who, bytes calldata newCode) external;
+    function etch(address target, bytes calldata newRuntimeBytecode) external;
     // Expects an error on next call
     function expectRevert(bytes calldata revertData) external;
     function expectRevert(bytes4 revertData) external;
@@ -338,19 +338,19 @@ interface Vm is VmSafe {
     // This deletes the snapshot and all snapshots taken after the given snapshot id.
     function revertTo(uint256 snapshotId) external returns (bool success);
     // Creates a new fork with the given endpoint and block and returns the identifier of the fork
-    function createFork(string calldata endpoint, uint256 blockNumber) external returns (uint256 forkId);
+    function createFork(string calldata urlOrAlias, uint256 blockNumber) external returns (uint256 forkId);
     // Creates a new fork with the given endpoint and the _latest_ block and returns the identifier of the fork
-    function createFork(string calldata endpoint) external returns (uint256 forkId);
+    function createFork(string calldata urlOrAlias) external returns (uint256 forkId);
     // Creates a new fork with the given endpoint and at the block the given transaction was mined in, replays all transaction mined in the block before the transaction,
     // and returns the identifier of the fork
-    function createFork(string calldata endpoint, bytes32 txHash) external returns (uint256 forkId);
+    function createFork(string calldata urlOrAlias, bytes32 txHash) external returns (uint256 forkId);
     // Creates _and_ also selects a new fork with the given endpoint and block and returns the identifier of the fork
-    function createSelectFork(string calldata endpoint, uint256 blockNumber) external returns (uint256 forkId);
+    function createSelectFork(string calldata urlOrAlias, uint256 blockNumber) external returns (uint256 forkId);
     // Creates _and_ also selects new fork with the given endpoint and at the block the given transaction was mined in, replays all transaction mined in the block before
     // the transaction, returns the identifier of the fork
-    function createSelectFork(string calldata endpoint, bytes32 txHash) external returns (uint256 forkId);
+    function createSelectFork(string calldata urlOrAlias, bytes32 txHash) external returns (uint256 forkId);
     // Creates _and_ also selects a new fork with the given endpoint and the latest block and returns the identifier of the fork
-    function createSelectFork(string calldata endpoint) external returns (uint256 forkId);
+    function createSelectFork(string calldata urlOrAlias) external returns (uint256 forkId);
     // Takes a fork identifier created by `createFork` and sets the corresponding forked state as active.
     function selectFork(uint256 forkId) external;
     /// Returns the identifier of the currently active fork. Reverts if no fork is currently active.


### PR DESCRIPTION
Benefits:

1. Enable Forge Std users to call cheatcodes with [named arguments](https://twitter.com/PaulRBerg/status/1574071928544976896), which improves readability.
2. Better documentation for people who read the source code.

Examples:

```solidity
vm.roll({ newHeight: block.height + 100 });
vm.getCode({ path: "../../path/to/MyContract.sol" });
vm.expectEmit({ checkTopic1: true, checkTopic2: true, checkTopic3: true, checkData: true });
```

I think that this is especially useful for the `expectEmit` cheatcode, which, to quote the [Foundry Book](https://book.getfoundry.sh/forge/cheatcodes), is known for being "non-intuitive".

Notes:

- Generally I have tried to follow the argument names suggested in the comments
- When there was no name suggestion in the comments, I came up with my own (feedback welcome)

Questions:

1. Should we keep the argument names in the comments above the functions? They look a bit superfluous now.
2. I am torn between `txid` and `txhash`, which is needed in multiple functions. Which one do you like more?