### PR TITLE
feat: add "IMulticall3" interface

### DIFF
--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -122,7 +122,11 @@ abstract contract StdUtils {
         virtual
         returns (uint256[] memory balances)
     {
-        require(token.code.length > 0, "StdUtils getTokenBalances(address,address[]): Token address is not a contract.");
+        uint256 tokenCodeSize;
+        assembly {
+            tokenCodeSize := extcodesize(tokenCodeSize)
+        }
+        require(tokenCodeSize > 0, "StdUtils getTokenBalances(address,address[]): Token address is not a contract.");
 
         // ABI encode the aggregate call to Multicall3.
         uint256 length = addresses.length;

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.6.2 <0.9.0;
 
+pragma experimental ABIEncoderV2;
+
 import {IMulticall3} from "./interfaces/IMulticall3.sol";
 // TODO Remove import.
 import {VmSafe} from "./Vm.sol";
@@ -120,10 +122,7 @@ abstract contract StdUtils {
         uint256 length = addresses.length;
         IMulticall3.Call[] memory calls = new IMulticall3.Call[](length);
         for (uint256 i = 0; i < length; ++i) {
-            calls[i] = IMulticall3.Call({
-                target: token,
-                callData: abi.encodeWithSelector(0x70a08231, (addresses[i]))
-            });
+            calls[i] = IMulticall3.Call({target: token, callData: abi.encodeWithSelector(0x70a08231, (addresses[i]))});
         }
 
         // Make the aggregate call.
@@ -136,7 +135,7 @@ abstract contract StdUtils {
         }
     }
 
-        /*//////////////////////////////////////////////////////////////////////////
+    /*//////////////////////////////////////////////////////////////////////////
                                  PRIVATE FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -116,13 +116,9 @@ abstract contract StdUtils {
         return addressFromLast20Bytes(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, initcodeHash)));
     }
 
