### PR TITLE
Usability Updates for StdChains

### DIFF
--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -39,6 +39,12 @@ abstract contract StdChains {
 
     bool private initialized;
 
+    struct ChainData {
+        string name;
+        uint256 chainId;
+        string rpcUrl;
+    }
+
     struct Chain {
         // The chain name.
         string name;
@@ -90,7 +96,7 @@ abstract contract StdChains {
     }
 
     // set chain info, with priority to argument's rpcUrl field.
-    function setChain(string memory chainAlias, Chain memory chain) internal virtual {
+    function setChain(string memory chainAlias, ChainData memory chain) internal virtual {
         require(
             bytes(chainAlias).length != 0, "StdChains setChain(string,Chain): Chain alias cannot be the empty string."
         );
@@ -98,7 +104,6 @@ abstract contract StdChains {
         require(chain.chainId != 0, "StdChains setChain(string,Chain): Chain ID cannot be 0.");
 
         initialize();
-        chain.chainAlias = chainAlias;
         string memory foundAlias = idToAlias[chain.chainId];
 
         require(
@@ -117,7 +122,12 @@ abstract contract StdChains {
         uint256 oldChainId = chains[chainAlias].chainId;
         delete idToAlias[oldChainId];
 
-        chains[chainAlias] = chain;
+        chains[chainAlias] = Chain({
+            name: chain.name,
+            chainId: chain.chainId,
+            chainAlias: chainAlias,
+            rpcUrl: chain.rpcUrl
+        });
         idToAlias[chain.chainId] = chainAlias;
     }
 
@@ -164,40 +174,36 @@ abstract contract StdChains {
         initialized = true;
 
         // If adding an RPC here, make sure to test the default RPC URL in `testRpcs`
-        setChainWithDefaultRpcUrl("anvil", Chain("Anvil", 31337, "", "http://127.0.0.1:8545"));
+        setChainWithDefaultRpcUrl("anvil", ChainData("Anvil", 31337, "http://127.0.0.1:8545"));
         setChainWithDefaultRpcUrl(
-            "mainnet", Chain("Mainnet", 1, "", "https://mainnet.infura.io/v3/6770454bc6ea42c58aac12978531b93f")
+            "mainnet", ChainData("Mainnet", 1, "https://mainnet.infura.io/v3/6770454bc6ea42c58aac12978531b93f")
         );
         setChainWithDefaultRpcUrl(
-            "goerli", Chain("Goerli", 5, "", "https://goerli.infura.io/v3/6770454bc6ea42c58aac12978531b93f")
+            "goerli", ChainData("Goerli", 5, "https://goerli.infura.io/v3/6770454bc6ea42c58aac12978531b93f")
         );
         setChainWithDefaultRpcUrl(
-            "sepolia", Chain("Sepolia", 11155111, "", "https://sepolia.infura.io/v3/6770454bc6ea42c58aac12978531b93f")
+            "sepolia", ChainData("Sepolia", 11155111, "https://sepolia.infura.io/v3/6770454bc6ea42c58aac12978531b93f")
         );
-        setChainWithDefaultRpcUrl("optimism", Chain("Optimism", 10, "", "https://mainnet.optimism.io"));
-        setChainWithDefaultRpcUrl("optimism_goerli", Chain("Optimism Goerli", 420, "", "https://goerli.optimism.io"));
-        setChainWithDefaultRpcUrl("arbitrum_one", Chain("Arbitrum One", 42161, "", "https://arb1.arbitrum.io/rpc"));
+        setChainWithDefaultRpcUrl("optimism", ChainData("Optimism", 10, "https://mainnet.optimism.io"));
+        setChainWithDefaultRpcUrl("optimism_goerli", ChainData("Optimism Goerli", 420, "https://goerli.optimism.io"));
+        setChainWithDefaultRpcUrl("arbitrum_one", ChainData("Arbitrum One", 42161, "https://arb1.arbitrum.io/rpc"));
         setChainWithDefaultRpcUrl(
-            "arbitrum_one_goerli", Chain("Arbitrum One Goerli", 421613, "", "https://goerli-rollup.arbitrum.io/rpc")
+            "arbitrum_one_goerli", ChainData("Arbitrum One Goerli", 421613, "https://goerli-rollup.arbitrum.io/rpc")
         );
-        setChainWithDefaultRpcUrl("arbitrum_nova", Chain("Arbitrum Nova", 42170, "", "https://nova.arbitrum.io/rpc"));
-        setChainWithDefaultRpcUrl("polygon", Chain("Polygon", 137, "", "https://polygon-rpc.com"));
+        setChainWithDefaultRpcUrl("arbitrum_nova", ChainData("Arbitrum Nova", 42170, "https://nova.arbitrum.io/rpc"));
+        setChainWithDefaultRpcUrl("polygon", ChainData("Polygon", 137, "https://polygon-rpc.com"));
+        setChainWithDefaultRpcUrl("polygon_mumbai", ChainData("Polygon Mumbai", 80001, "https://rpc-mumbai.maticvigil.com"));
+        setChainWithDefaultRpcUrl("avalanche", ChainData("Avalanche", 43114, "https://api.avax.network/ext/bc/C/rpc"));
         setChainWithDefaultRpcUrl(
-            "polygon_mumbai", Chain("Polygon Mumbai", 80001, "", "https://rpc-mumbai.maticvigil.com")
+            "avalanche_fuji", ChainData("Avalanche Fuji", 43113, "https://api.avax-test.network/ext/bc/C/rpc")
         );
-        setChainWithDefaultRpcUrl("avalanche", Chain("Avalanche", 43114, "", "https://api.avax.network/ext/bc/C/rpc"));
-        setChainWithDefaultRpcUrl(
-            "avalanche_fuji", Chain("Avalanche Fuji", 43113, "", "https://api.avax-test.network/ext/bc/C/rpc")
-        );
-        setChainWithDefaultRpcUrl(
-            "bnb_smart_chain", Chain("BNB Smart Chain", 56, "", "https://bsc-dataseed1.binance.org")
-        );
-        setChainWithDefaultRpcUrl("bnb_smart_chain_testnet", Chain("BNB Smart Chain Testnet", 97, "", "https://data-seed-prebsc-1-s1.binance.org:8545"));// forgefmt: disable-line
-        setChainWithDefaultRpcUrl("gnosis_chain", Chain("Gnosis Chain", 100, "", "https://rpc.gnosischain.com"));
+        setChainWithDefaultRpcUrl("bnb_smart_chain", ChainData("BNB Smart Chain", 56, "https://bsc-dataseed1.binance.org"));
+        setChainWithDefaultRpcUrl("bnb_smart_chain_testnet", ChainData("BNB Smart Chain Testnet", 97, "https://data-seed-prebsc-1-s1.binance.org:8545"));// forgefmt: disable-line
+        setChainWithDefaultRpcUrl("gnosis_chain", ChainData("Gnosis Chain", 100, "https://rpc.gnosischain.com"));
     }
 
     // set chain info, with priority to chainAlias' rpc url in foundry.toml
-    function setChainWithDefaultRpcUrl(string memory chainAlias, Chain memory chain) private {
+    function setChainWithDefaultRpcUrl(string memory chainAlias, ChainData memory chain) private {
         string memory rpcUrl = chain.rpcUrl;
         defaultRpcUrls[chainAlias] = rpcUrl;
         chain.rpcUrl = "";

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -198,7 +198,10 @@ abstract contract StdChains {
         setChainWithDefaultRpcUrl(
             "bnb_smart_chain", ChainData("BNB Smart Chain", 56, "https://bsc-dataseed1.binance.org")
         );
-        setChainWithDefaultRpcUrl("bnb_smart_chain_testnet", ChainData("BNB Smart Chain Testnet", 97, "https://data-seed-prebsc-1-s1.binance.org:8545"));// forgefmt: disable-line
+        setChainWithDefaultRpcUrl(
+            "bnb_smart_chain_testnet",
+            ChainData("BNB Smart Chain Testnet", 97, "https://data-seed-prebsc-1-s1.binance.org:8545")
+        );
         setChainWithDefaultRpcUrl("gnosis_chain", ChainData("Gnosis Chain", 100, "https://rpc.gnosischain.com"));
     }
 

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -14,7 +14,7 @@ import {VmSafe} from "./Vm.sol";
  * `setChainWithDefaultRpcUrl` call in the `initialize` function.
  *
  * There are two main ways to use this contract:
- *   1. Set a chain with `setChain(string memory chainAlias, ChainData memory chain)` or 
+ *   1. Set a chain with `setChain(string memory chainAlias, ChainData memory chain)` or
  *      `setChain(string memory chainAlias, Chain memory chain)`
  *   2. Get a chain with `getChain(string memory chainAlias)` or `getChain(uint256 chainId)`.
  *
@@ -99,7 +99,8 @@ abstract contract StdChains {
     // set chain info, with priority to argument's rpcUrl field.
     function setChain(string memory chainAlias, ChainData memory chain) internal virtual {
         require(
-            bytes(chainAlias).length != 0, "StdChains setChain(string,ChainData): Chain alias cannot be the empty string."
+            bytes(chainAlias).length != 0,
+            "StdChains setChain(string,ChainData): Chain alias cannot be the empty string."
         );
 
         require(chain.chainId != 0, "StdChains setChain(string,ChainData): Chain ID cannot be 0.");

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -143,7 +143,7 @@ abstract contract StdChains {
                 chain.rpcUrl = configRpcUrl;
             } catch (bytes memory err) {
                 chain.rpcUrl =
-                    vm.envOr(string(abi.encodePacked("RPC_URL_", _toUpper(chainAlias))), defaultRpcUrls[chainAlias]);
+                    vm.envOr(string(abi.encodePacked(_toUpper(chainAlias), "_RPC_URL")), defaultRpcUrls[chainAlias]);
                 // distinguish 'not found' from 'cannot read'
                 bytes memory notFoundError =
                     abi.encodeWithSignature("CheatCodeError", string(abi.encodePacked("invalid rpc url ", chainAlias)));

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -190,7 +190,9 @@ abstract contract StdChains {
         setChainWithDefaultRpcUrl(
             "avalanche_fuji", Chain("Avalanche Fuji", 43113, "", "https://api.avax-test.network/ext/bc/C/rpc")
         );
-        setChainWithDefaultRpcUrl("bnb_smart_chain", Chain("BNB Smart Chain", 56, "", "https://bsc-dataseed1.binance.org"));
+        setChainWithDefaultRpcUrl(
+            "bnb_smart_chain", Chain("BNB Smart Chain", 56, "", "https://bsc-dataseed1.binance.org")
+        );
         setChainWithDefaultRpcUrl("bnb_smart_chain_testnet", Chain("BNB Smart Chain Testnet", 97, "", "https://data-seed-prebsc-1-s1.binance.org:8545"));// forgefmt: disable-line
         setChainWithDefaultRpcUrl("gnosis_chain", Chain("Gnosis Chain", 100, "", "https://rpc.gnosischain.com"));
     }

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -145,7 +145,8 @@ abstract contract StdChains {
             try vm.rpcUrl(chainAlias) returns (string memory configRpcUrl) {
                 chain.rpcUrl = configRpcUrl;
             } catch (bytes memory err) {
-                chain.rpcUrl = vm.envOr(string(abi.encodePacked("RPC_URL_", _toUpper(chainAlias))), defaultRpcUrls[chainAlias]);
+                chain.rpcUrl =
+                    vm.envOr(string(abi.encodePacked("RPC_URL_", _toUpper(chainAlias))), defaultRpcUrls[chainAlias]);
                 // distinguish 'not found' from 'cannot read'
                 bytes memory notFoundError =
                     abi.encodeWithSignature("CheatCodeError", string(abi.encodePacked("invalid rpc url ", chainAlias)));

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -122,12 +122,8 @@ abstract contract StdChains {
         uint256 oldChainId = chains[chainAlias].chainId;
         delete idToAlias[oldChainId];
 
-        chains[chainAlias] = Chain({
-            name: chain.name,
-            chainId: chain.chainId,
-            chainAlias: chainAlias,
-            rpcUrl: chain.rpcUrl
-        });
+        chains[chainAlias] =
+            Chain({name: chain.name, chainId: chain.chainId, chainAlias: chainAlias, rpcUrl: chain.rpcUrl});
         idToAlias[chain.chainId] = chainAlias;
     }
 
@@ -192,12 +188,16 @@ abstract contract StdChains {
         );
         setChainWithDefaultRpcUrl("arbitrum_nova", ChainData("Arbitrum Nova", 42170, "https://nova.arbitrum.io/rpc"));
         setChainWithDefaultRpcUrl("polygon", ChainData("Polygon", 137, "https://polygon-rpc.com"));
-        setChainWithDefaultRpcUrl("polygon_mumbai", ChainData("Polygon Mumbai", 80001, "https://rpc-mumbai.maticvigil.com"));
+        setChainWithDefaultRpcUrl(
+            "polygon_mumbai", ChainData("Polygon Mumbai", 80001, "https://rpc-mumbai.maticvigil.com")
+        );
         setChainWithDefaultRpcUrl("avalanche", ChainData("Avalanche", 43114, "https://api.avax.network/ext/bc/C/rpc"));
         setChainWithDefaultRpcUrl(
             "avalanche_fuji", ChainData("Avalanche Fuji", 43113, "https://api.avax-test.network/ext/bc/C/rpc")
         );
-        setChainWithDefaultRpcUrl("bnb_smart_chain", ChainData("BNB Smart Chain", 56, "https://bsc-dataseed1.binance.org"));
+        setChainWithDefaultRpcUrl(
+            "bnb_smart_chain", ChainData("BNB Smart Chain", 56, "https://bsc-dataseed1.binance.org")
+        );
         setChainWithDefaultRpcUrl("bnb_smart_chain_testnet", ChainData("BNB Smart Chain Testnet", 97, "https://data-seed-prebsc-1-s1.binance.org:8545"));// forgefmt: disable-line
         setChainWithDefaultRpcUrl("gnosis_chain", ChainData("Gnosis Chain", 100, "https://rpc.gnosischain.com"));
     }

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -137,10 +137,7 @@ abstract contract StdChains {
 
     // lookup rpcUrl, in descending order of priority:
     // current -> config (foundry.toml) -> environment variable -> default
-    function getChainWithUpdatedRpcUrl(string memory chainAlias, Chain memory chain)
-        private
-        returns (Chain memory)
-    {
+    function getChainWithUpdatedRpcUrl(string memory chainAlias, Chain memory chain) private returns (Chain memory) {
         if (bytes(chain.rpcUrl).length == 0) {
             try vm.rpcUrl(chainAlias) returns (string memory configRpcUrl) {
                 chain.rpcUrl = configRpcUrl;

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -133,7 +133,7 @@ abstract contract StdChains {
             }
         }
         return string(copy);
-	}
+    }
 
     // lookup rpcUrl, in descending order of priority:
     // current -> config (foundry.toml) -> environment variable -> default

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -185,7 +185,9 @@ abstract contract StdChains {
         );
         setChainWithDefaultRpcUrl("arbitrum_nova", Chain("Arbitrum Nova", 42170, "", "https://nova.arbitrum.io/rpc"));
         setChainWithDefaultRpcUrl("polygon", Chain("Polygon", 137, "", "https://polygon-rpc.com"));
-        setChainWithDefaultRpcUrl("polygon_mumbai", Chain("Polygon Mumbai", 80001, "", "https://rpc-mumbai.maticvigil.com"));
+        setChainWithDefaultRpcUrl(
+            "polygon_mumbai", Chain("Polygon Mumbai", 80001, "", "https://rpc-mumbai.maticvigil.com")
+        );
         setChainWithDefaultRpcUrl("avalanche", Chain("Avalanche", 43114, "", "https://api.avax.network/ext/bc/C/rpc"));
         setChainWithDefaultRpcUrl(
             "avalanche_fuji", Chain("Avalanche Fuji", 43113, "", "https://api.avax-test.network/ext/bc/C/rpc")

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -44,7 +44,7 @@ abstract contract StdChains {
         string name;
         // The chain's Chain ID.
         uint256 chainId;
-        // The chain's alias.
+        // The chain's alias. (i.e. what gets specified in `foundry.toml`).
         string chainAlias;
         // A default RPC endpoint for this chain.
         // NOTE: This default RPC URL is included for convenience to facilitate quick tests and

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -44,6 +44,8 @@ abstract contract StdChains {
         string name;
         // The chain's Chain ID.
         uint256 chainId;
+        // The chain's alias.
+        string chainAlias;
         // A default RPC endpoint for this chain.
         // NOTE: This default RPC URL is included for convenience to facilitate quick tests and
         // experimentation. Do not use this RPC URL for production test suites, CI, or other heavy
@@ -96,6 +98,7 @@ abstract contract StdChains {
         require(chain.chainId != 0, "StdChains setChain(string,Chain): Chain ID cannot be 0.");
 
         initialize();
+        chain.chainAlias = chainAlias;
         string memory foundAlias = idToAlias[chain.chainId];
 
         require(
@@ -150,32 +153,32 @@ abstract contract StdChains {
         initialized = true;
 
         // If adding an RPC here, make sure to test the default RPC URL in `testRpcs`
-        setChainWithDefaultRpcUrl("anvil", Chain("Anvil", 31337, "http://127.0.0.1:8545"));
+        setChainWithDefaultRpcUrl("anvil", Chain("Anvil", 31337, "", "http://127.0.0.1:8545"));
         setChainWithDefaultRpcUrl(
-            "mainnet", Chain("Mainnet", 1, "https://mainnet.infura.io/v3/6770454bc6ea42c58aac12978531b93f")
+            "mainnet", Chain("Mainnet", 1, "", "https://mainnet.infura.io/v3/6770454bc6ea42c58aac12978531b93f")
         );
         setChainWithDefaultRpcUrl(
-            "goerli", Chain("Goerli", 5, "https://goerli.infura.io/v3/6770454bc6ea42c58aac12978531b93f")
+            "goerli", Chain("Goerli", 5, "", "https://goerli.infura.io/v3/6770454bc6ea42c58aac12978531b93f")
         );
         setChainWithDefaultRpcUrl(
-            "sepolia", Chain("Sepolia", 11155111, "https://sepolia.infura.io/v3/6770454bc6ea42c58aac12978531b93f")
+            "sepolia", Chain("Sepolia", 11155111, "", "https://sepolia.infura.io/v3/6770454bc6ea42c58aac12978531b93f")
         );
-        setChainWithDefaultRpcUrl("optimism", Chain("Optimism", 10, "https://mainnet.optimism.io"));
-        setChainWithDefaultRpcUrl("optimism_goerli", Chain("Optimism Goerli", 420, "https://goerli.optimism.io"));
-        setChainWithDefaultRpcUrl("arbitrum_one", Chain("Arbitrum One", 42161, "https://arb1.arbitrum.io/rpc"));
+        setChainWithDefaultRpcUrl("optimism", Chain("Optimism", 10, "", "https://mainnet.optimism.io"));
+        setChainWithDefaultRpcUrl("optimism_goerli", Chain("Optimism Goerli", 420, "", "https://goerli.optimism.io"));
+        setChainWithDefaultRpcUrl("arbitrum_one", Chain("Arbitrum One", 42161, "", "https://arb1.arbitrum.io/rpc"));
         setChainWithDefaultRpcUrl(
-            "arbitrum_one_goerli", Chain("Arbitrum One Goerli", 421613, "https://goerli-rollup.arbitrum.io/rpc")
+            "arbitrum_one_goerli", Chain("Arbitrum One Goerli", 421613, "", "https://goerli-rollup.arbitrum.io/rpc")
         );
-        setChainWithDefaultRpcUrl("arbitrum_nova", Chain("Arbitrum Nova", 42170, "https://nova.arbitrum.io/rpc"));
-        setChainWithDefaultRpcUrl("polygon", Chain("Polygon", 137, "https://polygon-rpc.com"));
-        setChainWithDefaultRpcUrl("polygon_mumbai", Chain("Polygon Mumbai", 80001, "https://rpc-mumbai.maticvigil.com"));
-        setChainWithDefaultRpcUrl("avalanche", Chain("Avalanche", 43114, "https://api.avax.network/ext/bc/C/rpc"));
+        setChainWithDefaultRpcUrl("arbitrum_nova", Chain("Arbitrum Nova", 42170, "", "https://nova.arbitrum.io/rpc"));
+        setChainWithDefaultRpcUrl("polygon", Chain("Polygon", 137, "", "https://polygon-rpc.com"));
+        setChainWithDefaultRpcUrl("polygon_mumbai", Chain("Polygon Mumbai", 80001, "", "https://rpc-mumbai.maticvigil.com"));
+        setChainWithDefaultRpcUrl("avalanche", Chain("Avalanche", 43114, "", "https://api.avax.network/ext/bc/C/rpc"));
         setChainWithDefaultRpcUrl(
-            "avalanche_fuji", Chain("Avalanche Fuji", 43113, "https://api.avax-test.network/ext/bc/C/rpc")
+            "avalanche_fuji", Chain("Avalanche Fuji", 43113, "", "https://api.avax-test.network/ext/bc/C/rpc")
         );
-        setChainWithDefaultRpcUrl("bnb_smart_chain", Chain("BNB Smart Chain", 56, "https://bsc-dataseed1.binance.org"));
-        setChainWithDefaultRpcUrl("bnb_smart_chain_testnet", Chain("BNB Smart Chain Testnet", 97, "https://data-seed-prebsc-1-s1.binance.org:8545"));// forgefmt: disable-line
-        setChainWithDefaultRpcUrl("gnosis_chain", Chain("Gnosis Chain", 100, "https://rpc.gnosischain.com"));
+        setChainWithDefaultRpcUrl("bnb_smart_chain", Chain("BNB Smart Chain", 56, "", "https://bsc-dataseed1.binance.org"));
+        setChainWithDefaultRpcUrl("bnb_smart_chain_testnet", Chain("BNB Smart Chain Testnet", 97, "", "https://data-seed-prebsc-1-s1.binance.org:8545"));// forgefmt: disable-line
+        setChainWithDefaultRpcUrl("gnosis_chain", Chain("Gnosis Chain", 100, "", "https://rpc.gnosischain.com"));
     }
 
     // set chain info, with priority to chainAlias' rpc url in foundry.toml

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -122,8 +122,8 @@ abstract contract StdChains {
     }
 
     function _toUpper(string memory str) private pure returns (string memory) {
-		bytes memory strb = bytes(str);
-		bytes memory copy = new bytes(strb.length);
+        bytes memory strb = bytes(str);
+        bytes memory copy = new bytes(strb.length);
         for (uint256 i = 0; i < strb.length; i++) {
             bytes1 b = strb[i];
             if (b >= 0x61 && b <= 0x7A) {

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -10,6 +10,16 @@ contract StdChainsTest is Test {
         assertEq(getChain("optimism_goerli").rpcUrl, "https://goerli.optimism.io/");
         assertEq(getChain("arbitrum_one_goerli").rpcUrl, "https://goerli-rollup.arbitrum.io/rpc/");
 
+        // Environment variables should be the next fallback
+        assertEq(getChain("arbitrum_nova").rpcUrl, "https://nova.arbitrum.io/rpc");
+        vm.setEnv("RPC_URL_ARBITRUM_NOVA", "myoverride");
+        assertEq(getChain("arbitrum_nova").rpcUrl, "myoverride");
+        vm.setEnv("RPC_URL_ARBITRUM_NOVA", "https://nova.arbitrum.io/rpc");
+
+        // Cannot override RPCs defined in `foundry.toml`
+        vm.setEnv("RPC_URL_MAINNET", "myoverride2");
+        assertEq(getChain("mainnet").rpcUrl, "https://mainnet.infura.io/v3/7a8769b798b642f6933f2ed52042bd70");
+
         // Other RPCs should remain unchanged.
         assertEq(getChain(31337).rpcUrl, "http://127.0.0.1:8545");
         assertEq(getChain("sepolia").rpcUrl, "https://sepolia.infura.io/v3/6770454bc6ea42c58aac12978531b93f");

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -46,11 +46,11 @@ contract StdChainsTest is Test {
 
     function testSetChainFirstFails() public {
         vm.expectRevert("StdChains setChain(string,Chain): Chain ID 31337 already used by \"anvil\".");
-        setChain("anvil2", Chain("Anvil", 31337, "URL"));
+        setChain("anvil2", Chain("Anvil", 31337, "", "URL"));
     }
 
     function testChainBubbleUp() public {
-        setChain("needs_undefined_env_var", Chain("", 123456789, ""));
+        setChain("needs_undefined_env_var", Chain("", 123456789, "", ""));
         vm.expectRevert(
             "Failed to resolve env var `UNDEFINED_RPC_URL_PLACEHOLDER` in `${UNDEFINED_RPC_URL_PLACEHOLDER}`: environment variable not found"
         );
@@ -58,33 +58,35 @@ contract StdChainsTest is Test {
     }
 
     function testCannotSetChain_ChainIdExists() public {
-        setChain("custom_chain", Chain("Custom Chain", 123456789, "https://custom.chain/"));
+        setChain("custom_chain", Chain("Custom Chain", 123456789, "", "https://custom.chain/"));
 
         vm.expectRevert('StdChains setChain(string,Chain): Chain ID 123456789 already used by "custom_chain".');
 
-        setChain("another_custom_chain", Chain("", 123456789, ""));
+        setChain("another_custom_chain", Chain("", 123456789, "", ""));
     }
 
     function testSetChain() public {
-        setChain("custom_chain", Chain("Custom Chain", 123456789, "https://custom.chain/"));
+        setChain("custom_chain", Chain("Custom Chain", 123456789, "", "https://custom.chain/"));
         Chain memory customChain = getChain("custom_chain");
         assertEq(customChain.name, "Custom Chain");
         assertEq(customChain.chainId, 123456789);
+        assertEq(customChain.chainAlias, "custom_chain");
         assertEq(customChain.rpcUrl, "https://custom.chain/");
         Chain memory chainById = getChain(123456789);
         assertEq(chainById.name, customChain.name);
         assertEq(chainById.chainId, customChain.chainId);
+        assertEq(chainById.chainAlias, customChain.chainAlias);
         assertEq(chainById.rpcUrl, customChain.rpcUrl);
     }
 
     function testSetNoEmptyAlias() public {
         vm.expectRevert("StdChains setChain(string,Chain): Chain alias cannot be the empty string.");
-        setChain("", Chain("", 123456789, ""));
+        setChain("", Chain("", 123456789, "", ""));
     }
 
     function testSetNoChainId0() public {
         vm.expectRevert("StdChains setChain(string,Chain): Chain ID cannot be 0.");
-        setChain("alias", Chain("", 0, ""));
+        setChain("alias", Chain("", 0, "", ""));
     }
 
     function testGetNoChainId0() public {
@@ -108,10 +110,10 @@ contract StdChainsTest is Test {
     }
 
     function testSetChain_ExistingOne() public {
-        setChain("custom_chain", Chain("Custom Chain", 123456789, "https://custom.chain/"));
+        setChain("custom_chain", Chain("Custom Chain", 123456789, "", "https://custom.chain/"));
         assertEq(getChain(123456789).chainId, 123456789);
 
-        setChain("custom_chain", Chain("Modified Chain", 999999999, "https://modified.chain/"));
+        setChain("custom_chain", Chain("Modified Chain", 999999999, "", "https://modified.chain/"));
         vm.expectRevert("StdChains getChain(uint256): Chain with ID 123456789 not found.");
         getChain(123456789);
 

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -56,11 +56,11 @@ contract StdChainsTest is Test {
 
     function testSetChainFirstFails() public {
         vm.expectRevert("StdChains setChain(string,Chain): Chain ID 31337 already used by \"anvil\".");
-        setChain("anvil2", Chain("Anvil", 31337, "", "URL"));
+        setChain("anvil2", ChainData("Anvil", 31337, "URL"));
     }
 
     function testChainBubbleUp() public {
-        setChain("needs_undefined_env_var", Chain("", 123456789, "", ""));
+        setChain("needs_undefined_env_var", ChainData("", 123456789, ""));
         vm.expectRevert(
             "Failed to resolve env var `UNDEFINED_RPC_URL_PLACEHOLDER` in `${UNDEFINED_RPC_URL_PLACEHOLDER}`: environment variable not found"
         );
@@ -68,15 +68,15 @@ contract StdChainsTest is Test {
     }
 
     function testCannotSetChain_ChainIdExists() public {
-        setChain("custom_chain", Chain("Custom Chain", 123456789, "", "https://custom.chain/"));
+        setChain("custom_chain", ChainData("Custom Chain", 123456789, "https://custom.chain/"));
 
         vm.expectRevert('StdChains setChain(string,Chain): Chain ID 123456789 already used by "custom_chain".');
 
-        setChain("another_custom_chain", Chain("", 123456789, "", ""));
+        setChain("another_custom_chain", ChainData("", 123456789, ""));
     }
 
     function testSetChain() public {
-        setChain("custom_chain", Chain("Custom Chain", 123456789, "", "https://custom.chain/"));
+        setChain("custom_chain", ChainData("Custom Chain", 123456789, "https://custom.chain/"));
         Chain memory customChain = getChain("custom_chain");
         assertEq(customChain.name, "Custom Chain");
         assertEq(customChain.chainId, 123456789);
@@ -91,12 +91,12 @@ contract StdChainsTest is Test {
 
     function testSetNoEmptyAlias() public {
         vm.expectRevert("StdChains setChain(string,Chain): Chain alias cannot be the empty string.");
-        setChain("", Chain("", 123456789, "", ""));
+        setChain("", ChainData("", 123456789, ""));
     }
 
     function testSetNoChainId0() public {
         vm.expectRevert("StdChains setChain(string,Chain): Chain ID cannot be 0.");
-        setChain("alias", Chain("", 0, "", ""));
+        setChain("alias", ChainData("", 0, ""));
     }
 
     function testGetNoChainId0() public {
@@ -120,10 +120,10 @@ contract StdChainsTest is Test {
     }
 
     function testSetChain_ExistingOne() public {
-        setChain("custom_chain", Chain("Custom Chain", 123456789, "", "https://custom.chain/"));
+        setChain("custom_chain", ChainData("Custom Chain", 123456789, "https://custom.chain/"));
         assertEq(getChain(123456789).chainId, 123456789);
 
-        setChain("custom_chain", Chain("Modified Chain", 999999999, "", "https://modified.chain/"));
+        setChain("custom_chain", ChainData("Modified Chain", 999999999, "https://modified.chain/"));
         vm.expectRevert("StdChains getChain(uint256): Chain with ID 123456789 not found.");
         getChain(123456789);
 

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -55,7 +55,7 @@ contract StdChainsTest is Test {
     }
 
     function testSetChainFirstFails() public {
-        vm.expectRevert("StdChains setChain(string,Chain): Chain ID 31337 already used by \"anvil\".");
+        vm.expectRevert("StdChains setChain(string,ChainData): Chain ID 31337 already used by \"anvil\".");
         setChain("anvil2", ChainData("Anvil", 31337, "URL"));
     }
 
@@ -70,7 +70,7 @@ contract StdChainsTest is Test {
     function testCannotSetChain_ChainIdExists() public {
         setChain("custom_chain", ChainData("Custom Chain", 123456789, "https://custom.chain/"));
 
-        vm.expectRevert('StdChains setChain(string,Chain): Chain ID 123456789 already used by "custom_chain".');
+        vm.expectRevert('StdChains setChain(string,ChainData): Chain ID 123456789 already used by "custom_chain".');
 
         setChain("another_custom_chain", ChainData("", 123456789, ""));
     }
@@ -87,15 +87,27 @@ contract StdChainsTest is Test {
         assertEq(chainById.chainId, customChain.chainId);
         assertEq(chainById.chainAlias, customChain.chainAlias);
         assertEq(chainById.rpcUrl, customChain.rpcUrl);
+        customChain.name = "Another Custom Chain";
+        customChain.chainId = 987654321;
+        setChain("another_custom_chain", customChain);
+        Chain memory anotherCustomChain = getChain("another_custom_chain");
+        assertEq(anotherCustomChain.name, "Another Custom Chain");
+        assertEq(anotherCustomChain.chainId, 987654321);
+        assertEq(anotherCustomChain.chainAlias, "another_custom_chain");
+        assertEq(anotherCustomChain.rpcUrl, "https://custom.chain/");
+        // Verify the first chain data was not overwritten
+        chainById = getChain(123456789);
+        assertEq(chainById.name, "Custom Chain");
+        assertEq(chainById.chainId, 123456789);
     }
 
     function testSetNoEmptyAlias() public {
-        vm.expectRevert("StdChains setChain(string,Chain): Chain alias cannot be the empty string.");
+        vm.expectRevert("StdChains setChain(string,ChainData): Chain alias cannot be the empty string.");
         setChain("", ChainData("", 123456789, ""));
     }
 
     function testSetNoChainId0() public {
-        vm.expectRevert("StdChains setChain(string,Chain): Chain ID cannot be 0.");
+        vm.expectRevert("StdChains setChain(string,ChainData): Chain ID cannot be 0.");
         setChain("alias", ChainData("", 0, ""));
     }
 

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -12,12 +12,12 @@ contract StdChainsTest is Test {
 
         // Environment variables should be the next fallback
         assertEq(getChain("arbitrum_nova").rpcUrl, "https://nova.arbitrum.io/rpc");
-        vm.setEnv("RPC_URL_ARBITRUM_NOVA", "myoverride");
+        vm.setEnv("ARBITRUM_NOVA_RPC_URL", "myoverride");
         assertEq(getChain("arbitrum_nova").rpcUrl, "myoverride");
-        vm.setEnv("RPC_URL_ARBITRUM_NOVA", "https://nova.arbitrum.io/rpc");
+        vm.setEnv("ARBITRUM_NOVA_RPC_URL", "https://nova.arbitrum.io/rpc");
 
         // Cannot override RPCs defined in `foundry.toml`
-        vm.setEnv("RPC_URL_MAINNET", "myoverride2");
+        vm.setEnv("MAINNET_RPC_URL", "myoverride2");
         assertEq(getChain("mainnet").rpcUrl, "https://mainnet.infura.io/v3/7a8769b798b642f6933f2ed52042bd70");
 
         // Other RPCs should remain unchanged.


### PR DESCRIPTION
Ping @mds1

Two useful updates to the `StdChains`.

1. Adds the `chainAlias` to the`Chain` struct. We need access to this as the chain alias is useful for defining chain-specific stuff inside configuration json files such as:

```
{
    "domains": {
        "mainnet": {
            "chainlog": "0xdA0Ab1e0017DEbCd72Be8599041a2aa3bA7e740F"
        },
        "optimism": {
            "l1Messenger": "0x25ace71c97B33Cc4729CF772ae268934F7ab5fA1",
            "l2Messenger": "0x4200000000000000000000000000000000000007"
        },
        "arbitrum_one": {
            "inbox": "0x4Dbd4fc535Ac27206064B68FfCf827b0A60BAB3f",
            "arbSys": "0x0000000000000000000000000000000000000064"
        }
    }
}
```

This is nicer to define than using chain ids.

2. Allow automatic environment variable overrides via `ALIAS_RPC_URL`. For example a user can define `MAINNET_RPC_URL` to set the mainnet rpc url.

This saves having to repeat this pattern in all `foundry.toml` which will be common for us at least:

```
[rpc_endpoints]
mainnet = "${MAINNET_RPC_URL}"
goerli = "${GOERLI_RPC_URL}"
optimism = "${OPTIMISM_RPC_URL}"
... etc
```