### PR TITLE
Added deal cheat for ERC721 and ERC1155

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -549,8 +549,10 @@ abstract contract StdCheats is StdCheatsSafe {
         deal(token, to, give, false);
     }
 
-    function deal(address token, address to, uint256 id, uint256 give) internal virtual {
-        deal(token, to, id, give, false);
+    // Set the balance of an account for any ERC1155 token
+    // Use the alternative signature to update `totalSupply`
+    function dealERC1155(address token, address to, uint256 id, uint256 give) internal virtual {
+        dealERC1155(token, to, id, give, false);
     }
 
     function deal(address token, address to, uint256 give, bool adjust) internal virtual {

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -549,6 +549,10 @@ abstract contract StdCheats is StdCheatsSafe {
         deal(token, to, give, false);
     }
 
+    function deal(address token, address to, uint256 id, uint256 give) internal virtual {
+        deal(token, to, id, give, false);
+    }
+
     function deal(address token, address to, uint256 give, bool adjust) internal virtual {
         // get current balance
         (, bytes memory balData) = token.call(abi.encodeWithSelector(0x70a08231, to));
@@ -568,5 +572,48 @@ abstract contract StdCheats is StdCheatsSafe {
             }
             stdstore.target(token).sig(0x18160ddd).checked_write(totSup);
         }
+    }
+
+    function deal(address token, address to, uint256 id, uint256 give, bool adjust) internal virtual {
+        // get current balance
+        (, bytes memory balData) = token.call(abi.encodeWithSelector(0x00fdd58e, to, id));
+        uint256 prevBal = abi.decode(balData, (uint256));
+
+        // update balance
+        stdstore.target(token).sig(0x00fdd58e).with_key(to).with_key(id).checked_write(give);
+
+        // update total supply
+        if (adjust) {
+            (, bytes memory totSupData) = token.call(abi.encodeWithSelector(0xbd85b039, id));
+            require(totSupData.length != 0, "StdCheats deal(address,address,uint,uint,bool): target contract is not ERC1155Supply.");
+            uint256 totSup = abi.decode(totSupData, (uint256));
+            if (give < prevBal) {
+                totSup -= (prevBal - give);
+            } else {
+                totSup += (give - prevBal);
+            }
+            stdstore.target(token).sig(0xbd85b039).with_key(id).checked_write(totSup);
+        }
+    }
+
+    function dealNft(address token, address to, uint256 id) internal virtual {
+        // check if token id is already minted and the actual owner.
+        (bool successMinted, bytes memory ownerData) = token.staticcall(abi.encodeWithSelector(0x6352211e, id));
+        require(successMinted, "StdCheats deal(address,address,uint,bool): id not minted.");
+
+        // get owner current balance
+        (, bytes memory fromBalData) = token.call(abi.encodeWithSelector(0x70a08231, abi.decode(ownerData, (address))));
+        uint256 fromPrevBal = abi.decode(fromBalData, (uint256));
+
+        // get new user current balance
+        (, bytes memory toBalData) = token.call(abi.encodeWithSelector(0x70a08231, to));
+        uint256 toPrevBal = abi.decode(toBalData, (uint256));
+
+        // update balances
+        stdstore.target(token).sig(0x70a08231).with_key(abi.decode(ownerData, (address))).checked_write(--fromPrevBal);
+        stdstore.target(token).sig(0x70a08231).with_key(to).checked_write(++toPrevBal);
+
+        // update owner
+        stdstore.target(token).sig(0x6352211e).with_key(id).checked_write(to);
     }
 }

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -574,7 +574,7 @@ abstract contract StdCheats is StdCheatsSafe {
         }
     }
 
