### PR TITLE
Add flag disable default rpc

### DIFF
--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -67,7 +67,7 @@ abstract contract StdChains {
     // Maps from a chain ID to it's alias.
     mapping(uint256 => string) private idToAlias;
 
-    bool private useDefaultRpcUrls = true;
+    bool private fallbackToDefaultRpcUrls = true;
 
     // The RPC URL will be fetched from config or defaultRpcUrls if possible.
     function getChain(string memory chainAlias) internal virtual returns (Chain memory chain) {
@@ -158,7 +158,7 @@ abstract contract StdChains {
                 chain.rpcUrl = configRpcUrl;
             } catch (bytes memory err) {
                 string memory envName = string(abi.encodePacked(_toUpper(chainAlias), "_RPC_URL"));
-                if (useDefaultRpcUrls) {
+                if (fallbackToDefaultRpcUrls) {
                     chain.rpcUrl = vm.envOr(envName, defaultRpcUrls[chainAlias]);
                 } else {
                     chain.rpcUrl = vm.envString(envName);
@@ -177,8 +177,8 @@ abstract contract StdChains {
         return chain;
     }
 
-    function setUseDefaultRpcUrls(bool useDefault) internal {
-        useDefaultRpcUrls = useDefault;
+    function setFallbackToDefaultRpcUrls(bool useDefault) internal {
+        fallbackToDefaultRpcUrls = useDefault;
     }
 
     function initialize() private {

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -67,6 +67,8 @@ abstract contract StdChains {
     // Maps from a chain ID to it's alias.
     mapping(uint256 => string) private idToAlias;
 
+    bool private useDefaultRpcUrls = true;
+
     // The RPC URL will be fetched from config or defaultRpcUrls if possible.
     function getChain(string memory chainAlias) internal virtual returns (Chain memory chain) {
         require(bytes(chainAlias).length != 0, "StdChains getChain(string): Chain alias cannot be the empty string.");
@@ -155,8 +157,12 @@ abstract contract StdChains {
             try vm.rpcUrl(chainAlias) returns (string memory configRpcUrl) {
                 chain.rpcUrl = configRpcUrl;
             } catch (bytes memory err) {
-                chain.rpcUrl =
-                    vm.envOr(string(abi.encodePacked(_toUpper(chainAlias), "_RPC_URL")), defaultRpcUrls[chainAlias]);
+                string memory envName = string(abi.encodePacked(_toUpper(chainAlias), "_RPC_URL"));
+                if (useDefaultRpcUrls) {
+                    chain.rpcUrl = vm.envOr(envName, defaultRpcUrls[chainAlias]);
+                } else {
+                    chain.rpcUrl = vm.envString(envName);
+                }
                 // distinguish 'not found' from 'cannot read'
                 bytes memory notFoundError =
                     abi.encodeWithSignature("CheatCodeError", string(abi.encodePacked("invalid rpc url ", chainAlias)));
@@ -169,6 +175,10 @@ abstract contract StdChains {
             }
         }
         return chain;
+    }
+
+    function setUseDefaultRpcUrls(bool useDefault) internal {
+        useDefaultRpcUrls = useDefault;
     }
 
     function initialize() private {

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -144,4 +144,13 @@ contract StdChainsTest is Test {
         assertEq(modifiedChain.chainId, 999999999);
         assertEq(modifiedChain.rpcUrl, "https://modified.chain/");
     }
+
+    function testUseDefaultRpcUrl() public {
+        // Should error if default RPCs flag is set to false.
+        setUseDefaultRpcUrls(false);
+        vm.expectRevert("Failed to get environment variable `ANVIL_RPC_URL` as type `string`: environment variable not found");
+        getChain(31337);
+        vm.expectRevert("Failed to get environment variable `SEPOLIA_RPC_URL` as type `string`: environment variable not found");
+        getChain("sepolia");
+    }
 }

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -147,7 +147,7 @@ contract StdChainsTest is Test {
 
     function testDontUseDefaultRpcUrl() public {
         // Should error if default RPCs flag is set to false.
-        setUseDefaultRpcUrls(false);
+        setFallbackToDefaultRpcUrls(false);
         vm.expectRevert(
             "Failed to get environment variable `ANVIL_RPC_URL` as type `string`: environment variable not found"
         );

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -145,7 +145,7 @@ contract StdChainsTest is Test {
         assertEq(modifiedChain.rpcUrl, "https://modified.chain/");
     }
 
-    function testUseDefaultRpcUrl() public {
+    function testDontUseDefaultRpcUrl() public {
         // Should error if default RPCs flag is set to false.
         setUseDefaultRpcUrls(false);
         vm.expectRevert(

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -148,9 +148,13 @@ contract StdChainsTest is Test {
     function testUseDefaultRpcUrl() public {
         // Should error if default RPCs flag is set to false.
         setUseDefaultRpcUrls(false);
-        vm.expectRevert("Failed to get environment variable `ANVIL_RPC_URL` as type `string`: environment variable not found");
+        vm.expectRevert(
+            "Failed to get environment variable `ANVIL_RPC_URL` as type `string`: environment variable not found"
+        );
         getChain(31337);
-        vm.expectRevert("Failed to get environment variable `SEPOLIA_RPC_URL` as type `string`: environment variable not found");
+        vm.expectRevert(
+            "Failed to get environment variable `SEPOLIA_RPC_URL` as type `string`: environment variable not found"
+        );
         getChain("sepolia");
     }
 }


### PR DESCRIPTION
Added a flag to disable falling back to default RPC URLs automatically. Public RPC endpoints are often rate-limited and may result in obscure errors when rate limits are hit. On our team we want to disable this behavior and instead spit out a very clear error that the user does not have the proper environment variable configured.

I've opened it as a draft because the new test is failing because the error is not matching even though I copied it exactly from the console. Is there hidden whitespace or an extra character or something? I don't have time to dig into this atm, so thought I'd submit most of the work.

Ping: @mds1 