### PR TITLE
feat: Add gas metering cheatcodes + modifier

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -200,6 +200,11 @@ interface VmSafe {
     function rpcUrlStructs() external view returns (Rpc[] memory);
     // If the condition is false, discard this run's fuzz inputs and generate new ones.
     function assume(bool) external pure;
+
+    // Pauses gas metering (i.e. gas usage is not counted). Noop if already paused.
+    function pauseGasMetering() external;
+    // Resumes gas metering (i.e. gas usage is counted again). Noop if already on.
+    function resumeGasMetering() external;
 }
 
 interface Vm is VmSafe {

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -219,6 +219,41 @@ contract StdCheatsTest is Test {
         receipts;
     }
 
+    function testGasMeteringModifier() public {
+        uint256 gas_start_normal = gasleft();
+        addInLoop();
+        uint256 gas_used_normal = gas_start_normal - gasleft();
+
+        uint256 gas_start_single = gasleft();
+        addInLoopNoGas();
+        uint256 gas_used_single = gas_start_single - gasleft();
+
+        uint256 gas_start_double = gasleft();
+        addInLoopNoGasNoGas();
+        uint256 gas_used_double = gas_start_double - gasleft();
+
+        emit log_named_uint("Normal gas", gas_used_normal);
+        emit log_named_uint("Single modifier gas", gas_used_single);
+        emit log_named_uint("Double modifier  gas", gas_used_double);
+        assertTrue(gas_used_double + gas_used_single < gas_used_normal);
+    }
+
+    function addInLoop() internal returns (uint256) {
+        uint256 b;
+        for (uint256 i; i < 10000; i++) {
+            b += i;
+        }
+        return b;
+    }
+
+    function addInLoopNoGas() internal noGasMetering returns (uint256) {
+        return addInLoop();
+    }
+
+    function addInLoopNoGasNoGas() internal noGasMetering returns (uint256) {
+        return addInLoopNoGas();
+    }
+
     function bytesToUint_test(bytes memory b) private pure returns (uint256) {
         uint256 number;
         for (uint256 i = 0; i < b.length; i++) {


### PR DESCRIPTION
Adds support for `pauseGasMetering` and `resumeGasMetering` to `VmSafe`.

Additionally adds a modifier: `noGasMetering`, that pauses gas metering during the function's execution and resumes afterward (allows for nested `noGasMetering` function calls).

Depends on
https://github.com/foundry-rs/foundry/pull/3826