-    function deal(address token, address to, uint256 id, uint256 give, bool adjust) internal virtual {
+    function dealERC1155(address token, address to, uint256 id, uint256 give, bool adjust) internal virtual {
         // get current balance
         (, bytes memory balData) = token.call(abi.encodeWithSelector(0x00fdd58e, to, id));
         uint256 prevBal = abi.decode(balData, (uint256));
@@ -585,7 +585,10 @@ abstract contract StdCheats is StdCheatsSafe {
         // update total supply
         if (adjust) {
             (, bytes memory totSupData) = token.call(abi.encodeWithSelector(0xbd85b039, id));
-            require(totSupData.length != 0, "StdCheats deal(address,address,uint,uint,bool): target contract is not ERC1155Supply.");
+            require(
+                totSupData.length != 0,
+                "StdCheats deal(address,address,uint,uint,bool): target contract is not ERC1155Supply."
+            );
             uint256 totSup = abi.decode(totSupData, (uint256));
             if (give < prevBal) {
                 totSup -= (prevBal - give);
@@ -596,7 +599,7 @@ abstract contract StdCheats is StdCheatsSafe {
         }
     }
 
-    function dealNft(address token, address to, uint256 id) internal virtual {
+    function dealERC721(address token, address to, uint256 id) internal virtual {
         // check if token id is already minted and the actual owner.
         (bool successMinted, bytes memory ownerData) = token.staticcall(abi.encodeWithSelector(0x6352211e, id));
         require(successMinted, "StdCheats deal(address,address,uint,bool): id not minted.");

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -92,7 +92,7 @@ contract StdCheatsTest is Test {
         assertEq(barToken.balanceOf(address(this)), 10000e18);
     }
 
-    function testDealTokenAdjustTS() public {
+    function testDealTokenAdjustTotalSupply() public {
         Bar barToken = new Bar();
         address bar = address(barToken);
         deal(bar, address(this), 10000e18, true);

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -103,6 +103,35 @@ contract StdCheatsTest is Test {
         assertEq(barToken.totalSupply(), 10000e18);
     }
 
+    function testDealERC1155Token() public {
+        BarERC1155 barToken = new BarERC1155();
+        address bar = address(barToken);
+        dealERC1155(bar, address(this), 0, 10000e18, false);
+        assertEq(barToken.balanceOf(address(this), 0), 10000e18);
+    }
+
+    function testDealERC1155TokenAdjustTS() public {
+        BarERC1155 barToken = new BarERC1155();
+        address bar = address(barToken);
+        dealERC1155(bar, address(this), 0, 10000e18, true);
+        assertEq(barToken.balanceOf(address(this), 0), 10000e18);
+        assertEq(barToken.totalSupply(0), 20000e18);
+        dealERC1155(bar, address(this), 0, 0, true);
+        assertEq(barToken.balanceOf(address(this), 0), 0);
+        assertEq(barToken.totalSupply(0), 10000e18);
+    }
+
+    function testDealERC721Token() public {
+        BarERC721 barToken = new BarERC721();
+        address bar = address(barToken);
+        dealERC721(bar, address(2), 1);
+        assertEq(barToken.balanceOf(address(2)), 1);
+        assertEq(barToken.balanceOf(address(1)), 0);
+        dealERC721(bar, address(1), 2);
+        assertEq(barToken.balanceOf(address(1)), 1);
+        assertEq(barToken.balanceOf(bar), 1);
+    }
+
     function testDeployCode() public {
         address deployed = deployCode("StdCheats.t.sol:Bar", bytes(""));
         assertEq(string(getCode(deployed)), string(getCode(address(test))));
@@ -320,6 +349,50 @@ contract Bar {
     /// `DEAL` STDCHEAT
     mapping(address => uint256) public balanceOf;
     uint256 public totalSupply;
+}
+
+contract BarERC1155 {
+    constructor() payable {
+        /// `DEALERC1155` STDCHEAT
+        _totalSupply[0] = 10000e18;
+        _balances[0][address(this)] = _totalSupply[0];
+    }
+
+    function balanceOf(address account, uint256 id) public view virtual returns (uint256) {
+        return _balances[id][account];
+    }
+
+    function totalSupply(uint256 id) public view virtual returns (uint256) {
+        return _totalSupply[id];
+    }
+
+    /// `DEALERC1155` STDCHEAT
+    mapping(uint256 => mapping(address => uint256)) private _balances;
+    mapping(uint256 => uint256) private _totalSupply;
+}
+
+contract BarERC721 {
+    constructor() payable {
+        /// `DEALERC721` STDCHEAT
+        _owners[1] = address(1);
+        _balances[address(1)] = 1;
+        _owners[2] = address(this);
+        _owners[3] = address(this);
+        _balances[address(this)] = 2;
+    }
+
+    function balanceOf(address owner) public view virtual returns (uint256) {
+        return _balances[owner];
+    }
+
+    function ownerOf(uint256 tokenId) public view virtual returns (address) {
+        address owner = _owners[tokenId];
+        return owner;
+    }
+
+
+    mapping(uint256 => address) private _owners;
+    mapping(address => uint256) private _balances;
 }
 
 contract RevertingContract {

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -390,7 +390,6 @@ contract BarERC721 {
         return owner;
     }
 
-
     mapping(uint256 => address) private _owners;
     mapping(address => uint256) private _balances;
 }

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -110,7 +110,7 @@ contract StdCheatsTest is Test {
         assertEq(barToken.balanceOf(address(this), 0), 10000e18);
     }
 
-    function testDealERC1155TokenAdjustTS() public {
+    function testDealERC1155TokenAdjustTotalSupply() public {
         BarERC1155 barToken = new BarERC1155();
         address bar = address(barToken);
         dealERC1155(bar, address(this), 0, 10000e18, true);


### PR DESCRIPTION
I've created the deal cheatcode for ERC721 and ERC1155 tokens.

For ERC721 and it shares the same function signature as ERC20 i've modified the name to dealNft(), this could be merged into a single deal function by checking the interface of the given contract but I'm not sure it is the best option as it would increase gas usage and could lead to more errors for non-standard implementations.

Usage:
```solidity
// ERC721
dealNft(nftAddress, bob, tokenId);

//ERC1155
deal(1155address, bob, id, amount);
deal(1155address, bob, id, amount, true); // Will check if it is ERC1155Supply and adjust totalSupply.
```