### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -197,7 +197,7 @@ abstract contract StdCheatsSafe {
         assumeNoPrecompiles(addr, chainId);
     }
 
-    function assumeNoPrecompiles(address addr, uint256 chainId) internal virtual {
+    function assumeNoPrecompiles(address addr, uint256 chainId) internal pure virtual {
         // Note: For some chains like Optimism these are technically predeploys (i.e. bytecode placed at a specific
         // address), but the same rationale for excluding them applies so we include those too.
 
@@ -425,7 +425,7 @@ abstract contract StdCheatsSafe {
         return abi.decode(abi.encodePacked(new bytes(32 - b.length), b), (uint256));
     }
 
-    function isFork() internal virtual returns (bool status) {
+    function isFork() internal view virtual returns (bool status) {
         try vm.activeFork() {
             status = true;
         } catch (bytes memory) {}

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -36,7 +36,7 @@ interface VmSafe {
     // Signs data
     function sign(uint256 privateKey, bytes32 digest) external pure returns (uint8 v, bytes32 r, bytes32 s);
     // Gets the address for a given private key
-    function addr(uint256 privateKey) external pure returns (address addr);
+    function addr(uint256 privateKey) external pure returns (address keyAddr);
     // Gets the nonce of an account
     function getNonce(address account) external view returns (uint64 nonce);
     // Performs a foreign function call via the terminal
@@ -163,7 +163,7 @@ interface VmSafe {
         pure
         returns (uint256 privateKey);
     // Adds a private key to the local forge wallet and returns the address
-    function rememberKey(uint256 privateKey) external returns (address addr);
+    function rememberKey(uint256 privateKey) external returns (address keyAddr);
     //
     // parseJson
     //


### PR DESCRIPTION
## Description

There are currently compiler warnings when using Forge Std v1.2.0:

```text
lib/forge-std/src/Vm.sol:39:62: Warning: This declaration shadows an existing declaration.
function addr(uint256 privateKey) external pure returns (address addr);
^----------^
lib/forge-std/src/Vm.sol:39:5: The shadowed declaration is here:
function addr(uint256 privateKey) external pure returns (address addr);
^---------------------------------------------------------------------^


lib/forge-std/src/Vm.sol:166:64: Warning: This declaration shadows an existing declaration.
function rememberKey(uint256 privateKey) external returns (address addr);
^----------^
lib/forge-std/src/Vm.sol:39:5: The shadowed declaration is here:
function addr(uint256 privateKey) external pure returns (address addr);
^---------------------------------------------------------------------^


lib/forge-std/src/StdCheats.sol:200:5: Warning: Function state mutability can be restricted to pure
function assumeNoPrecompiles(address addr, uint256 chainId) internal virtual {
^ (Relevant source part starts here and spans across multiple lines).


lib/forge-std/src/StdCheats.sol:428:5: Warning: Function state mutability can be restricted to view
function isFork() internal virtual returns (bool status) {
^ (Relevant source part starts here and spans across multiple lines).
```

I was the one who introduced the declaration shadow of `addr` in #246.

## Changelog

- [x] fix: fix declaration shadow "addr"
- [x] fix: make "assumeNoPrecompiles" pure
- [x] fix: make "isFork" view