### PR TITLE
Import of `src/interfaces` when importing `forge-std` via node package managers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "(Apache-2.0 OR MIT)",
   "author": "Contributors to Forge Standard Library",
   "files": [
-    "src/*"
+    "src/**/*"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION

When importing `forge-std` using `yarn`. Only one level deep of the `src/` directory is included. This means that all of the end contracts are, but their dependent interfaces in `src/interfaces/` are **not** imported which causes compiler errors when building forge-std

```
Compiler run failed
error[6275]: node_modules/forge-std/src/StdUtils.sol:6:1: ParserError: Source "node_modules/forge-std/src/interfaces/IMulticall3.sol" not found: File not found.
import {IMulticall3} from "./interfaces/IMulticall3.sol";
^-------------------------------------------------------^


error[6275]: ParserError: Source "node_modules/forge-std/src/interfaces/IMulticall3.sol" not found: File not found. Searched the following locations: "/Users/wbj/Documents/mono/packages/protocol".
 --> node_modules/forge-std/src/StdUtils.sol:6:1:
  |
6 | import {IMulticall3} from "./interfaces/IMulticall3.sol";
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^



error[6275]: ParserError: Source "node_modules/forge-std/src/interfaces/IMulticall3.sol" not found: File not found. Searched the following locations: "/Users/wbj/Documents/mono/packages/protocol".
 --> node_modules/forge-std/src/StdUtils.sol:6:1:
  |
6 | import {IMulticall3} from "./interfaces/IMulticall3.sol";
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^



error[6275]: ParserError: Source "node_modules/forge-std/src/interfaces/IMulticall3.sol" not found: File not found.
 --> node_modules/forge-std/src/StdUtils.sol:6:1:
  |
6 | import {IMulticall3} from "./interfaces/IMulticall3.sol";
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This PR makes it so that `src/interfaces` is included when importing via node package managers when importing like this

`package.json`
```jsonc
{
  "dependencies": {
    // ...
    "forge-std": "https://github.com/foundry-rs/forge-std#v1.4.0,
   // ...
  }
}
```