### PR TITLE
feat: implement boundInt

### DIFF
--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -41,8 +41,8 @@ abstract contract StdUtils {
         console2.log("Bound Result", result);
     }
 
-    function boundInt(int256 x, int256 min, int256 max) internal view virtual returns (int256 result) {
-        require(min <= max, "StdUtils boundInt(int256,int256,int256): Max is less than min.");
+    function bound(int256 x, int256 min, int256 max) internal view virtual returns (int256 result) {
+        require(min <= max, "StdUtils bound(int256,int256,int256): Max is less than min.");
 
         // Shifting all int256 values to uint256 to use _bound function. The range of two types are:
         // int256 : -(2**255) ~ (2**255 - 1)

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -58,7 +58,7 @@ abstract contract StdUtils {
         uint256 y = _bound(_x, _min, _max);
 
         // To move it back to int256 value, subtract INT256_MIN_ABS at here.
-        result = y < INT256_MIN_ABS ? int256(~(INT256_MIN_ABS - y) + 1): int256(y - INT256_MIN_ABS);
+        result = y < INT256_MIN_ABS ? int256(~(INT256_MIN_ABS - y) + 1) : int256(y - INT256_MIN_ABS);
         console2.log("Bound Result", result);
     }
 

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -4,12 +4,12 @@ pragma solidity >=0.6.2 <0.9.0;
 import "./console2.sol";
 
 abstract contract StdUtils {
+    uint256 private constant INT256_MIN_ABS =
+        57896044618658097711785492504343953926634992332820282019728792003956564819968;
     uint256 private constant UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
     function _bound(uint256 x, uint256 min, uint256 max) internal pure virtual returns (uint256 result) {
-        require(min <= max, "StdUtils bound(uint256,uint256,uint256): Max is less than min.");
-
         // If x is between min and max, return x directly. This is to ensure that dictionary values
         // do not get shifted if the min is nonzero. More info: https://github.com/foundry-rs/forge-std/issues/188
         if (x >= min && x <= max) return x;
@@ -36,8 +36,22 @@ abstract contract StdUtils {
     }
 
     function bound(uint256 x, uint256 min, uint256 max) internal view virtual returns (uint256 result) {
+        require(min <= max, "StdUtils bound(uint256,uint256,uint256): Max is less than min.");
         result = _bound(x, min, max);
         console2.log("Bound Result", result);
+    }
+
+    function boundInt(int256 x, int256 min, int256 max) internal view virtual returns (int256 result) {
+        require(min <= max, "StdUtils boundInt(int256,int256,int256): Max is less than min.");
+
+        uint256 _x = x < 0 ? (INT256_MIN_ABS - ~uint256(x) - 1) : (uint256(x) + INT256_MIN_ABS);
+        uint256 _min = min < 0 ? (INT256_MIN_ABS - ~uint256(min) - 1) : (uint256(min) + INT256_MIN_ABS);
+        uint256 _max = max < 0 ? (INT256_MIN_ABS - ~uint256(max) - 1) : (uint256(max) + INT256_MIN_ABS);
+
+        uint256 y = _bound(_x, _min, _max);
+        result = y > INT256_MIN_ABS ? int256(y - INT256_MIN_ABS) : -int256(INT256_MIN_ABS - y);
+        // TODO: change after log(string,int256) is made
+        console2.log("Bound Result", uint256(result));
     }
 
     /// @dev Compute the address a contract will be deployed at for a given deployer address and nonce

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.6.2 <0.9.0;
 
-import "./console2.sol";
+// TODO Remove import.
+import {Vm} from "./Vm.sol";
 
 abstract contract StdUtils {
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    address private constant CONSOLE2_ADDRESS = 0x000000000000000000636F6e736F6c652e6c6f67;
+
     uint256 private constant INT256_MIN_ABS =
         57896044618658097711785492504343953926634992332820282019728792003956564819968;
     uint256 private constant UINT256_MAX =
@@ -38,7 +42,7 @@ abstract contract StdUtils {
 
     function bound(uint256 x, uint256 min, uint256 max) internal view virtual returns (uint256 result) {
         result = _bound(x, min, max);
-        console2.log("Bound Result", result);
+        console2_log("Bound Result", result);
     }
 
     function bound(int256 x, int256 min, int256 max) internal view virtual returns (int256 result) {
@@ -59,7 +63,7 @@ abstract contract StdUtils {
 
         // To move it back to int256 value, subtract INT256_MIN_ABS at here.
         result = y < INT256_MIN_ABS ? int256(~(INT256_MIN_ABS - y) + 1) : int256(y - INT256_MIN_ABS);
-        console2.log("Bound Result", result);
+        console2_log(string(abi.encodePacked("Bound result: ", vm.toString(result))));
     }
 
     /// @dev Compute the address a contract will be deployed at for a given deployer address and nonce
@@ -103,5 +107,15 @@ abstract contract StdUtils {
 
     function addressFromLast20Bytes(bytes32 bytesValue) private pure returns (address) {
         return address(uint160(uint256(bytesValue)));
+    }
+
+    function console2_log(string memory p0, uint256 p1) private view {
+        (bool status,) = address(CONSOLE2_ADDRESS).staticcall(abi.encodeWithSignature("log(string,uint256)", p0, p1));
+        status;
+    }
+
+    function console2_log(string memory p0) private view {
+        (bool status,) = address(CONSOLE2_ADDRESS).staticcall(abi.encodeWithSignature("log(string)", p0));
+        status;
     }
 }

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -63,7 +63,7 @@ abstract contract StdUtils {
 
         // To move it back to int256 value, subtract INT256_MIN_ABS at here.
         result = y < INT256_MIN_ABS ? int256(~(INT256_MIN_ABS - y) + 1) : int256(y - INT256_MIN_ABS);
-        console2_log(string(abi.encodePacked("Bound result: ", vm.toString(result))));
+        console2_log("Bound result", vm.toString(result));
     }
 
     /// @dev Compute the address a contract will be deployed at for a given deployer address and nonce
@@ -114,8 +114,8 @@ abstract contract StdUtils {
         status;
     }
 
-    function console2_log(string memory p0) private view {
-        (bool status,) = address(CONSOLE2_ADDRESS).staticcall(abi.encodeWithSignature("log(string)", p0));
+    function console2_log(string memory p0, string memory p1) private view {
+        (bool status,) = address(CONSOLE2_ADDRESS).staticcall(abi.encodeWithSignature("log(string,string)", p0, p1));
         status;
     }
 }

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -44,11 +44,20 @@ abstract contract StdUtils {
     function boundInt(int256 x, int256 min, int256 max) internal view virtual returns (int256 result) {
         require(min <= max, "StdUtils boundInt(int256,int256,int256): Max is less than min.");
 
+        // Shifting all int256 values to uint256 to use _bound function. The range of two types are:
+        // int256 : -(2**255) ~ (2**255 - 1)
+        // uint256:     0     ~ (2**256 - 1)
+        // So, add 2**255, INT256_MIN_ABS to the integer values.
+        //
+        // If the given integer value is -2**255, we cannot use `-uint256(-x)` because of the overflow.
+        // So, use `~uint256(x) + 1` instead.
         uint256 _x = x < 0 ? (INT256_MIN_ABS - ~uint256(x) - 1) : (uint256(x) + INT256_MIN_ABS);
         uint256 _min = min < 0 ? (INT256_MIN_ABS - ~uint256(min) - 1) : (uint256(min) + INT256_MIN_ABS);
         uint256 _max = max < 0 ? (INT256_MIN_ABS - ~uint256(max) - 1) : (uint256(max) + INT256_MIN_ABS);
 
         uint256 y = _bound(_x, _min, _max);
+
+        // To move it back to int256 value, subtract INT256_MIN_ABS at here.
         result = y > INT256_MIN_ABS ? int256(y - INT256_MIN_ABS) : -int256(INT256_MIN_ABS - y);
         // TODO: change after log(string,int256) is made
         console2.log("Bound Result", uint256(result));

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -58,7 +58,7 @@ abstract contract StdUtils {
         uint256 y = _bound(_x, _min, _max);
 
         // To move it back to int256 value, subtract INT256_MIN_ABS at here.
-        result = y > INT256_MIN_ABS ? int256(y - INT256_MIN_ABS) : -int256(INT256_MIN_ABS - y);
+        result = y < INT256_MIN_ABS ? int256(~(INT256_MIN_ABS - y) + 1): int256(y - INT256_MIN_ABS);
         // TODO: change after log(string,int256) is made
         console2.log("Bound Result", uint256(result));
     }

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -59,8 +59,7 @@ abstract contract StdUtils {
 
         // To move it back to int256 value, subtract INT256_MIN_ABS at here.
         result = y < INT256_MIN_ABS ? int256(~(INT256_MIN_ABS - y) + 1): int256(y - INT256_MIN_ABS);
-        // TODO: change after log(string,int256) is made
-        console2.log("Bound Result", uint256(result));
+        console2.log("Bound Result", result);
     }
 
     /// @dev Compute the address a contract will be deployed at for a given deployer address and nonce

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -10,6 +10,7 @@ abstract contract StdUtils {
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
     function _bound(uint256 x, uint256 min, uint256 max) internal pure virtual returns (uint256 result) {
+        require(min <= max, "StdUtils bound(uint256,uint256,uint256): Max is less than min.");
         // If x is between min and max, return x directly. This is to ensure that dictionary values
         // do not get shifted if the min is nonzero. More info: https://github.com/foundry-rs/forge-std/issues/188
         if (x >= min && x <= max) return x;
@@ -36,7 +37,6 @@ abstract contract StdUtils {
     }
 
     function bound(uint256 x, uint256 min, uint256 max) internal view virtual returns (uint256 result) {
-        require(min <= max, "StdUtils bound(uint256,uint256,uint256): Max is less than min.");
         result = _bound(x, min, max);
         console2.log("Bound Result", result);
     }

--- a/src/console2.sol
+++ b/src/console2.sol
@@ -179,6 +179,10 @@ library console2 {
         _sendLogPayload(abi.encodeWithSignature("log(uint256)", p0));
     }
 
+    function log(int256 p0) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(int256)", p0));
+    }
+
     function log(string memory p0) internal view {
         _sendLogPayload(abi.encodeWithSignature("log(string)", p0));
     }

--- a/src/console2.sol
+++ b/src/console2.sol
@@ -211,6 +211,10 @@ library console2 {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256)", p0, p1));
     }
 
+    function log(string memory p0, int256 p1) internal view {
+        _sendLogPayload(abi.encodeWithSignature("log(string,int256)", p0, p1));
+    }
+
     function log(string memory p0, string memory p1) internal view {
         _sendLogPayload(abi.encodeWithSignature("log(string,string)", p0, p1));
     }

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -238,7 +238,7 @@ contract StdCheatsTest is Test {
         assertTrue(gas_used_double + gas_used_single < gas_used_normal);
     }
 
-    function addInLoop() internal returns (uint256) {
+    function addInLoop() internal pure returns (uint256) {
         uint256 b;
         for (uint256 i; i < 10000; i++) {
             b += i;

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -74,7 +74,7 @@ contract StdUtilsTest is Test {
         bound(num, min, max);
     }
 
-    function testBoundInt_DD() public {
+    function testBoundInt() public {
         assertEq(boundInt(-3, 0, 4), 2);
         assertEq(boundInt(0, -69, -69), -69);
         assertEq(boundInt(0, -69, -68), -68);
@@ -92,13 +92,22 @@ contract StdUtilsTest is Test {
 
     function testBoundInt_EdgeCoverage() public {
         assertEq(boundInt(type(int256).min, -50, 150), -50);
+        assertEq(boundInt(type(int256).min, 10, 150), 10);
         assertEq(boundInt(type(int256).min + 1, -50, 150), -49);
+        assertEq(boundInt(type(int256).min + 1, 10, 150), 11);
         assertEq(boundInt(type(int256).min + 2, -50, 150), -48);
+        assertEq(boundInt(type(int256).min + 2, 10, 150), 12);
         assertEq(boundInt(type(int256).min + 3, -50, 150), -47);
+        assertEq(boundInt(type(int256).min + 3, 10, 150), 13);
+
         assertEq(boundInt(type(int256).max, -50, 150), 150);
+        assertEq(boundInt(type(int256).max, -50, -10), -10);
         assertEq(boundInt(type(int256).max - 1, -50, 150), 149);
+        assertEq(boundInt(type(int256).max - 1, -50, -10), -11);
         assertEq(boundInt(type(int256).max - 2, -50, 150), 148);
+        assertEq(boundInt(type(int256).max - 2, -50, -10), -12);
         assertEq(boundInt(type(int256).max - 3, -50, 150), 147);
+        assertEq(boundInt(type(int256).max - 3, -50, -10), -13);
     }
 
     function testBoundInt_DistributionIsEven(int256 min, uint256 size) public {
@@ -131,6 +140,11 @@ contract StdUtilsTest is Test {
     function testBoundIntInt256Max() public {
         assertEq(boundInt(0, type(int256).max - 1, type(int256).max), type(int256).max - 1);
         assertEq(boundInt(1, type(int256).max - 1, type(int256).max), type(int256).max);
+    }
+
+    function testBoundIntInt256Min() public {
+        assertEq(boundInt(0, type(int256).min, type(int256).min + 1), type(int256).min);
+        assertEq(boundInt(1, type(int256).min, type(int256).min + 1), type(int256).min + 1);
     }
 
     function testCannotBoundIntMaxLessThanMin() public {

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -5,26 +5,26 @@ import "../src/Test.sol";
 
 contract StdUtilsTest is Test {
     function testBound() public {
-        assertEq(bound(5, 0, 4), 0);
-        assertEq(bound(0, 69, 69), 69);
-        assertEq(bound(0, 68, 69), 68);
-        assertEq(bound(10, 150, 190), 174);
-        assertEq(bound(300, 2800, 3200), 3107);
-        assertEq(bound(9999, 1337, 6666), 4669);
+        assertEq(bound(uint256(5), 0, 4), 0);
+        assertEq(bound(uint256(0), 69, 69), 69);
+        assertEq(bound(uint256(0), 68, 69), 68);
+        assertEq(bound(uint256(10), 150, 190), 174);
+        assertEq(bound(uint256(300), 2800, 3200), 3107);
+        assertEq(bound(uint256(9999), 1337, 6666), 4669);
     }
 
     function testBound_WithinRange() public {
-        assertEq(bound(51, 50, 150), 51);
-        assertEq(bound(51, 50, 150), bound(bound(51, 50, 150), 50, 150));
-        assertEq(bound(149, 50, 150), 149);
-        assertEq(bound(149, 50, 150), bound(bound(149, 50, 150), 50, 150));
+        assertEq(bound(uint256(51), 50, 150), 51);
+        assertEq(bound(uint256(51), 50, 150), bound(bound(uint256(51), 50, 150), 50, 150));
+        assertEq(bound(uint256(149), 50, 150), 149);
+        assertEq(bound(uint256(149), 50, 150), bound(bound(uint256(149), 50, 150), 50, 150));
     }
 
     function testBound_EdgeCoverage() public {
-        assertEq(bound(0, 50, 150), 50);
-        assertEq(bound(1, 50, 150), 51);
-        assertEq(bound(2, 50, 150), 52);
-        assertEq(bound(3, 50, 150), 53);
+        assertEq(bound(uint256(0), 50, 150), 50);
+        assertEq(bound(uint256(1), 50, 150), 51);
+        assertEq(bound(uint256(2), 50, 150), 52);
+        assertEq(bound(uint256(3), 50, 150), 53);
         assertEq(bound(type(uint256).max, 50, 150), 150);
         assertEq(bound(type(uint256).max - 1, 50, 150), 149);
         assertEq(bound(type(uint256).max - 2, 50, 150), 148);
@@ -65,7 +65,7 @@ contract StdUtilsTest is Test {
 
     function testCannotBoundMaxLessThanMin() public {
         vm.expectRevert(bytes("StdUtils bound(uint256,uint256,uint256): Max is less than min."));
-        bound(5, 100, 10);
+        bound(uint256(5), 100, 10);
     }
 
     function testCannotBoundMaxLessThanMin(uint256 num, uint256 min, uint256 max) public {
@@ -75,53 +75,53 @@ contract StdUtilsTest is Test {
     }
 
     function testBoundInt() public {
-        assertEq(boundInt(-3, 0, 4), 2);
-        assertEq(boundInt(0, -69, -69), -69);
-        assertEq(boundInt(0, -69, -68), -68);
-        assertEq(boundInt(-10, 150, 190), 154);
-        assertEq(boundInt(-300, 2800, 3200), 2908);
-        assertEq(boundInt(9999, -1337, 6666), 1995);
+        assertEq(bound(-3, 0, 4), 2);
+        assertEq(bound(0, -69, -69), -69);
+        assertEq(bound(0, -69, -68), -68);
+        assertEq(bound(-10, 150, 190), 154);
+        assertEq(bound(-300, 2800, 3200), 2908);
+        assertEq(bound(9999, -1337, 6666), 1995);
     }
 
     function testBoundInt_WithinRange() public {
-        assertEq(boundInt(51, -50, 150), 51);
-        assertEq(boundInt(51, -50, 150), boundInt(boundInt(51, -50, 150), -50, 150));
-        assertEq(boundInt(149, -50, 150), 149);
-        assertEq(boundInt(149, -50, 150), boundInt(boundInt(149, -50, 150), -50, 150));
+        assertEq(bound(51, -50, 150), 51);
+        assertEq(bound(51, -50, 150), bound(bound(51, -50, 150), -50, 150));
+        assertEq(bound(149, -50, 150), 149);
+        assertEq(bound(149, -50, 150), bound(bound(149, -50, 150), -50, 150));
     }
 
     function testBoundInt_EdgeCoverage() public {
-        assertEq(boundInt(type(int256).min, -50, 150), -50);
-        assertEq(boundInt(type(int256).min, 10, 150), 10);
-        assertEq(boundInt(type(int256).min + 1, -50, 150), -49);
-        assertEq(boundInt(type(int256).min + 1, 10, 150), 11);
-        assertEq(boundInt(type(int256).min + 2, -50, 150), -48);
-        assertEq(boundInt(type(int256).min + 2, 10, 150), 12);
-        assertEq(boundInt(type(int256).min + 3, -50, 150), -47);
-        assertEq(boundInt(type(int256).min + 3, 10, 150), 13);
+        assertEq(bound(type(int256).min, -50, 150), -50);
+        assertEq(bound(type(int256).min, 10, 150), 10);
+        assertEq(bound(type(int256).min + 1, -50, 150), -49);
+        assertEq(bound(type(int256).min + 1, 10, 150), 11);
+        assertEq(bound(type(int256).min + 2, -50, 150), -48);
+        assertEq(bound(type(int256).min + 2, 10, 150), 12);
+        assertEq(bound(type(int256).min + 3, -50, 150), -47);
+        assertEq(bound(type(int256).min + 3, 10, 150), 13);
 
-        assertEq(boundInt(type(int256).max, -50, 150), 150);
-        assertEq(boundInt(type(int256).max, -50, -10), -10);
-        assertEq(boundInt(type(int256).max - 1, -50, 150), 149);
-        assertEq(boundInt(type(int256).max - 1, -50, -10), -11);
-        assertEq(boundInt(type(int256).max - 2, -50, 150), 148);
-        assertEq(boundInt(type(int256).max - 2, -50, -10), -12);
-        assertEq(boundInt(type(int256).max - 3, -50, 150), 147);
-        assertEq(boundInt(type(int256).max - 3, -50, -10), -13);
+        assertEq(bound(type(int256).max, -50, 150), 150);
+        assertEq(bound(type(int256).max, -50, -10), -10);
+        assertEq(bound(type(int256).max - 1, -50, 150), 149);
+        assertEq(bound(type(int256).max - 1, -50, -10), -11);
+        assertEq(bound(type(int256).max - 2, -50, 150), 148);
+        assertEq(bound(type(int256).max - 2, -50, -10), -12);
+        assertEq(bound(type(int256).max - 3, -50, 150), 147);
+        assertEq(bound(type(int256).max - 3, -50, -10), -13);
     }
 
     function testBoundInt_DistributionIsEven(int256 min, uint256 size) public {
         size = size % 100 + 1;
-        min = boundInt(min, -int256(size / 2), int256(size - size / 2));
+        min = bound(min, -int256(size / 2), int256(size - size / 2));
         int256 max = min + int256(size) - 1;
         int256 result;
 
         for (uint256 i = 1; i <= size * 4; ++i) {
             // x > max
-            result = boundInt(max + int256(i), min, max);
+            result = bound(max + int256(i), min, max);
             assertEq(result, min + int256((i - 1) % size));
             // x < min
-            result = boundInt(min - int256(i), min, max);
+            result = bound(min - int256(i), min, max);
             assertEq(result, max - int256((i - 1) % size));
         }
     }
@@ -129,33 +129,33 @@ contract StdUtilsTest is Test {
     function testBoundInt(int256 num, int256 min, int256 max) public {
         if (min > max) (min, max) = (max, min);
 
-        int256 result = boundInt(num, min, max);
+        int256 result = bound(num, min, max);
 
         assertGe(result, min);
         assertLe(result, max);
-        assertEq(result, boundInt(result, min, max));
+        assertEq(result, bound(result, min, max));
         if (num >= min && num <= max) assertEq(result, num);
     }
 
     function testBoundIntInt256Max() public {
-        assertEq(boundInt(0, type(int256).max - 1, type(int256).max), type(int256).max - 1);
-        assertEq(boundInt(1, type(int256).max - 1, type(int256).max), type(int256).max);
+        assertEq(bound(0, type(int256).max - 1, type(int256).max), type(int256).max - 1);
+        assertEq(bound(1, type(int256).max - 1, type(int256).max), type(int256).max);
     }
 
     function testBoundIntInt256Min() public {
-        assertEq(boundInt(0, type(int256).min, type(int256).min + 1), type(int256).min);
-        assertEq(boundInt(1, type(int256).min, type(int256).min + 1), type(int256).min + 1);
+        assertEq(bound(0, type(int256).min, type(int256).min + 1), type(int256).min);
+        assertEq(bound(1, type(int256).min, type(int256).min + 1), type(int256).min + 1);
     }
 
     function testCannotBoundIntMaxLessThanMin() public {
-        vm.expectRevert(bytes("StdUtils boundInt(int256,int256,int256): Max is less than min."));
-        boundInt(-5, 100, 10);
+        vm.expectRevert(bytes("StdUtils bound(int256,int256,int256): Max is less than min."));
+        bound(-5, 100, 10);
     }
 
     function testCannotBoundIntMaxLessThanMin(int256 num, int256 min, int256 max) public {
         vm.assume(min > max);
-        vm.expectRevert(bytes("StdUtils boundInt(int256,int256,int256): Max is less than min."));
-        boundInt(num, min, max);
+        vm.expectRevert(bytes("StdUtils bound(int256,int256,int256): Max is less than min."));
+        bound(num, min, max);
     }
 
     function testGenerateCreateAddress() external {

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -92,21 +92,21 @@ contract StdUtilsTest is Test {
 
     function testBoundInt_EdgeCoverage() public {
         assertEq(bound(type(int256).min, -50, 150), -50);
-        assertEq(bound(type(int256).min, 10, 150), 10);
         assertEq(bound(type(int256).min + 1, -50, 150), -49);
-        assertEq(bound(type(int256).min + 1, 10, 150), 11);
         assertEq(bound(type(int256).min + 2, -50, 150), -48);
-        assertEq(bound(type(int256).min + 2, 10, 150), 12);
         assertEq(bound(type(int256).min + 3, -50, 150), -47);
+        assertEq(bound(type(int256).min, 10, 150), 10);
+        assertEq(bound(type(int256).min + 1, 10, 150), 11);
+        assertEq(bound(type(int256).min + 2, 10, 150), 12);
         assertEq(bound(type(int256).min + 3, 10, 150), 13);
 
         assertEq(bound(type(int256).max, -50, 150), 150);
-        assertEq(bound(type(int256).max, -50, -10), -10);
         assertEq(bound(type(int256).max - 1, -50, 150), 149);
-        assertEq(bound(type(int256).max - 1, -50, -10), -11);
         assertEq(bound(type(int256).max - 2, -50, 150), 148);
-        assertEq(bound(type(int256).max - 2, -50, -10), -12);
         assertEq(bound(type(int256).max - 3, -50, 150), 147);
+        assertEq(bound(type(int256).max, -50, -10), -10);
+        assertEq(bound(type(int256).max - 1, -50, -10), -11);
+        assertEq(bound(type(int256).max - 2, -50, -10), -12);
         assertEq(bound(type(int256).max - 3, -50, -10), -13);
     }
 


### PR DESCRIPTION
Implementing `boundInt(int256,int256,int256)` at StdUtils.sol to help fuzzing test with integer arguments.

One problem is that `log(string,int256)` does not exist so I used `log(string,uint256)` instead of it.