-    // Performs a single call with IMulticall3 to query the ERC-20 token balances of the given addresses.
-    function getTokenBalances(address token, address[] memory addresses)
-        internal
-        virtual
-        returns (uint256[] memory balances)
-    {
-        // ABI encode the aggregate call to IMulticall3.
+    // Performs a single call with Multicall3 to query the ERC-20 token balances of the given addresses.
+    function getTokenBalances(address token, address[] memory addresses) internal returns (uint256[] memory balances) {
+        // ABI encode the aggregate call to Multicall3.
         uint256 length = addresses.length;
         IMulticall3.Call[] memory calls = new IMulticall3.Call[](length);
         for (uint256 i = 0; i < length; ++i) {

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.6.2 <0.9.0;
 
 pragma experimental ABIEncoderV2;
 
-import {console2} from "./console2.sol";
 import {IMulticall3} from "./interfaces/IMulticall3.sol";
 // TODO Remove import.
 import {VmSafe} from "./Vm.sol";

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.6.2 <0.9.0;
 
 pragma experimental ABIEncoderV2;
 
+import {console2} from "./console2.sol";
 import {IMulticall3} from "./interfaces/IMulticall3.sol";
 // TODO Remove import.
 import {VmSafe} from "./Vm.sol";
@@ -122,10 +123,13 @@ abstract contract StdUtils {
         virtual
         returns (uint256[] memory balances)
     {
+        require(token.code.length > 0, "StdUtils getTokenBalances)address,address[]): Token address is not a contract.");
+
         // ABI encode the aggregate call to Multicall3.
         uint256 length = addresses.length;
         IMulticall3.Call[] memory calls = new IMulticall3.Call[](length);
         for (uint256 i = 0; i < length; ++i) {
+            // 0x70a08231 = bytes4("balanceOf(address)"))
             calls[i] = IMulticall3.Call({target: token, callData: abi.encodeWithSelector(0x70a08231, (addresses[i]))});
         }
 

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -124,7 +124,7 @@ abstract contract StdUtils {
     {
         uint256 tokenCodeSize;
         assembly {
-            tokenCodeSize := extcodesize(tokenCodeSize)
+            tokenCodeSize := extcodesize(token)
         }
         require(tokenCodeSize > 0, "StdUtils getTokenBalances(address,address[]): Token address is not a contract.");
 

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -122,7 +122,7 @@ abstract contract StdUtils {
         virtual
         returns (uint256[] memory balances)
     {
-        require(token.code.length > 0, "StdUtils getTokenBalances)address,address[]): Token address is not a contract.");
+        require(token.code.length > 0, "StdUtils getTokenBalances(address,address[]): Token address is not a contract.");
 
         // ABI encode the aggregate call to Multicall3.
         uint256 length = addresses.length;

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -1,17 +1,26 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.6.2 <0.9.0;
 
+import {IMulticall3} from "./interfaces/IMulticall3.sol";
 // TODO Remove import.
 import {VmSafe} from "./Vm.sol";
 
 abstract contract StdUtils {
+    /*//////////////////////////////////////////////////////////////////////////
+                                     CONSTANTS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    IMulticall3 private constant multicall = IMulticall3(0xcA11bde05977b3631167028862bE2a173976CA11);
     VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
     address private constant CONSOLE2_ADDRESS = 0x000000000000000000636F6e736F6c652e6c6f67;
-
     uint256 private constant INT256_MIN_ABS =
         57896044618658097711785492504343953926634992332820282019728792003956564819968;
     uint256 private constant UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                 INTERNAL FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
 
     function _bound(uint256 x, uint256 min, uint256 max) internal pure virtual returns (uint256 result) {
         require(min <= max, "StdUtils bound(uint256,uint256,uint256): Max is less than min.");
@@ -66,8 +75,13 @@ abstract contract StdUtils {
         console2_log("Bound result", vm.toString(result));
     }
 
+    function bytesToUint(bytes memory b) internal pure virtual returns (uint256) {
+        require(b.length <= 32, "StdUtils bytesToUint(bytes): Bytes length exceeds 32.");
+        return abi.decode(abi.encodePacked(new bytes(32 - b.length), b), (uint256));
+    }
+
     /// @dev Compute the address a contract will be deployed at for a given deployer address and nonce
-    /// @notice adapated from Solmate implementation (https://github.com/Rari-Capital/solmate/blob/main/src/utils/LibRLP.sol)
+    /// @notice adapted from Solmate implementation (https://github.com/Rari-Capital/solmate/blob/main/src/utils/LibRLP.sol)
     function computeCreateAddress(address deployer, uint256 nonce) internal pure virtual returns (address) {
         // forgefmt: disable-start
         // The integer zero is treated as an empty byte string, and as a result it only has a length prefix, 0x80, computed via 0x80 + 0.
@@ -100,10 +114,31 @@ abstract contract StdUtils {
         return addressFromLast20Bytes(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, initcodeHash)));
     }
 
-    function bytesToUint(bytes memory b) internal pure virtual returns (uint256) {
-        require(b.length <= 32, "StdUtils bytesToUint(bytes): Bytes length exceeds 32.");
-        return abi.decode(abi.encodePacked(new bytes(32 - b.length), b), (uint256));
+    // Performs a single call with Multicall3 to query the ERC-20 token balances of the given addresses.
+    function getTokenBalances(address token, address[] memory addresses) internal returns (uint256[] memory balances) {
+        // ABI encode the aggregate call to Multicall3.
+        uint256 length = addresses.length;
+        IMulticall3.Call[] memory calls = new IMulticall3.Call[](length);
+        for (uint256 i = 0; i < length; ++i) {
+            calls[i] = IMulticall3.Call({
+                target: token,
+                callData: abi.encodeWithSelector(0x70a08231, (addresses[i]))
+            });
+        }
+
+        // Make the aggregate call.
+        (, bytes[] memory returnData) = multicall.aggregate(calls);
+
+        // ABI decode the return data and return the balances.
+        balances = new uint256[](length);
+        for (uint256 i = 0; i < length; ++i) {
+            balances[i] = abi.decode(returnData[i], (uint256));
+        }
     }
+
+        /*//////////////////////////////////////////////////////////////////////////
+                                 PRIVATE FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
 
     function addressFromLast20Bytes(bytes32 bytesValue) private pure returns (address) {
         return address(uint160(uint256(bytesValue)));

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -117,7 +117,11 @@ abstract contract StdUtils {
     }
 
     // Performs a single call with Multicall3 to query the ERC-20 token balances of the given addresses.
-    function getTokenBalances(address token, address[] memory addresses) internal returns (uint256[] memory balances) {
+    function getTokenBalances(address token, address[] memory addresses)
+        internal
+        virtual
+        returns (uint256[] memory balances)
+    {
         // ABI encode the aggregate call to Multicall3.
         uint256 length = addresses.length;
         IMulticall3.Call[] memory calls = new IMulticall3.Call[](length);

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -116,9 +116,13 @@ abstract contract StdUtils {
         return addressFromLast20Bytes(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, initcodeHash)));
     }
 
-    // Performs a single call with Multicall3 to query the ERC-20 token balances of the given addresses.
-    function getTokenBalances(address token, address[] memory addresses) internal returns (uint256[] memory balances) {
-        // ABI encode the aggregate call to Multicall3.
+    // Performs a single call with IMulticall3 to query the ERC-20 token balances of the given addresses.
+    function getTokenBalances(address token, address[] memory addresses)
+        internal
+        virtual
+        returns (uint256[] memory balances)
+    {
+        // ABI encode the aggregate call to IMulticall3.
         uint256 length = addresses.length;
         IMulticall3.Call[] memory calls = new IMulticall3.Call[](length);
         for (uint256 i = 0; i < length; ++i) {

--- a/src/interfaces/IMulticall3.sol
+++ b/src/interfaces/IMulticall3.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.12 <0.9.0;
+
+interface IMulticall3 {
+    struct Call {
+        address target;
+        bytes callData;
+    }
+
+    struct Call3 {
+        address target;
+        bool allowFailure;
+        bytes callData;
+    }
+
+    struct Call3Value {
+        address target;
+        bool allowFailure;
+        uint256 value;
+        bytes callData;
+    }
+
+    struct Result {
+        bool success;
+        bytes returnData;
+    }
+
+    function aggregate(Call[] memory calls) external payable returns (uint256 blockNumber, bytes[] memory returnData);
+
+    function aggregate3(Call3[] memory calls) external payable returns (Result[] memory returnData);
+
+    function aggregate3Value(Call3Value[] memory calls) external payable returns (Result[] memory returnData);
+
+    function blockAndAggregate(
+        Call[] memory calls
+    ) external payable returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData);
+
+    function getBasefee() external view returns (uint256 basefee);
+
+    function getBlockHash(uint256 blockNumber) external view returns (bytes32 blockHash);
+
+    function getBlockNumber() external view returns (uint256 blockNumber);
+
+    function getChainId() external view returns (uint256 chainid);
+
+    function getCurrentBlockCoinbase() external view returns (address coinbase);
+
+    function getCurrentBlockDifficulty() external view returns (uint256 difficulty);
+
+    function getCurrentBlockGasLimit() external view returns (uint256 gaslimit);
+
+    function getCurrentBlockTimestamp() external view returns (uint256 timestamp);
+
+    function getEthBalance(address addr) external view returns (uint256 balance);
+
+    function getLastBlockHash() external view returns (bytes32 blockHash);
+
+    function tryAggregate(
+        bool requireSuccess,
+        Call[] memory calls
+    ) external payable returns (Result[] memory returnData);
+
+    function tryBlockAndAggregate(
+        bool requireSuccess,
+        Call[] memory calls
+    ) external payable returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData);
+}

--- a/src/interfaces/IMulticall3.sol
+++ b/src/interfaces/IMulticall3.sol
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.8.12 <0.9.0;
+pragma solidity >=0.6.2 <0.9.0;
+
+pragma experimental ABIEncoderV2;
 
 interface IMulticall3 {
     struct Call {
@@ -25,15 +27,19 @@ interface IMulticall3 {
         bytes returnData;
     }
 
-    function aggregate(Call[] memory calls) external payable returns (uint256 blockNumber, bytes[] memory returnData);
+    function aggregate(Call[] calldata calls)
+        external
+        payable
+        returns (uint256 blockNumber, bytes[] memory returnData);
 
-    function aggregate3(Call3[] memory calls) external payable returns (Result[] memory returnData);
+    function aggregate3(Call3[] calldata calls) external payable returns (Result[] memory returnData);
 
-    function aggregate3Value(Call3Value[] memory calls) external payable returns (Result[] memory returnData);
+    function aggregate3Value(Call3Value[] calldata calls) external payable returns (Result[] memory returnData);
 
-    function blockAndAggregate(
-        Call[] memory calls
-    ) external payable returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData);
+    function blockAndAggregate(Call[] calldata calls)
+        external
+        payable
+        returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData);
 
     function getBasefee() external view returns (uint256 basefee);
 
@@ -55,13 +61,13 @@ interface IMulticall3 {
 
     function getLastBlockHash() external view returns (bytes32 blockHash);
 
-    function tryAggregate(
-        bool requireSuccess,
-        Call[] memory calls
-    ) external payable returns (Result[] memory returnData);
+    function tryAggregate(bool requireSuccess, Call[] calldata calls)
+        external
+        payable
+        returns (Result[] memory returnData);
 
-    function tryBlockAndAggregate(
-        bool requireSuccess,
-        Call[] memory calls
-    ) external payable returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData);
+    function tryBlockAndAggregate(bool requireSuccess, Call[] calldata calls)
+        external
+        payable
+        returns (uint256 blockNumber, bytes32 blockHash, Result[] memory returnData);
 }

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -223,10 +223,17 @@ contract StdUtilsTest is Test {
                                   GET TOKEN BALANCES
     //////////////////////////////////////////////////////////////////////////*/
 
-    address internal USDC_HOLDER = 0xDa9CE944a37d218c3302F6B82a094844C6ECEb17;
+    address internal SHIB = 0x95aD61b0a150d79219dCF64E1E6Cc01f0B64C4cE;
+    address internal SHIB_HOLDER_0 = 0x855F5981e831D83e6A4b4EBFCAdAa68D92333170;
+    address internal SHIB_HOLDER_1 = 0x8F509A90c2e47779cA408Fe00d7A72e359229AdA;
+    address internal SHIB_HOLDER_2 = 0x0e3bbc0D04fF62211F71f3e4C45d82ad76224385;
+
+    address internal USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address internal USDC_HOLDER_0 = 0xDa9CE944a37d218c3302F6B82a094844C6ECEb17;
+    address internal USDC_HOLDER_1 = 0x3e67F4721E6d1c41a015f645eFa37BEd854fcf52;
 
     modifier forkMainnet() {
-        vm.createSelectFork({urlOrAlias: "mainnet", blockNumber: 16376000});
+        vm.createSelectFork({urlOrAlias: "mainnet", blockNumber: 16_428_900});
         _;
     }
 
@@ -238,9 +245,37 @@ contract StdUtilsTest is Test {
         // so the `balanceOf` call should revert.
         address token = address(0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f);
         address[] memory addresses = new address[](1);
-        addresses[0] = USDC_HOLDER;
+        addresses[0] = USDC_HOLDER_0;
 
         vm.expectRevert("Multicall3: call failed");
         stdUtils.getTokenBalances_(token, addresses);
+    }
+
+    function testCannotGetTokenBalances_EOA() external forkMainnet {
+        address eoa = vm.addr({privateKey: 1});
+        address[] memory addresses = new address[](1);
+        addresses[0] = USDC_HOLDER_0;
+        vm.expectRevert("StdUtils getTokenBalances)address,address[]): Token address is not a contract.");
+        getTokenBalances(eoa, addresses);
+    }
+
+    function testGetTokenBalances_USDC() external forkMainnet {
+        address[] memory addresses = new address[](2);
+        addresses[0] = USDC_HOLDER_0;
+        addresses[1] = USDC_HOLDER_1;
+        uint256[] memory balances = getTokenBalances(USDC, addresses);
+        assertEq(balances[0], 159_000_000_000_000);
+        assertEq(balances[1], 131_350_000_000_000);
+    }
+
+    function testGetTokenBalances_SHIB() external forkMainnet {
+        address[] memory addresses = new address[](3);
+        addresses[0] = SHIB_HOLDER_0;
+        addresses[1] = SHIB_HOLDER_1;
+        addresses[2] = SHIB_HOLDER_2;
+        uint256[] memory balances = getTokenBalances(SHIB, addresses);
+        assertEq(balances[0], 3_323_256_285_484.42e18);
+        assertEq(balances[1], 1_271_702_771_149.99999928e18);
+        assertEq(balances[2], 606_357_106_247e18);
     }
 }

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -1,88 +1,52 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
-import "../src/StdUtils.sol";
 import "../src/Test.sol";
 
-contract StdUtilsMock is StdUtils {
-    function bound_(uint256 x, uint256 min, uint256 max) external view returns (uint256 result) {
-        result = bound(x, min, max);
-    }
-
-    function bound_(int256 x, int256 min, int256 max) external view returns (int256 result) {
-        result = bound(x, min, max);
-    }
-
-    function bytesToUint_(bytes memory b) external pure returns (uint256) {
-        return bytesToUint(b);
-    }
-
-    function computeCreateAddress_(address deployer, uint256 nonce) external pure returns (address) {
-        return computeCreateAddress(deployer, nonce);
-    }
-
-    function computeCreate2Address_(bytes32 salt, bytes32 initcodeHash, address deployer)
-        external
-        pure
-        returns (address)
-    {
-        return computeCreate2Address(salt, initcodeHash, deployer);
-    }
-
-    function getTokenBalances_(address token, address[] memory addresses)
-        external
-        returns (uint256[] memory balances)
-    {
-        balances = getTokenBalances(token, addresses);
-    }
-}
-
 contract StdUtilsTest is Test {
-    StdUtilsMock internal utils = new StdUtilsMock();
-
     /*//////////////////////////////////////////////////////////////////////////
-                                    BOUND UINT
+                                     BOUND UINT
     //////////////////////////////////////////////////////////////////////////*/
 
     function testBound() public {
-        assertEq(utils.bound_(uint256(5), 0, 4), 0);
-        assertEq(utils.bound_(uint256(0), 69, 69), 69);
-        assertEq(utils.bound_(uint256(0), 68, 69), 68);
-        assertEq(utils.bound_(uint256(10), 150, 190), 174);
-        assertEq(utils.bound_(uint256(300), 2800, 3200), 3107);
-        assertEq(utils.bound_(uint256(9999), 1337, 6666), 4669);
+        assertEq(bound(uint256(5), 0, 4), 0);
+        assertEq(bound(uint256(0), 69, 69), 69);
+        assertEq(bound(uint256(0), 68, 69), 68);
+        assertEq(bound(uint256(10), 150, 190), 174);
+        assertEq(bound(uint256(300), 2800, 3200), 3107);
+        assertEq(bound(uint256(9999), 1337, 6666), 4669);
     }
 
     function testBound_WithinRange() public {
-        assertEq(utils.bound_(uint256(51), 50, 150), 51);
-        assertEq(utils.bound_(uint256(51), 50, 150), bound(utils.bound_(uint256(51), 50, 150), 50, 150));
-        assertEq(utils.bound_(uint256(149), 50, 150), 149);
-        assertEq(utils.bound_(uint256(149), 50, 150), bound(utils.bound_(uint256(149), 50, 150), 50, 150));
+        assertEq(bound(uint256(51), 50, 150), 51);
+        assertEq(bound(uint256(51), 50, 150), bound(bound(uint256(51), 50, 150), 50, 150));
+        assertEq(bound(uint256(149), 50, 150), 149);
+        assertEq(bound(uint256(149), 50, 150), bound(bound(uint256(149), 50, 150), 50, 150));
     }
 
     function testBound_EdgeCoverage() public {
-        assertEq(utils.bound_(uint256(0), 50, 150), 50);
-        assertEq(utils.bound_(uint256(1), 50, 150), 51);
-        assertEq(utils.bound_(uint256(2), 50, 150), 52);
-        assertEq(utils.bound_(uint256(3), 50, 150), 53);
-        assertEq(utils.bound_(type(uint256).max, 50, 150), 150);
-        assertEq(utils.bound_(type(uint256).max - 1, 50, 150), 149);
-        assertEq(utils.bound_(type(uint256).max - 2, 50, 150), 148);
-        assertEq(utils.bound_(type(uint256).max - 3, 50, 150), 147);
+        assertEq(bound(uint256(0), 50, 150), 50);
+        assertEq(bound(uint256(1), 50, 150), 51);
+        assertEq(bound(uint256(2), 50, 150), 52);
+        assertEq(bound(uint256(3), 50, 150), 53);
+        assertEq(bound(type(uint256).max, 50, 150), 150);
+        assertEq(bound(type(uint256).max - 1, 50, 150), 149);
+        assertEq(bound(type(uint256).max - 2, 50, 150), 148);
+        assertEq(bound(type(uint256).max - 3, 50, 150), 147);
     }
 
     function testBound_DistributionIsEven(uint256 min, uint256 size) public {
         size = size % 100 + 1;
-        min = utils.bound_(min, UINT256_MAX / 2, UINT256_MAX / 2 + size);
+        min = bound(min, UINT256_MAX / 2, UINT256_MAX / 2 + size);
         uint256 max = min + size - 1;
         uint256 result;
 
         for (uint256 i = 1; i <= size * 4; ++i) {
             // x > max
-            result = utils.bound_(max + i, min, max);
+            result = bound(max + i, min, max);
             assertEq(result, min + (i - 1) % size);
             // x < min
-            result = utils.bound_(min - i, min, max);
+            result = bound(min - i, min, max);
             assertEq(result, max - (i - 1) % size);
         }
     }
@@ -90,82 +54,82 @@ contract StdUtilsTest is Test {
     function testBound(uint256 num, uint256 min, uint256 max) public {
         if (min > max) (min, max) = (max, min);
 
-        uint256 result = utils.bound_(num, min, max);
+        uint256 result = bound(num, min, max);
 
         assertGe(result, min);
         assertLe(result, max);
-        assertEq(result, utils.bound_(result, min, max));
+        assertEq(result, bound(result, min, max));
         if (num >= min && num <= max) assertEq(result, num);
     }
 
     function testBoundUint256Max() public {
-        assertEq(utils.bound_(0, type(uint256).max - 1, type(uint256).max), type(uint256).max - 1);
-        assertEq(utils.bound_(1, type(uint256).max - 1, type(uint256).max), type(uint256).max);
+        assertEq(bound(0, type(uint256).max - 1, type(uint256).max), type(uint256).max - 1);
+        assertEq(bound(1, type(uint256).max - 1, type(uint256).max), type(uint256).max);
     }
 
     function testCannotBoundMaxLessThanMin() public {
         vm.expectRevert(bytes("StdUtils bound(uint256,uint256,uint256): Max is less than min."));
-        utils.bound_(uint256(5), 100, 10);
+        bound(uint256(5), 100, 10);
     }
 
     function testCannotBoundMaxLessThanMin(uint256 num, uint256 min, uint256 max) public {
         vm.assume(min > max);
         vm.expectRevert(bytes("StdUtils bound(uint256,uint256,uint256): Max is less than min."));
-        utils.bound_(num, min, max);
+        bound(num, min, max);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-                                      BOUND INT
+                                     BOUND INT
     //////////////////////////////////////////////////////////////////////////*/
 
     function testBoundInt() public {
-        assertEq(utils.bound_(-3, 0, 4), 2);
-        assertEq(utils.bound_(0, -69, -69), -69);
-        assertEq(utils.bound_(0, -69, -68), -68);
-        assertEq(utils.bound_(-10, 150, 190), 154);
-        assertEq(utils.bound_(-300, 2800, 3200), 2908);
-        assertEq(utils.bound_(9999, -1337, 6666), 1995);
+        assertEq(bound(-3, 0, 4), 2);
+        assertEq(bound(0, -69, -69), -69);
+        assertEq(bound(0, -69, -68), -68);
+        assertEq(bound(-10, 150, 190), 154);
+        assertEq(bound(-300, 2800, 3200), 2908);
+        assertEq(bound(9999, -1337, 6666), 1995);
     }
 
     function testBoundInt_WithinRange() public {
-        assertEq(utils.bound_(51, -50, 150), 51);
-        assertEq(utils.bound_(51, -50, 150), bound(utils.bound_(51, -50, 150), -50, 150));
-        assertEq(utils.bound_(149, -50, 150), 149);
-        assertEq(utils.bound_(149, -50, 150), bound(utils.bound_(149, -50, 150), -50, 150));
+        assertEq(bound(51, -50, 150), 51);
+        assertEq(bound(51, -50, 150), bound(bound(51, -50, 150), -50, 150));
+        assertEq(bound(149, -50, 150), 149);
+        assertEq(bound(149, -50, 150), bound(bound(149, -50, 150), -50, 150));
     }
 
     function testBoundInt_EdgeCoverage() public {
-        assertEq(utils.bound_(type(int256).min, -50, 150), -50);
-        assertEq(utils.bound_(type(int256).min + 1, -50, 150), -49);
-        assertEq(utils.bound_(type(int256).min + 2, -50, 150), -48);
-        assertEq(utils.bound_(type(int256).min + 3, -50, 150), -47);
-        assertEq(utils.bound_(type(int256).min, 10, 150), 10);
-        assertEq(utils.bound_(type(int256).min + 1, 10, 150), 11);
-        assertEq(utils.bound_(type(int256).min + 2, 10, 150), 12);
-        assertEq(utils.bound_(type(int256).min + 3, 10, 150), 13);
+        assertEq(bound(type(int256).min, -50, 150), -50);
+        assertEq(bound(type(int256).min + 1, -50, 150), -49);
+        assertEq(bound(type(int256).min + 2, -50, 150), -48);
+        assertEq(bound(type(int256).min + 3, -50, 150), -47);
+        assertEq(bound(type(int256).min, 10, 150), 10);
+        assertEq(bound(type(int256).min + 1, 10, 150), 11);
+        assertEq(bound(type(int256).min + 2, 10, 150), 12);
+        assertEq(bound(type(int256).min + 3, 10, 150), 13);
 
-        assertEq(utils.bound_(type(int256).max, -50, 150), 150);
-        assertEq(utils.bound_(type(int256).max - 1, -50, 150), 149);
-        assertEq(utils.bound_(type(int256).max - 2, -50, 150), 148);
-        assertEq(utils.bound_(type(int256).max - 3, -50, 150), 147);
-        assertEq(utils.bound_(type(int256).max, -50, -10), -10);
-        assertEq(utils.bound_(type(int256).max - 1, -50, -10), -11);
-        assertEq(utils.bound_(type(int256).max - 2, -50, -10), -12);
-        assertEq(utils.bound_(type(int256).max - 3, -50, -10), -13);
+        assertEq(bound(type(int256).max, -50, 150), 150);
+        assertEq(bound(type(int256).max - 1, -50, 150), 149);
+        assertEq(bound(type(int256).max - 2, -50, 150), 148);
+        assertEq(bound(type(int256).max - 3, -50, 150), 147);
+        assertEq(bound(type(int256).max, -50, -10), -10);
+        assertEq(bound(type(int256).max - 1, -50, -10), -11);
+        assertEq(bound(type(int256).max - 2, -50, -10), -12);
+        assertEq(bound(type(int256).max - 3, -50, -10), -13);
     }
 
     function testBoundInt_DistributionIsEven(int256 min, uint256 size) public {
         size = size % 100 + 1;
-        min = utils.bound_(min, -int256(size / 2), int256(size - size / 2));
+        min = bound(min, -int256(size / 2), int256(size - size / 2));
         int256 max = min + int256(size) - 1;
         int256 result;
 
         for (uint256 i = 1; i <= size * 4; ++i) {
             // x > max
-            result = utils.bound_(max + int256(i), min, max);
+            result = bound(max + int256(i), min, max);
             assertEq(result, min + int256((i - 1) % size));
             // x < min
-            result = utils.bound_(min - int256(i), min, max);
+            result = bound(min - int256(i), min, max);
             assertEq(result, max - int256((i - 1) % size));
         }
     }
@@ -173,22 +137,22 @@ contract StdUtilsTest is Test {
     function testBoundInt(int256 num, int256 min, int256 max) public {
         if (min > max) (min, max) = (max, min);
 
-        int256 result = utils.bound_(num, min, max);
+        int256 result = bound(num, min, max);
 
         assertGe(result, min);
         assertLe(result, max);
-        assertEq(result, utils.bound_(result, min, max));
+        assertEq(result, bound(result, min, max));
         if (num >= min && num <= max) assertEq(result, num);
     }
 
     function testBoundIntInt256Max() public {
-        assertEq(utils.bound_(0, type(int256).max - 1, type(int256).max), type(int256).max - 1);
-        assertEq(utils.bound_(1, type(int256).max - 1, type(int256).max), type(int256).max);
+        assertEq(bound(0, type(int256).max - 1, type(int256).max), type(int256).max - 1);
+        assertEq(bound(1, type(int256).max - 1, type(int256).max), type(int256).max);
     }
 
     function testBoundIntInt256Min() public {
-        assertEq(utils.bound_(0, type(int256).min, type(int256).min + 1), type(int256).min);
-        assertEq(utils.bound_(1, type(int256).min, type(int256).min + 1), type(int256).min + 1);
+        assertEq(bound(0, type(int256).min, type(int256).min + 1), type(int256).min);
+        assertEq(bound(1, type(int256).min, type(int256).min + 1), type(int256).min + 1);
     }
 
     function testCannotBoundIntMaxLessThanMin() public {
@@ -203,7 +167,7 @@ contract StdUtilsTest is Test {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-                                    BYTES TO UINT
+                                   BYTES TO UINT
     //////////////////////////////////////////////////////////////////////////*/
 
     function testBytesToUint() external {
@@ -211,57 +175,37 @@ contract StdUtilsTest is Test {
         bytes memory two = hex"02";
         bytes memory millionEther = hex"d3c21bcecceda1000000";
 
-        assertEq(utils.bytesToUint_(maxUint), type(uint256).max);
-        assertEq(utils.bytesToUint_(two), 2);
-        assertEq(utils.bytesToUint_(millionEther), 1_000_000 ether);
+        assertEq(bytesToUint(maxUint), type(uint256).max);
+        assertEq(bytesToUint(two), 2);
+        assertEq(bytesToUint(millionEther), 1_000_000 ether);
     }
 
     function testCannotConvertGT32Bytes() external {
         bytes memory thirty3Bytes = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
         vm.expectRevert("StdUtils bytesToUint(bytes): Bytes length exceeds 32.");
-        utils.bytesToUint_(thirty3Bytes);
+        bytesToUint(thirty3Bytes);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-                                COMPUTE CREATE ADDRESS
+                               COMPUTE CREATE ADDRESS
     //////////////////////////////////////////////////////////////////////////*/
 
     function testComputeCreateAddress() external {
         address deployer = 0x6C9FC64A53c1b71FB3f9Af64d1ae3A4931A5f4E9;
         uint256 nonce = 14;
-        address createAddress = utils.computeCreateAddress_(deployer, nonce);
+        address createAddress = computeCreateAddress(deployer, nonce);
         assertEq(createAddress, 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-                                COMPUTE CREATE2 ADDRESS
+                              COMPUTE CREATE2 ADDRESS
     //////////////////////////////////////////////////////////////////////////*/
 
     function testComputeCreate2Address() external {
         bytes32 salt = bytes32(uint256(31415));
         bytes32 initcodeHash = keccak256(abi.encode(0x6080));
         address deployer = 0x6C9FC64A53c1b71FB3f9Af64d1ae3A4931A5f4E9;
-        address create2Address = utils.computeCreate2Address_(salt, initcodeHash, deployer);
+        address create2Address = computeCreate2Address(salt, initcodeHash, deployer);
         assertEq(create2Address, 0xB147a5d25748fda14b463EB04B111027C290f4d3);
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                  GET TOKEN BALANCES
-    //////////////////////////////////////////////////////////////////////////*/
-
-    address internal USDC_HOLDER = 0xDa9CE944a37d218c3302F6B82a094844C6ECEb17;
-
-    modifier forkMainnet() {
-        vm.createSelectFork({urlOrAlias: "mainnet", blockNumber: 16376000});
-        _;
-    }
-
-    function testCannotGetTokenBalances_NonTokenContract() external forkMainnet {
-        // The UniswapV2Factory contract has neither a "balanceOf" function nor a fallback function.
-        address token = address(0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f);
-        address[] memory addresses = new address[](1);
-        addresses[0] = USDC_HOLDER;
-        vm.expectRevert();
-        utils.getTokenBalances_(token, addresses);
     }
 }

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -218,7 +218,9 @@ contract StdUtilsTest is Test {
         address create2Address = computeCreate2Address(salt, initcodeHash, deployer);
         assertEq(create2Address, 0xB147a5d25748fda14b463EB04B111027C290f4d3);
     }
+}
 
+contract StdUtilsForkTest is Test {
     /*//////////////////////////////////////////////////////////////////////////
                                   GET TOKEN BALANCES
     //////////////////////////////////////////////////////////////////////////*/
@@ -232,12 +234,11 @@ contract StdUtilsTest is Test {
     address internal USDC_HOLDER_0 = 0xDa9CE944a37d218c3302F6B82a094844C6ECEb17;
     address internal USDC_HOLDER_1 = 0x3e67F4721E6d1c41a015f645eFa37BEd854fcf52;
 
-    modifier forkMainnet() {
+    function setUp() public {
         vm.createSelectFork({urlOrAlias: "mainnet", blockNumber: 16_428_900});
-        _;
     }
 
-    function testCannotGetTokenBalances_NonTokenContract() external forkMainnet {
+    function testCannotGetTokenBalances_NonTokenContract() external {
         // We deploy a mock version so we can properly test the revert.
         StdUtilsMock stdUtils = new StdUtilsMock();
 
@@ -251,7 +252,7 @@ contract StdUtilsTest is Test {
         stdUtils.getTokenBalances_(token, addresses);
     }
 
-    function testCannotGetTokenBalances_EOA() external forkMainnet {
+    function testCannotGetTokenBalances_EOA() external {
         address eoa = vm.addr({privateKey: 1});
         address[] memory addresses = new address[](1);
         addresses[0] = USDC_HOLDER_0;
@@ -259,13 +260,13 @@ contract StdUtilsTest is Test {
         getTokenBalances(eoa, addresses);
     }
 
-    function testGetTokenBalances_Empty() external forkMainnet {
+    function testGetTokenBalances_Empty() external {
         address[] memory addresses = new address[](0);
         uint256[] memory balances = getTokenBalances(USDC, addresses);
         assertEq(balances.length, 0);
     }
 
-    function testGetTokenBalances_USDC() external forkMainnet {
+    function testGetTokenBalances_USDC() external {
         address[] memory addresses = new address[](2);
         addresses[0] = USDC_HOLDER_0;
         addresses[1] = USDC_HOLDER_1;
@@ -274,7 +275,7 @@ contract StdUtilsTest is Test {
         assertEq(balances[1], 131_350_000_000_000);
     }
 
-    function testGetTokenBalances_SHIB() external forkMainnet {
+    function testGetTokenBalances_SHIB() external {
         address[] memory addresses = new address[](3);
         addresses[0] = SHIB_HOLDER_0;
         addresses[1] = SHIB_HOLDER_1;

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -259,6 +259,12 @@ contract StdUtilsTest is Test {
         getTokenBalances(eoa, addresses);
     }
 
+    function testGetTokenBalances_Empty() external forkMainnet {
+        address[] memory addresses = new address[](0);
+        uint256[] memory balances = getTokenBalances(USDC, addresses);
+        assertEq(balances.length, 0);
+    }
+
     function testGetTokenBalances_USDC() external forkMainnet {
         address[] memory addresses = new address[](2);
         addresses[0] = USDC_HOLDER_0;

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -1,52 +1,88 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
+import "../src/StdUtils.sol";
 import "../src/Test.sol";
 
+contract StdUtilsMock is StdUtils {
+    function bound_(uint256 x, uint256 min, uint256 max) external view returns (uint256 result) {
+        result = bound(x, min, max);
+    }
+
+    function bound_(int256 x, int256 min, int256 max) external view returns (int256 result) {
+        result = bound(x, min, max);
+    }
+
+    function bytesToUint_(bytes memory b) external pure returns (uint256) {
+        return bytesToUint(b);
+    }
+
+    function computeCreateAddress_(address deployer, uint256 nonce) external pure returns (address) {
+        return computeCreateAddress(deployer, nonce);
+    }
+
+    function computeCreate2Address_(bytes32 salt, bytes32 initcodeHash, address deployer)
+        external
+        pure
+        returns (address)
+    {
+        return computeCreate2Address(salt, initcodeHash, deployer);
+    }
+
+    function getTokenBalances_(address token, address[] memory addresses)
+        external
+        returns (uint256[] memory balances)
+    {
+        balances = getTokenBalances(token, addresses);
+    }
+}
+
 contract StdUtilsTest is Test {
+    StdUtilsMock internal utils = new StdUtilsMock();
+
     /*//////////////////////////////////////////////////////////////////////////
-                                     BOUND UINT
+                                    BOUND UINT
     //////////////////////////////////////////////////////////////////////////*/
 
     function testBound() public {
-        assertEq(bound(uint256(5), 0, 4), 0);
-        assertEq(bound(uint256(0), 69, 69), 69);
-        assertEq(bound(uint256(0), 68, 69), 68);
-        assertEq(bound(uint256(10), 150, 190), 174);
-        assertEq(bound(uint256(300), 2800, 3200), 3107);
-        assertEq(bound(uint256(9999), 1337, 6666), 4669);
+        assertEq(utils.bound_(uint256(5), 0, 4), 0);
+        assertEq(utils.bound_(uint256(0), 69, 69), 69);
+        assertEq(utils.bound_(uint256(0), 68, 69), 68);
+        assertEq(utils.bound_(uint256(10), 150, 190), 174);
+        assertEq(utils.bound_(uint256(300), 2800, 3200), 3107);
+        assertEq(utils.bound_(uint256(9999), 1337, 6666), 4669);
     }
 
     function testBound_WithinRange() public {
-        assertEq(bound(uint256(51), 50, 150), 51);
-        assertEq(bound(uint256(51), 50, 150), bound(bound(uint256(51), 50, 150), 50, 150));
-        assertEq(bound(uint256(149), 50, 150), 149);
-        assertEq(bound(uint256(149), 50, 150), bound(bound(uint256(149), 50, 150), 50, 150));
+        assertEq(utils.bound_(uint256(51), 50, 150), 51);
+        assertEq(utils.bound_(uint256(51), 50, 150), bound(utils.bound_(uint256(51), 50, 150), 50, 150));
+        assertEq(utils.bound_(uint256(149), 50, 150), 149);
+        assertEq(utils.bound_(uint256(149), 50, 150), bound(utils.bound_(uint256(149), 50, 150), 50, 150));
     }
 
     function testBound_EdgeCoverage() public {
-        assertEq(bound(uint256(0), 50, 150), 50);
-        assertEq(bound(uint256(1), 50, 150), 51);
-        assertEq(bound(uint256(2), 50, 150), 52);
-        assertEq(bound(uint256(3), 50, 150), 53);
-        assertEq(bound(type(uint256).max, 50, 150), 150);
-        assertEq(bound(type(uint256).max - 1, 50, 150), 149);
-        assertEq(bound(type(uint256).max - 2, 50, 150), 148);
-        assertEq(bound(type(uint256).max - 3, 50, 150), 147);
+        assertEq(utils.bound_(uint256(0), 50, 150), 50);
+        assertEq(utils.bound_(uint256(1), 50, 150), 51);
+        assertEq(utils.bound_(uint256(2), 50, 150), 52);
+        assertEq(utils.bound_(uint256(3), 50, 150), 53);
+        assertEq(utils.bound_(type(uint256).max, 50, 150), 150);
+        assertEq(utils.bound_(type(uint256).max - 1, 50, 150), 149);
+        assertEq(utils.bound_(type(uint256).max - 2, 50, 150), 148);
+        assertEq(utils.bound_(type(uint256).max - 3, 50, 150), 147);
     }
 
     function testBound_DistributionIsEven(uint256 min, uint256 size) public {
         size = size % 100 + 1;
-        min = bound(min, UINT256_MAX / 2, UINT256_MAX / 2 + size);
+        min = utils.bound_(min, UINT256_MAX / 2, UINT256_MAX / 2 + size);
         uint256 max = min + size - 1;
         uint256 result;
 
         for (uint256 i = 1; i <= size * 4; ++i) {
             // x > max
-            result = bound(max + i, min, max);
+            result = utils.bound_(max + i, min, max);
             assertEq(result, min + (i - 1) % size);
             // x < min
-            result = bound(min - i, min, max);
+            result = utils.bound_(min - i, min, max);
             assertEq(result, max - (i - 1) % size);
         }
     }
@@ -54,82 +90,82 @@ contract StdUtilsTest is Test {
     function testBound(uint256 num, uint256 min, uint256 max) public {
         if (min > max) (min, max) = (max, min);
 
-        uint256 result = bound(num, min, max);
+        uint256 result = utils.bound_(num, min, max);
 
         assertGe(result, min);
         assertLe(result, max);
-        assertEq(result, bound(result, min, max));
+        assertEq(result, utils.bound_(result, min, max));
         if (num >= min && num <= max) assertEq(result, num);
     }
 
     function testBoundUint256Max() public {
-        assertEq(bound(0, type(uint256).max - 1, type(uint256).max), type(uint256).max - 1);
-        assertEq(bound(1, type(uint256).max - 1, type(uint256).max), type(uint256).max);
+        assertEq(utils.bound_(0, type(uint256).max - 1, type(uint256).max), type(uint256).max - 1);
+        assertEq(utils.bound_(1, type(uint256).max - 1, type(uint256).max), type(uint256).max);
     }
 
     function testCannotBoundMaxLessThanMin() public {
         vm.expectRevert(bytes("StdUtils bound(uint256,uint256,uint256): Max is less than min."));
-        bound(uint256(5), 100, 10);
+        utils.bound_(uint256(5), 100, 10);
     }
 
     function testCannotBoundMaxLessThanMin(uint256 num, uint256 min, uint256 max) public {
         vm.assume(min > max);
         vm.expectRevert(bytes("StdUtils bound(uint256,uint256,uint256): Max is less than min."));
-        bound(num, min, max);
+        utils.bound_(num, min, max);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-                                     BOUND INT
+                                      BOUND INT
     //////////////////////////////////////////////////////////////////////////*/
 
     function testBoundInt() public {
-        assertEq(bound(-3, 0, 4), 2);
-        assertEq(bound(0, -69, -69), -69);
-        assertEq(bound(0, -69, -68), -68);
-        assertEq(bound(-10, 150, 190), 154);
-        assertEq(bound(-300, 2800, 3200), 2908);
-        assertEq(bound(9999, -1337, 6666), 1995);
+        assertEq(utils.bound_(-3, 0, 4), 2);
+        assertEq(utils.bound_(0, -69, -69), -69);
+        assertEq(utils.bound_(0, -69, -68), -68);
+        assertEq(utils.bound_(-10, 150, 190), 154);
+        assertEq(utils.bound_(-300, 2800, 3200), 2908);
+        assertEq(utils.bound_(9999, -1337, 6666), 1995);
     }
 
     function testBoundInt_WithinRange() public {
-        assertEq(bound(51, -50, 150), 51);
-        assertEq(bound(51, -50, 150), bound(bound(51, -50, 150), -50, 150));
-        assertEq(bound(149, -50, 150), 149);
-        assertEq(bound(149, -50, 150), bound(bound(149, -50, 150), -50, 150));
+        assertEq(utils.bound_(51, -50, 150), 51);
+        assertEq(utils.bound_(51, -50, 150), bound(utils.bound_(51, -50, 150), -50, 150));
+        assertEq(utils.bound_(149, -50, 150), 149);
+        assertEq(utils.bound_(149, -50, 150), bound(utils.bound_(149, -50, 150), -50, 150));
     }
 
     function testBoundInt_EdgeCoverage() public {
-        assertEq(bound(type(int256).min, -50, 150), -50);
-        assertEq(bound(type(int256).min + 1, -50, 150), -49);
-        assertEq(bound(type(int256).min + 2, -50, 150), -48);
-        assertEq(bound(type(int256).min + 3, -50, 150), -47);
-        assertEq(bound(type(int256).min, 10, 150), 10);
-        assertEq(bound(type(int256).min + 1, 10, 150), 11);
-        assertEq(bound(type(int256).min + 2, 10, 150), 12);
-        assertEq(bound(type(int256).min + 3, 10, 150), 13);
+        assertEq(utils.bound_(type(int256).min, -50, 150), -50);
+        assertEq(utils.bound_(type(int256).min + 1, -50, 150), -49);
+        assertEq(utils.bound_(type(int256).min + 2, -50, 150), -48);
+        assertEq(utils.bound_(type(int256).min + 3, -50, 150), -47);
+        assertEq(utils.bound_(type(int256).min, 10, 150), 10);
+        assertEq(utils.bound_(type(int256).min + 1, 10, 150), 11);
+        assertEq(utils.bound_(type(int256).min + 2, 10, 150), 12);
+        assertEq(utils.bound_(type(int256).min + 3, 10, 150), 13);
 
-        assertEq(bound(type(int256).max, -50, 150), 150);
-        assertEq(bound(type(int256).max - 1, -50, 150), 149);
-        assertEq(bound(type(int256).max - 2, -50, 150), 148);
-        assertEq(bound(type(int256).max - 3, -50, 150), 147);
-        assertEq(bound(type(int256).max, -50, -10), -10);
-        assertEq(bound(type(int256).max - 1, -50, -10), -11);
-        assertEq(bound(type(int256).max - 2, -50, -10), -12);
-        assertEq(bound(type(int256).max - 3, -50, -10), -13);
+        assertEq(utils.bound_(type(int256).max, -50, 150), 150);
+        assertEq(utils.bound_(type(int256).max - 1, -50, 150), 149);
+        assertEq(utils.bound_(type(int256).max - 2, -50, 150), 148);
+        assertEq(utils.bound_(type(int256).max - 3, -50, 150), 147);
+        assertEq(utils.bound_(type(int256).max, -50, -10), -10);
+        assertEq(utils.bound_(type(int256).max - 1, -50, -10), -11);
+        assertEq(utils.bound_(type(int256).max - 2, -50, -10), -12);
+        assertEq(utils.bound_(type(int256).max - 3, -50, -10), -13);
     }
 
     function testBoundInt_DistributionIsEven(int256 min, uint256 size) public {
         size = size % 100 + 1;
-        min = bound(min, -int256(size / 2), int256(size - size / 2));
+        min = utils.bound_(min, -int256(size / 2), int256(size - size / 2));
         int256 max = min + int256(size) - 1;
         int256 result;
 
         for (uint256 i = 1; i <= size * 4; ++i) {
             // x > max
-            result = bound(max + int256(i), min, max);
+            result = utils.bound_(max + int256(i), min, max);
             assertEq(result, min + int256((i - 1) % size));
             // x < min
-            result = bound(min - int256(i), min, max);
+            result = utils.bound_(min - int256(i), min, max);
             assertEq(result, max - int256((i - 1) % size));
         }
     }
@@ -137,22 +173,22 @@ contract StdUtilsTest is Test {
     function testBoundInt(int256 num, int256 min, int256 max) public {
         if (min > max) (min, max) = (max, min);
 
-        int256 result = bound(num, min, max);
+        int256 result = utils.bound_(num, min, max);
 
         assertGe(result, min);
         assertLe(result, max);
-        assertEq(result, bound(result, min, max));
+        assertEq(result, utils.bound_(result, min, max));
         if (num >= min && num <= max) assertEq(result, num);
     }
 
     function testBoundIntInt256Max() public {
-        assertEq(bound(0, type(int256).max - 1, type(int256).max), type(int256).max - 1);
-        assertEq(bound(1, type(int256).max - 1, type(int256).max), type(int256).max);
+        assertEq(utils.bound_(0, type(int256).max - 1, type(int256).max), type(int256).max - 1);
+        assertEq(utils.bound_(1, type(int256).max - 1, type(int256).max), type(int256).max);
     }
 
     function testBoundIntInt256Min() public {
-        assertEq(bound(0, type(int256).min, type(int256).min + 1), type(int256).min);
-        assertEq(bound(1, type(int256).min, type(int256).min + 1), type(int256).min + 1);
+        assertEq(utils.bound_(0, type(int256).min, type(int256).min + 1), type(int256).min);
+        assertEq(utils.bound_(1, type(int256).min, type(int256).min + 1), type(int256).min + 1);
     }
 
     function testCannotBoundIntMaxLessThanMin() public {
@@ -167,7 +203,7 @@ contract StdUtilsTest is Test {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-                                   BYTES TO UINT
+                                    BYTES TO UINT
     //////////////////////////////////////////////////////////////////////////*/
 
     function testBytesToUint() external {
@@ -175,37 +211,57 @@ contract StdUtilsTest is Test {
         bytes memory two = hex"02";
         bytes memory millionEther = hex"d3c21bcecceda1000000";
 
-        assertEq(bytesToUint(maxUint), type(uint256).max);
-        assertEq(bytesToUint(two), 2);
-        assertEq(bytesToUint(millionEther), 1_000_000 ether);
+        assertEq(utils.bytesToUint_(maxUint), type(uint256).max);
+        assertEq(utils.bytesToUint_(two), 2);
+        assertEq(utils.bytesToUint_(millionEther), 1_000_000 ether);
     }
 
     function testCannotConvertGT32Bytes() external {
         bytes memory thirty3Bytes = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
         vm.expectRevert("StdUtils bytesToUint(bytes): Bytes length exceeds 32.");
-        bytesToUint(thirty3Bytes);
+        utils.bytesToUint_(thirty3Bytes);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-                               COMPUTE CREATE ADDRESS
+                                COMPUTE CREATE ADDRESS
     //////////////////////////////////////////////////////////////////////////*/
 
     function testComputeCreateAddress() external {
         address deployer = 0x6C9FC64A53c1b71FB3f9Af64d1ae3A4931A5f4E9;
         uint256 nonce = 14;
-        address createAddress = computeCreateAddress(deployer, nonce);
+        address createAddress = utils.computeCreateAddress_(deployer, nonce);
         assertEq(createAddress, 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
-                              COMPUTE CREATE2 ADDRESS
+                                COMPUTE CREATE2 ADDRESS
     //////////////////////////////////////////////////////////////////////////*/
 
     function testComputeCreate2Address() external {
         bytes32 salt = bytes32(uint256(31415));
         bytes32 initcodeHash = keccak256(abi.encode(0x6080));
         address deployer = 0x6C9FC64A53c1b71FB3f9Af64d1ae3A4931A5f4E9;
-        address create2Address = computeCreate2Address(salt, initcodeHash, deployer);
+        address create2Address = utils.computeCreate2Address_(salt, initcodeHash, deployer);
         assertEq(create2Address, 0xB147a5d25748fda14b463EB04B111027C290f4d3);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                  GET TOKEN BALANCES
+    //////////////////////////////////////////////////////////////////////////*/
+
+    address internal USDC_HOLDER = 0xDa9CE944a37d218c3302F6B82a094844C6ECEb17;
+
+    modifier forkMainnet() {
+        vm.createSelectFork({urlOrAlias: "mainnet", blockNumber: 16376000});
+        _;
+    }
+
+    function testCannotGetTokenBalances_NonTokenContract() external forkMainnet {
+        // The UniswapV2Factory contract has neither a "balanceOf" function nor a fallback function.
+        address token = address(0x5C69bEe701ef814a2B6a3EDD4B1652CB9cc5aA6f);
+        address[] memory addresses = new address[](1);
+        addresses[0] = USDC_HOLDER;
+        vm.expectRevert();
+        utils.getTokenBalances_(token, addresses);
     }
 }

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -255,7 +255,7 @@ contract StdUtilsTest is Test {
         address eoa = vm.addr({privateKey: 1});
         address[] memory addresses = new address[](1);
         addresses[0] = USDC_HOLDER_0;
-        vm.expectRevert("StdUtils getTokenBalances)address,address[]): Token address is not a contract.");
+        vm.expectRevert("StdUtils getTokenBalances(address,address[]): Token address is not a contract.");
         getTokenBalances(eoa, addresses);
     }
 

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -4,6 +4,10 @@ pragma solidity >=0.7.0 <0.9.0;
 import "../src/Test.sol";
 
 contract StdUtilsTest is Test {
+    /*//////////////////////////////////////////////////////////////////////////
+                                     BOUND UINT
+    //////////////////////////////////////////////////////////////////////////*/
+
     function testBound() public {
         assertEq(bound(uint256(5), 0, 4), 0);
         assertEq(bound(uint256(0), 69, 69), 69);
@@ -73,6 +77,10 @@ contract StdUtilsTest is Test {
         vm.expectRevert(bytes("StdUtils bound(uint256,uint256,uint256): Max is less than min."));
         bound(num, min, max);
     }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                     BOUND INT
+    //////////////////////////////////////////////////////////////////////////*/
 
     function testBoundInt() public {
         assertEq(bound(-3, 0, 4), 2);
@@ -158,20 +166,9 @@ contract StdUtilsTest is Test {
         bound(num, min, max);
     }
 
-    function testGenerateCreateAddress() external {
-        address deployer = 0x6C9FC64A53c1b71FB3f9Af64d1ae3A4931A5f4E9;
-        uint256 nonce = 14;
-        address createAddress = computeCreateAddress(deployer, nonce);
-        assertEq(createAddress, 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45);
-    }
-
-    function testGenerateCreate2Address() external {
-        bytes32 salt = bytes32(uint256(31415));
-        bytes32 initcodeHash = keccak256(abi.encode(0x6080));
-        address deployer = 0x6C9FC64A53c1b71FB3f9Af64d1ae3A4931A5f4E9;
-        address create2Address = computeCreate2Address(salt, initcodeHash, deployer);
-        assertEq(create2Address, 0xB147a5d25748fda14b463EB04B111027C290f4d3);
-    }
+    /*//////////////////////////////////////////////////////////////////////////
+                                   BYTES TO UINT
+    //////////////////////////////////////////////////////////////////////////*/
 
     function testBytesToUint() external {
         bytes memory maxUint = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
@@ -187,5 +184,28 @@ contract StdUtilsTest is Test {
         bytes memory thirty3Bytes = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
         vm.expectRevert("StdUtils bytesToUint(bytes): Bytes length exceeds 32.");
         bytesToUint(thirty3Bytes);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                               COMPUTE CREATE ADDRESS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function testComputeCreateAddress() external {
+        address deployer = 0x6C9FC64A53c1b71FB3f9Af64d1ae3A4931A5f4E9;
+        uint256 nonce = 14;
+        address createAddress = computeCreateAddress(deployer, nonce);
+        assertEq(createAddress, 0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                              COMPUTE CREATE2 ADDRESS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function testComputeCreate2Address() external {
+        bytes32 salt = bytes32(uint256(31415));
+        bytes32 initcodeHash = keccak256(abi.encode(0x6080));
+        address deployer = 0x6C9FC64A53c1b71FB3f9Af64d1ae3A4931A5f4E9;
+        address create2Address = computeCreate2Address(salt, initcodeHash, deployer);
+        assertEq(create2Address, 0xB147a5d25748fda14b463EB04B111027C290f4d3);
     }
 }

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -235,6 +235,7 @@ contract StdUtilsForkTest is Test {
     address internal USDC_HOLDER_1 = 0x3e67F4721E6d1c41a015f645eFa37BEd854fcf52;
 
     function setUp() public {
+        // All tests of the `getTokenBalances` method are fork tests using live contracts.
         vm.createSelectFork({urlOrAlias: "mainnet", blockNumber: 16_428_900});
     }
 


### PR DESCRIPTION
## Description

As discussed in #266, this PR adds the `IMulticall3` interfaces in this repo (hardcoded, not imported from anywhere else). This PR also adds a `getTokenBalances` util in `StdUtils`, which I think will prove quite useful to Multicall users.

Note: I did not write tests for `getTokenBalances` just yet. Not sure if you are happy to merge the PR as is, or you would rather want me/ us to test it first.

## Full Changelog

- [x] chore: fix typos in comments
- [x] feat: add "getTokenBalances" util
- [x] feat: add "IMulticall3" interface
- [x] refactor: add header separators in "StdUtils"
- [x] refactor: order functions alphabetically in "StdUtils"