### PR TITLE
refactor: update total supply by default in "deal"

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -537,9 +537,9 @@ abstract contract StdCheats is StdCheatsSafe {
     }
 
     // Set the balance of an account for any ERC20 token
-    // Use the alternative signature to update `totalSupply`
+    // Use the alternative signature to not update `totalSupply`
     function deal(address token, address to, uint256 give) internal virtual {
-        deal(token, to, give, false);
+        deal(token, to, give, true);
     }
 
     function deal(address token, address to, uint256 give, bool adjust) internal virtual {


### PR DESCRIPTION
I find it a bit odd that by default `deal` (the overloaded method without an `adjust` argument) does not update the total supply after minting the tokens. The tokens are technically printed out of thin air, so IMO the total supply should by default be updated accordingly, just in case end users rely upon the total supply in their tests.

https://github.com/foundry-rs/forge-std/blob/eb980e1d4f0e8173ec27da77297ae411840c8ccb/src/StdCheats.sol#L540
