### PR TITLE
feat(StdAssertions): Add `assertEqCall`

### DIFF
--- a/src/StdAssertions.sol
+++ b/src/StdAssertions.sol
@@ -322,4 +322,55 @@ abstract contract StdAssertions is DSTest {
             assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals);
         }
     }
+
+    function assertEqCall(address target, bytes memory callDataA, bytes memory callDataB) internal virtual {
+        assertEqCall(target, callDataA, target, callDataB, true);
+    }
+
+    function assertEqCall(address targetA, bytes memory callDataA, address targetB, bytes memory callDataB)
+        internal
+        virtual
+    {
+        assertEqCall(targetA, callDataA, targetB, callDataB, true);
+    }
+
+    function assertEqCall(address target, bytes memory callDataA, bytes memory callDataB, bool strictRevertData)
+        internal
+        virtual
+    {
+        assertEqCall(target, callDataA, target, callDataB, strictRevertData);
+    }
+
+    function assertEqCall(
+        address targetA,
+        bytes memory callDataA,
+        address targetB,
+        bytes memory callDataB,
+        bool strictRevertData
+    ) internal virtual {
+        (bool successA, bytes memory returnDataA) = address(targetA).call(callDataA);
+        (bool successB, bytes memory returnDataB) = address(targetB).call(callDataB);
+
+        if (successA && successB) {
+            assertEq(returnDataA, returnDataB, "Call return data does not match");
+        }
+
+        if (!successA && !successB && strictRevertData) {
+            assertEq(returnDataA, returnDataB, "Call revert data does not match");
+        }
+
+        if (!successA && successB) {
+            emit log("Error: Call reverted unexpectedly");
+            emit log_named_bytes("  Left call revert data", returnDataA);
+            emit log_named_bytes(" Right call return data", returnDataB);
+            fail();
+        }
+
+        if (successA && !successB) {
+            emit log("Error: Call did not revert");
+            emit log_named_bytes("  Left call return data", returnDataA);
+            emit log_named_bytes(" Right call revert data", returnDataB);
+            fail();
+        }
+    }
 }

--- a/src/StdAssertions.sol
+++ b/src/StdAssertions.sol
@@ -367,7 +367,7 @@ abstract contract StdAssertions is DSTest {
         }
 
         if (successA && !successB) {
-            emit log("Error: Call did not revert");
+            emit log("Error: Calls were not equal");
             emit log_named_bytes("  Left call return data", returnDataA);
             emit log_named_bytes(" Right call revert data", returnDataB);
             fail();

--- a/src/StdAssertions.sol
+++ b/src/StdAssertions.sol
@@ -360,7 +360,7 @@ abstract contract StdAssertions is DSTest {
         }
 
         if (!successA && successB) {
-            emit log("Error: Call reverted unexpectedly");
+            emit log("Error: Calls were not equal");
             emit log_named_bytes("  Left call revert data", returnDataA);
             emit log_named_bytes(" Right call return data", returnDataB);
             fail();

--- a/test/StdAssertions.t.sol
+++ b/test/StdAssertions.t.sol
@@ -642,7 +642,7 @@ contract StdAssertionsTest is Test {
         address targetA = address(new TestMockCall(returnDataA, SHOULD_RETURN));
         address targetB = address(new TestMockCall(returnDataB, SHOULD_RETURN));
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit log_named_string("Error", "Call return data does not match");
         t._assertEqCall(targetA, targetB, callDataA, callDataB, returnDataA, returnDataB, strictRevertData, EXPECT_FAIL);
     }
@@ -672,7 +672,7 @@ contract StdAssertionsTest is Test {
         address targetA = address(new TestMockCall(revertDataA, SHOULD_REVERT));
         address targetB = address(new TestMockCall(revertDataB, SHOULD_REVERT));
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit log_named_string("Error", "Call revert data does not match");
         t._assertEqCall(
             targetA, targetB, callDataA, callDataB, revertDataA, revertDataB, STRICT_REVERT_DATA, EXPECT_FAIL
@@ -689,15 +689,15 @@ contract StdAssertionsTest is Test {
         address targetA = address(new TestMockCall(returnDataA, SHOULD_RETURN));
         address targetB = address(new TestMockCall(returnDataB, SHOULD_REVERT));
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit log_named_bytes("  Left call return data", returnDataA);
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit log_named_bytes(" Right call revert data", returnDataB);
         t._assertEqCall(targetA, targetB, callDataA, callDataB, returnDataA, returnDataB, strictRevertData, EXPECT_FAIL);
 
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit log_named_bytes("  Left call revert data", returnDataB);
-        vm.expectEmit(false, false, false, true);
+        vm.expectEmit(true, true, true, true);
         emit log_named_bytes(" Right call return data", returnDataA);
         t._assertEqCall(targetB, targetA, callDataB, callDataA, returnDataB, returnDataA, strictRevertData, EXPECT_FAIL);
     }


### PR DESCRIPTION
Adds new assertions to StdAssertions.sol. These are useful for differential fuzz-testing calls.
Expects two calls to either return the same data or revert in the same way (if `strictRevertData = true`).

```solidity
function assertEqCall(
    address targetA,
    bytes memory callDataA,
    address targetB,
    bytes memory callDataB,
    bool strictRevertData
) internal virtual;
```