### PR TITLE
Add create2 helper methods

### DIFF
--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -19,7 +19,9 @@ abstract contract StdUtils {
         57896044618658097711785492504343953926634992332820282019728792003956564819968;
     uint256 private constant UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
-    address private constant DEFAULT_CREATE2_DEPLOYER = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+
+    // Used by default when deploying with create2, https://github.com/Arachnid/deterministic-deployment-proxy.
+    address private constant CREATE2_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
 
     /*//////////////////////////////////////////////////////////////////////////
                                  INTERNAL FUNCTIONS
@@ -118,20 +120,20 @@ abstract contract StdUtils {
     }
 
     /// @dev returns the address of a contract created with CREATE2 using the default CREATE2 deployer
-    function computeCreate2Address(bytes32 salt, bytes32 _initCodeHash) internal pure returns (address) {
-        return computeCreate2Address(salt, _initCodeHash, DEFAULT_CREATE2_DEPLOYER);
+    function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) internal pure returns (address) {
+        return computeCreate2Address(salt, initCodeHash, CREATE2_FACTORY);
     }
 
     /// @dev returns the hash of the init code (creation code + no args) used in CREATE2 with no constructor arguments
     /// @param creationCode the creation code of a contract C, as returned by type(C).creationCode
-    function hashInitCodeNoConstructorArgs(bytes memory creationCode) public pure returns (bytes32) {
+    function hashInitCode(bytes memory creationCode) internal pure returns (bytes32) {
         return hashInitCode(creationCode, "");
     }
 
     /// @dev returns the hash of the init code (creation code + ABI-encoded args) used in CREATE2
     /// @param creationCode the creation code of a contract C, as returned by type(C).creationCode
     /// @param args the ABI-encoded arguments to the constructor of C
-    function hashInitCode(bytes memory creationCode, bytes memory args) public pure returns (bytes32) {
+    function hashInitCode(bytes memory creationCode, bytes memory args) internal pure returns (bytes32) {
         return keccak256(abi.encodePacked(creationCode, args));
     }
 

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -19,6 +19,7 @@ abstract contract StdUtils {
         57896044618658097711785492504343953926634992332820282019728792003956564819968;
     uint256 private constant UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
+    address private constant DEFAULT_CREATE2_DEPLOYER = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
 
     /*//////////////////////////////////////////////////////////////////////////
                                  INTERNAL FUNCTIONS
@@ -114,6 +115,24 @@ abstract contract StdUtils {
         returns (address)
     {
         return addressFromLast20Bytes(keccak256(abi.encodePacked(bytes1(0xff), deployer, salt, initcodeHash)));
+    }
+
+    /// @dev returns the address of a contract created with CREATE2 using the default CREATE2 deployer
+    function computeCreate2Address(bytes32 salt, bytes32 _initCodeHash) internal pure returns (address) {
+        return computeCreate2Address(salt, _initCodeHash, DEFAULT_CREATE2_DEPLOYER);
+    }
+
+    /// @dev returns the hash of the init code (creation code + no args) used in CREATE2 with no constructor arguments
+    /// @param creationCode the creation code of a contract C, as returned by type(C).creationCode
+    function hashInitCodeNoConstructorArgs(bytes memory creationCode) public pure returns (bytes32) {
+        return hashInitCode(creationCode, "");
+    }
+
+    /// @dev returns the hash of the init code (creation code + ABI-encoded args) used in CREATE2
+    /// @param creationCode the creation code of a contract C, as returned by type(C).creationCode
+    /// @param args the ABI-encoded arguments to the constructor of C
+    function hashInitCode(bytes memory creationCode, bytes memory args) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(creationCode, args));
     }
 
     // Performs a single call with Multicall3 to query the ERC-20 token balances of the given addresses.

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -218,6 +218,14 @@ contract StdUtilsTest is Test {
         address create2Address = computeCreate2Address(salt, initcodeHash, deployer);
         assertEq(create2Address, 0xB147a5d25748fda14b463EB04B111027C290f4d3);
     }
+
+    function testComputeCreate2AddressWithDefaultDeployer() external {
+        bytes32 salt = 0xc290c670fde54e5ef686f9132cbc8711e76a98f0333a438a92daa442c71403c0;
+        bytes32 initcodeHash = hashInitCode(hex"6080", "");
+        assertEq(initcodeHash, 0x1a578b7a4b0b5755db6d121b4118d4bc68fe170dca840c59bc922f14175a76b0);
+        address create2Address = computeCreate2Address(salt, initcodeHash);
+        assertEq(create2Address, 0xc0ffEe2198a06235aAbFffe5Db0CacF1717f5Ac6);
+    }
 }
 
 contract StdUtilsForkTest is Test {


### PR DESCRIPTION
- computeCreate2Address(bytes32 salt, bytes32 initCodeHash) returns an address using the default create2 deployer
- hashInitCode(bytes, bytes) and hashInitCodeNoConstructorArgs(bytes) make it more convenient to figure out the init code hash in deploy scripts