### PR TITLE
Added StdStyle library to print logs with different colors and styles

### DIFF
--- a/src/StdStyle.sol
+++ b/src/StdStyle.sol
@@ -24,19 +24,19 @@ library StdStyle {
     }
 
     function red(uint256 self) internal view returns (string memory) {
-        return string.concat(RED, vm.toString(self), RESET);
+        return red(vm.toString(self));
     }
 
     function red(int256 self) internal view returns (string memory) {
-        return string.concat(RED, vm.toString(self), RESET);
+        return red(vm.toString(self));
     }
 
     function red(address self) internal view returns (string memory) {
-        return string.concat(RED, vm.toString(self), RESET);
+        return red(vm.toString(self));
     }
 
     function red(bool self) internal view returns (string memory) {
-        return string.concat(RED, vm.toString(self), RESET);
+        return red(vm.toString(self));
     }
 
     function green(string memory self) internal view returns (string memory) {
@@ -44,19 +44,19 @@ library StdStyle {
     }
 
     function green(uint256 self) internal view returns (string memory) {
-        return string.concat(GREEN, vm.toString(self), RESET);
+        return green(vm.toString(self));
     }
 
     function green(int256 self) internal view returns (string memory) {
-        return string.concat(GREEN, vm.toString(self), RESET);
+        return green(vm.toString(self));
     }
 
     function green(address self) internal view returns (string memory) {
-        return string.concat(GREEN, vm.toString(self), RESET);
+        return green(vm.toString(self));
     }
 
     function green(bool self) internal view returns (string memory) {
-        return string.concat(GREEN, vm.toString(self), RESET);
+        return green(vm.toString(self));
     }
 
     function yellow(string memory self) internal view returns (string memory) {
@@ -64,19 +64,19 @@ library StdStyle {
     }
 
     function yellow(uint256 self) internal view returns (string memory) {
-        return string.concat(YELLOW, vm.toString(self), RESET);
+        return yellow(vm.toString(self));
     }
 
     function yellow(int256 self) internal view returns (string memory) {
-        return string.concat(YELLOW, vm.toString(self), RESET);
+        return yellow(vm.toString(self));
     }
 
     function yellow(address self) internal view returns (string memory) {
-        return string.concat(YELLOW, vm.toString(self), RESET);
+        return yellow(vm.toString(self));
     }
 
     function yellow(bool self) internal view returns (string memory) {
-        return string.concat(YELLOW, vm.toString(self), RESET);
+        return yellow(vm.toString(self));
     }
 
     function blue(string memory self) internal view returns (string memory) {
@@ -84,19 +84,19 @@ library StdStyle {
     }
 
     function blue(uint256 self) internal view returns (string memory) {
-        return string.concat(BLUE, vm.toString(self), RESET);
+        return blue(vm.toString(self));
     }
 
     function blue(int256 self) internal view returns (string memory) {
-        return string.concat(BLUE, vm.toString(self), RESET);
+        return blue(vm.toString(self));
     }
 
     function blue(address self) internal view returns (string memory) {
-        return string.concat(BLUE, vm.toString(self), RESET);
+        return blue(vm.toString(self));
     }
 
     function blue(bool self) internal view returns (string memory) {
-        return string.concat(BLUE, vm.toString(self), RESET);
+        return blue(vm.toString(self));
     }
 
     function magenta(string memory self) internal view returns (string memory) {
@@ -104,19 +104,19 @@ library StdStyle {
     }
 
     function magenta(uint256 self) internal view returns (string memory) {
-        return string.concat(MAGENTA, vm.toString(self), RESET);
+        return magenta(vm.toString(self));
     }
 
     function magenta(int256 self) internal view returns (string memory) {
-        return string.concat(MAGENTA, vm.toString(self), RESET);
+        return magenta(vm.toString(self));
     }
 
     function magenta(address self) internal view returns (string memory) {
-        return string.concat(MAGENTA, vm.toString(self), RESET);
+        return magenta(vm.toString(self));
     }
 
     function magenta(bool self) internal view returns (string memory) {
-        return string.concat(MAGENTA, vm.toString(self), RESET);
+        return magenta(vm.toString(self));
     }
 
     function cyan(string memory self) internal view returns (string memory) {
@@ -124,19 +124,19 @@ library StdStyle {
     }
 
     function cyan(uint256 self) internal view returns (string memory) {
-        return string.concat(CYAN, vm.toString(self), RESET);
+        return cyan(vm.toString(self));
     }
 
     function cyan(int256 self) internal view returns (string memory) {
-        return string.concat(CYAN, vm.toString(self), RESET);
+        return cyan(vm.toString(self));
     }
 
     function cyan(address self) internal view returns (string memory) {
-        return string.concat(CYAN, vm.toString(self), RESET);
+        return cyan(vm.toString(self));
     }
 
     function cyan(bool self) internal view returns (string memory) {
-        return string.concat(CYAN, vm.toString(self), RESET);
+        return cyan(vm.toString(self));
     }
 
     function bold(string memory self) internal view returns (string memory) {
@@ -144,19 +144,19 @@ library StdStyle {
     }
 
     function bold(uint256 self) internal view returns (string memory) {
-        return string.concat(BOLD, vm.toString(self), RESET);
+        return bold(vm.toString(self));
     }
 
     function bold(int256 self) internal view returns (string memory) {
-        return string.concat(BOLD, vm.toString(self), RESET);
+        return bold(vm.toString(self));
     }
 
     function bold(address self) internal view returns (string memory) {
-        return string.concat(BOLD, vm.toString(self), RESET);
+        return bold(vm.toString(self));
     }
 
     function bold(bool self) internal view returns (string memory) {
-        return string.concat(BOLD, vm.toString(self), RESET);
+        return bold(vm.toString(self));
     }
 
     function dim(string memory self) internal view returns (string memory) {
@@ -164,19 +164,19 @@ library StdStyle {
     }
 
     function dim(uint256 self) internal view returns (string memory) {
-        return string.concat(DIM, vm.toString(self), RESET);
+        return dim(vm.toString(self));
     }
 
     function dim(int256 self) internal view returns (string memory) {
-        return string.concat(DIM, vm.toString(self), RESET);
+        return dim(vm.toString(self));
     }
 
     function dim(address self) internal view returns (string memory) {
-        return string.concat(DIM, vm.toString(self), RESET);
+        return dim(vm.toString(self));
     }
 
     function dim(bool self) internal view returns (string memory) {
-        return string.concat(DIM, vm.toString(self), RESET);
+        return dim(vm.toString(self));
     }
 
     function italic(string memory self) internal view returns (string memory) {
@@ -184,19 +184,19 @@ library StdStyle {
     }
 
     function italic(uint256 self) internal view returns (string memory) {
-        return string.concat(ITALIC, vm.toString(self), RESET);
+        return italic(vm.toString(self));
     }
 
     function italic(int256 self) internal view returns (string memory) {
-        return string.concat(ITALIC, vm.toString(self), RESET);
+        return italic(vm.toString(self));
     }
 
     function italic(address self) internal view returns (string memory) {
-        return string.concat(ITALIC, vm.toString(self), RESET);
+        return italic(vm.toString(self));
     }
 
     function italic(bool self) internal view returns (string memory) {
-        return string.concat(ITALIC, vm.toString(self), RESET);
+        return italic(vm.toString(self));
     }
 
     function underline(string memory self) internal view returns (string memory) {
@@ -204,19 +204,19 @@ library StdStyle {
     }
 
     function underline(uint256 self) internal view returns (string memory) {
-        return string.concat(UNDERLINE, vm.toString(self), RESET);
+        return underline(vm.toString(self));
     }
 
     function underline(int256 self) internal view returns (string memory) {
-        return string.concat(UNDERLINE, vm.toString(self), RESET);
+        return underline(vm.toString(self));
     }
 
     function underline(address self) internal view returns (string memory) {
-        return string.concat(UNDERLINE, vm.toString(self), RESET);
+        return underline(vm.toString(self));
     }
 
     function underline(bool self) internal view returns (string memory) {
-        return string.concat(UNDERLINE, vm.toString(self), RESET);
+        return underline(vm.toString(self));
     }
 
     function reverse(string memory self) internal view returns (string memory) {
@@ -224,18 +224,18 @@ library StdStyle {
     }
 
     function reverse(uint256 self) internal view returns (string memory) {
-        return string.concat(REVERSE, vm.toString(self), RESET);
+        return reverse(vm.toString(self));
     }
 
     function reverse(int256 self) internal view returns (string memory) {
-        return string.concat(REVERSE, vm.toString(self), RESET);
+        return reverse(vm.toString(self));
     }
 
     function reverse(address self) internal view returns (string memory) {
-        return string.concat(REVERSE, vm.toString(self), RESET);
+        return reverse(vm.toString(self));
     }
 
     function reverse(bool self) internal view returns (string memory) {
-        return string.concat(REVERSE, vm.toString(self), RESET);
+        return reverse(vm.toString(self));
     }
 }

--- a/src/StdStyle.sol
+++ b/src/StdStyle.sol
@@ -16,226 +16,230 @@ library StdStyle {
     string constant DIM = "\u001b[2m";
     string constant ITALIC = "\u001b[3m";
     string constant UNDERLINE = "\u001b[4m";
-    string constant REVERSE = "\u001b[7m";
+    string constant INVERSE = "\u001b[7m";
     string constant RESET = "\u001b[0m";
 
-    function red(string memory self) internal view returns (string memory) {
-        return string.concat(RED, self, RESET);
+    function styleConcat(string memory style, string memory self) private pure returns (string memory) {
+        return string(abi.encodePacked(style, self, RESET));
     }
 
-    function red(uint256 self) internal view returns (string memory) {
+    function red(string memory self) internal pure returns (string memory) {
+        return styleConcat(RED, self);
+    }
+
+    function red(uint256 self) internal pure returns (string memory) {
         return red(vm.toString(self));
     }
 
-    function red(int256 self) internal view returns (string memory) {
+    function red(int256 self) internal pure returns (string memory) {
         return red(vm.toString(self));
     }
 
-    function red(address self) internal view returns (string memory) {
+    function red(address self) internal pure returns (string memory) {
         return red(vm.toString(self));
     }
 
-    function red(bool self) internal view returns (string memory) {
+    function red(bool self) internal pure returns (string memory) {
         return red(vm.toString(self));
     }
 
-    function green(string memory self) internal view returns (string memory) {
-        return string.concat(GREEN, self, RESET);
+    function green(string memory self) internal pure returns (string memory) {
+        return styleConcat(GREEN, self);
     }
 
-    function green(uint256 self) internal view returns (string memory) {
+    function green(uint256 self) internal pure returns (string memory) {
         return green(vm.toString(self));
     }
 
-    function green(int256 self) internal view returns (string memory) {
+    function green(int256 self) internal pure returns (string memory) {
         return green(vm.toString(self));
     }
 
-    function green(address self) internal view returns (string memory) {
+    function green(address self) internal pure returns (string memory) {
         return green(vm.toString(self));
     }
 
-    function green(bool self) internal view returns (string memory) {
+    function green(bool self) internal pure returns (string memory) {
         return green(vm.toString(self));
     }
 
-    function yellow(string memory self) internal view returns (string memory) {
-        return string.concat(YELLOW, self, RESET);
+    function yellow(string memory self) internal pure returns (string memory) {
+        return styleConcat(YELLOW, self);
     }
 
-    function yellow(uint256 self) internal view returns (string memory) {
+    function yellow(uint256 self) internal pure returns (string memory) {
         return yellow(vm.toString(self));
     }
 
-    function yellow(int256 self) internal view returns (string memory) {
+    function yellow(int256 self) internal pure returns (string memory) {
         return yellow(vm.toString(self));
     }
 
-    function yellow(address self) internal view returns (string memory) {
+    function yellow(address self) internal pure returns (string memory) {
         return yellow(vm.toString(self));
     }
 
-    function yellow(bool self) internal view returns (string memory) {
+    function yellow(bool self) internal pure returns (string memory) {
         return yellow(vm.toString(self));
     }
 
-    function blue(string memory self) internal view returns (string memory) {
-        return string.concat(BLUE, self, RESET);
+    function blue(string memory self) internal pure returns (string memory) {
+        return styleConcat(BLUE, self);
     }
 
-    function blue(uint256 self) internal view returns (string memory) {
+    function blue(uint256 self) internal pure returns (string memory) {
         return blue(vm.toString(self));
     }
 
-    function blue(int256 self) internal view returns (string memory) {
+    function blue(int256 self) internal pure returns (string memory) {
         return blue(vm.toString(self));
     }
 
-    function blue(address self) internal view returns (string memory) {
+    function blue(address self) internal pure returns (string memory) {
         return blue(vm.toString(self));
     }
 
-    function blue(bool self) internal view returns (string memory) {
+    function blue(bool self) internal pure returns (string memory) {
         return blue(vm.toString(self));
     }
 
-    function magenta(string memory self) internal view returns (string memory) {
-        return string.concat(MAGENTA, self, RESET);
+    function magenta(string memory self) internal pure returns (string memory) {
+        return styleConcat(MAGENTA, self);
     }
 
-    function magenta(uint256 self) internal view returns (string memory) {
+    function magenta(uint256 self) internal pure returns (string memory) {
         return magenta(vm.toString(self));
     }
 
-    function magenta(int256 self) internal view returns (string memory) {
+    function magenta(int256 self) internal pure returns (string memory) {
         return magenta(vm.toString(self));
     }
 
-    function magenta(address self) internal view returns (string memory) {
+    function magenta(address self) internal pure returns (string memory) {
         return magenta(vm.toString(self));
     }
 
-    function magenta(bool self) internal view returns (string memory) {
+    function magenta(bool self) internal pure returns (string memory) {
         return magenta(vm.toString(self));
     }
 
-    function cyan(string memory self) internal view returns (string memory) {
-        return string.concat(CYAN, self, RESET);
+    function cyan(string memory self) internal pure returns (string memory) {
+        return styleConcat(CYAN, self);
     }
 
-    function cyan(uint256 self) internal view returns (string memory) {
+    function cyan(uint256 self) internal pure returns (string memory) {
         return cyan(vm.toString(self));
     }
 
-    function cyan(int256 self) internal view returns (string memory) {
+    function cyan(int256 self) internal pure returns (string memory) {
         return cyan(vm.toString(self));
     }
 
-    function cyan(address self) internal view returns (string memory) {
+    function cyan(address self) internal pure returns (string memory) {
         return cyan(vm.toString(self));
     }
 
-    function cyan(bool self) internal view returns (string memory) {
+    function cyan(bool self) internal pure returns (string memory) {
         return cyan(vm.toString(self));
     }
 
-    function bold(string memory self) internal view returns (string memory) {
-        return string.concat(BOLD, self, RESET);
+    function bold(string memory self) internal pure returns (string memory) {
+        return styleConcat(BOLD, self);
     }
 
-    function bold(uint256 self) internal view returns (string memory) {
+    function bold(uint256 self) internal pure returns (string memory) {
         return bold(vm.toString(self));
     }
 
-    function bold(int256 self) internal view returns (string memory) {
+    function bold(int256 self) internal pure returns (string memory) {
         return bold(vm.toString(self));
     }
 
-    function bold(address self) internal view returns (string memory) {
+    function bold(address self) internal pure returns (string memory) {
         return bold(vm.toString(self));
     }
 
-    function bold(bool self) internal view returns (string memory) {
+    function bold(bool self) internal pure returns (string memory) {
         return bold(vm.toString(self));
     }
 
-    function dim(string memory self) internal view returns (string memory) {
-        return string.concat(DIM, self, RESET);
+    function dim(string memory self) internal pure returns (string memory) {
+        return styleConcat(DIM, self);
     }
 
-    function dim(uint256 self) internal view returns (string memory) {
+    function dim(uint256 self) internal pure returns (string memory) {
         return dim(vm.toString(self));
     }
 
-    function dim(int256 self) internal view returns (string memory) {
+    function dim(int256 self) internal pure returns (string memory) {
         return dim(vm.toString(self));
     }
 
-    function dim(address self) internal view returns (string memory) {
+    function dim(address self) internal pure returns (string memory) {
         return dim(vm.toString(self));
     }
 
-    function dim(bool self) internal view returns (string memory) {
+    function dim(bool self) internal pure returns (string memory) {
         return dim(vm.toString(self));
     }
 
-    function italic(string memory self) internal view returns (string memory) {
-        return string.concat(ITALIC, self, RESET);
+    function italic(string memory self) internal pure returns (string memory) {
+        return styleConcat(ITALIC, self);
     }
 
-    function italic(uint256 self) internal view returns (string memory) {
+    function italic(uint256 self) internal pure returns (string memory) {
         return italic(vm.toString(self));
     }
 
-    function italic(int256 self) internal view returns (string memory) {
+    function italic(int256 self) internal pure returns (string memory) {
         return italic(vm.toString(self));
     }
 
-    function italic(address self) internal view returns (string memory) {
+    function italic(address self) internal pure returns (string memory) {
         return italic(vm.toString(self));
     }
 
-    function italic(bool self) internal view returns (string memory) {
+    function italic(bool self) internal pure returns (string memory) {
         return italic(vm.toString(self));
     }
 
-    function underline(string memory self) internal view returns (string memory) {
-        return string.concat(UNDERLINE, self, RESET);
+    function underline(string memory self) internal pure returns (string memory) {
+        return styleConcat(UNDERLINE, self);
     }
 
-    function underline(uint256 self) internal view returns (string memory) {
+    function underline(uint256 self) internal pure returns (string memory) {
         return underline(vm.toString(self));
     }
 
-    function underline(int256 self) internal view returns (string memory) {
+    function underline(int256 self) internal pure returns (string memory) {
         return underline(vm.toString(self));
     }
 
-    function underline(address self) internal view returns (string memory) {
+    function underline(address self) internal pure returns (string memory) {
         return underline(vm.toString(self));
     }
 
-    function underline(bool self) internal view returns (string memory) {
+    function underline(bool self) internal pure returns (string memory) {
         return underline(vm.toString(self));
     }
 
-    function reverse(string memory self) internal view returns (string memory) {
-        return string.concat(REVERSE, self, RESET);
+    function inverse(string memory self) internal pure returns (string memory) {
+        return styleConcat(INVERSE, self);
     }
 
-    function reverse(uint256 self) internal view returns (string memory) {
-        return reverse(vm.toString(self));
+    function inverse(uint256 self) internal pure returns (string memory) {
+        return inverse(vm.toString(self));
     }
 
-    function reverse(int256 self) internal view returns (string memory) {
-        return reverse(vm.toString(self));
+    function inverse(int256 self) internal pure returns (string memory) {
+        return inverse(vm.toString(self));
     }
 
-    function reverse(address self) internal view returns (string memory) {
-        return reverse(vm.toString(self));
+    function inverse(address self) internal pure returns (string memory) {
+        return inverse(vm.toString(self));
     }
 
-    function reverse(bool self) internal view returns (string memory) {
-        return reverse(vm.toString(self));
+    function inverse(bool self) internal pure returns (string memory) {
+        return inverse(vm.toString(self));
     }
 }

--- a/src/StdStyle.sol
+++ b/src/StdStyle.sol
@@ -43,6 +43,14 @@ library StdStyle {
         return red(vm.toString(self));
     }
 
+    function redBytes(bytes memory self) internal pure returns (string memory) {
+        return red(vm.toString(self));
+    }
+
+    function redBytes32(bytes32 self) internal pure returns (string memory) {
+        return red(vm.toString(self));
+    }
+
     function green(string memory self) internal pure returns (string memory) {
         return styleConcat(GREEN, self);
     }
@@ -60,6 +68,14 @@ library StdStyle {
     }
 
     function green(bool self) internal pure returns (string memory) {
+        return green(vm.toString(self));
+    }
+
+    function greenBytes(bytes memory self) internal pure returns (string memory) {
+        return green(vm.toString(self));
+    }
+
+    function greenBytes32(bytes32 self) internal pure returns (string memory) {
         return green(vm.toString(self));
     }
 
@@ -83,6 +99,14 @@ library StdStyle {
         return yellow(vm.toString(self));
     }
 
+    function yellowBytes(bytes memory self) internal pure returns (string memory) {
+        return yellow(vm.toString(self));
+    }
+
+    function yellowBytes32(bytes32 self) internal pure returns (string memory) {
+        return yellow(vm.toString(self));
+    }
+
     function blue(string memory self) internal pure returns (string memory) {
         return styleConcat(BLUE, self);
     }
@@ -100,6 +124,14 @@ library StdStyle {
     }
 
     function blue(bool self) internal pure returns (string memory) {
+        return blue(vm.toString(self));
+    }
+
+    function blueBytes(bytes memory self) internal pure returns (string memory) {
+        return blue(vm.toString(self));
+    }
+
+    function blueBytes32(bytes32 self) internal pure returns (string memory) {
         return blue(vm.toString(self));
     }
 
@@ -123,6 +155,14 @@ library StdStyle {
         return magenta(vm.toString(self));
     }
 
+    function magentaBytes(bytes memory self) internal pure returns (string memory) {
+        return magenta(vm.toString(self));
+    }
+
+    function magentaBytes32(bytes32 self) internal pure returns (string memory) {
+        return magenta(vm.toString(self));
+    }
+
     function cyan(string memory self) internal pure returns (string memory) {
         return styleConcat(CYAN, self);
     }
@@ -140,6 +180,14 @@ library StdStyle {
     }
 
     function cyan(bool self) internal pure returns (string memory) {
+        return cyan(vm.toString(self));
+    }
+
+    function cyanBytes(bytes memory self) internal pure returns (string memory) {
+        return cyan(vm.toString(self));
+    }
+
+    function cyanBytes32(bytes32 self) internal pure returns (string memory) {
         return cyan(vm.toString(self));
     }
 
@@ -163,6 +211,14 @@ library StdStyle {
         return bold(vm.toString(self));
     }
 
+    function boldBytes(bytes memory self) internal pure returns (string memory) {
+        return bold(vm.toString(self));
+    }
+
+    function boldBytes32(bytes32 self) internal pure returns (string memory) {
+        return bold(vm.toString(self));
+    }
+
     function dim(string memory self) internal pure returns (string memory) {
         return styleConcat(DIM, self);
     }
@@ -180,6 +236,14 @@ library StdStyle {
     }
 
     function dim(bool self) internal pure returns (string memory) {
+        return dim(vm.toString(self));
+    }
+
+    function dimBytes(bytes memory self) internal pure returns (string memory) {
+        return dim(vm.toString(self));
+    }
+
+    function dimBytes32(bytes32 self) internal pure returns (string memory) {
         return dim(vm.toString(self));
     }
 
@@ -203,6 +267,14 @@ library StdStyle {
         return italic(vm.toString(self));
     }
 
+    function italicBytes(bytes memory self) internal pure returns (string memory) {
+        return italic(vm.toString(self));
+    }
+
+    function italicBytes32(bytes32 self) internal pure returns (string memory) {
+        return italic(vm.toString(self));
+    }
+
     function underline(string memory self) internal pure returns (string memory) {
         return styleConcat(UNDERLINE, self);
     }
@@ -223,6 +295,14 @@ library StdStyle {
         return underline(vm.toString(self));
     }
 
+    function underlineBytes(bytes memory self) internal pure returns (string memory) {
+        return underline(vm.toString(self));
+    }
+
+    function underlineBytes32(bytes32 self) internal pure returns (string memory) {
+        return underline(vm.toString(self));
+    }
+
     function inverse(string memory self) internal pure returns (string memory) {
         return styleConcat(INVERSE, self);
     }
@@ -240,6 +320,14 @@ library StdStyle {
     }
 
     function inverse(bool self) internal pure returns (string memory) {
+        return inverse(vm.toString(self));
+    }
+
+    function inverseBytes(bytes memory self) internal pure returns (string memory) {
+        return inverse(vm.toString(self));
+    }
+
+    function inverseBytes32(bytes32 self) internal pure returns (string memory) {
         return inverse(vm.toString(self));
     }
 }

--- a/src/StdStyle.sol
+++ b/src/StdStyle.sol
@@ -1,0 +1,241 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.4.22 <0.9.0;
+
+import {Vm} from "./Vm.sol";
+
+library StdStyle {
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    string constant RED = "\u001b[91m";
+    string constant GREEN = "\u001b[92m";
+    string constant YELLOW = "\u001b[93m";
+    string constant BLUE = "\u001b[94m";
+    string constant MAGENTA = "\u001b[95m";
+    string constant CYAN = "\u001b[96m";
+    string constant BOLD = "\u001b[1m";
+    string constant DIM = "\u001b[2m";
+    string constant ITALIC = "\u001b[3m";
+    string constant UNDERLINE = "\u001b[4m";
+    string constant REVERSE = "\u001b[7m";
+    string constant RESET = "\u001b[0m";
+
+    function red(string memory self) internal view returns (string memory) {
+        return string.concat(RED, self, RESET);
+    }
+
+    function red(uint256 self) internal view returns (string memory) {
+        return string.concat(RED, vm.toString(self), RESET);
+    }
+
+    function red(int256 self) internal view returns (string memory) {
+        return string.concat(RED, vm.toString(self), RESET);
+    }
+
+    function red(address self) internal view returns (string memory) {
+        return string.concat(RED, vm.toString(self), RESET);
+    }
+
+    function red(bool self) internal view returns (string memory) {
+        return string.concat(RED, vm.toString(self), RESET);
+    }
+
+    function green(string memory self) internal view returns (string memory) {
+        return string.concat(GREEN, self, RESET);
+    }
+
+    function green(uint256 self) internal view returns (string memory) {
+        return string.concat(GREEN, vm.toString(self), RESET);
+    }
+
+    function green(int256 self) internal view returns (string memory) {
+        return string.concat(GREEN, vm.toString(self), RESET);
+    }
+
+    function green(address self) internal view returns (string memory) {
+        return string.concat(GREEN, vm.toString(self), RESET);
+    }
+
+    function green(bool self) internal view returns (string memory) {
+        return string.concat(GREEN, vm.toString(self), RESET);
+    }
+
+    function yellow(string memory self) internal view returns (string memory) {
+        return string.concat(YELLOW, self, RESET);
+    }
+
+    function yellow(uint256 self) internal view returns (string memory) {
+        return string.concat(YELLOW, vm.toString(self), RESET);
+    }
+
+    function yellow(int256 self) internal view returns (string memory) {
+        return string.concat(YELLOW, vm.toString(self), RESET);
+    }
+
+    function yellow(address self) internal view returns (string memory) {
+        return string.concat(YELLOW, vm.toString(self), RESET);
+    }
+
+    function yellow(bool self) internal view returns (string memory) {
+        return string.concat(YELLOW, vm.toString(self), RESET);
+    }
+
+    function blue(string memory self) internal view returns (string memory) {
+        return string.concat(BLUE, self, RESET);
+    }
+
+    function blue(uint256 self) internal view returns (string memory) {
+        return string.concat(BLUE, vm.toString(self), RESET);
+    }
+
+    function blue(int256 self) internal view returns (string memory) {
+        return string.concat(BLUE, vm.toString(self), RESET);
+    }
+
+    function blue(address self) internal view returns (string memory) {
+        return string.concat(BLUE, vm.toString(self), RESET);
+    }
+
+    function blue(bool self) internal view returns (string memory) {
+        return string.concat(BLUE, vm.toString(self), RESET);
+    }
+
+    function magenta(string memory self) internal view returns (string memory) {
+        return string.concat(MAGENTA, self, RESET);
+    }
+
+    function magenta(uint256 self) internal view returns (string memory) {
+        return string.concat(MAGENTA, vm.toString(self), RESET);
+    }
+
+    function magenta(int256 self) internal view returns (string memory) {
+        return string.concat(MAGENTA, vm.toString(self), RESET);
+    }
+
+    function magenta(address self) internal view returns (string memory) {
+        return string.concat(MAGENTA, vm.toString(self), RESET);
+    }
+
+    function magenta(bool self) internal view returns (string memory) {
+        return string.concat(MAGENTA, vm.toString(self), RESET);
+    }
+
+    function cyan(string memory self) internal view returns (string memory) {
+        return string.concat(CYAN, self, RESET);
+    }
+
+    function cyan(uint256 self) internal view returns (string memory) {
+        return string.concat(CYAN, vm.toString(self), RESET);
+    }
+
+    function cyan(int256 self) internal view returns (string memory) {
+        return string.concat(CYAN, vm.toString(self), RESET);
+    }
+
+    function cyan(address self) internal view returns (string memory) {
+        return string.concat(CYAN, vm.toString(self), RESET);
+    }
+
+    function cyan(bool self) internal view returns (string memory) {
+        return string.concat(CYAN, vm.toString(self), RESET);
+    }
+
+    function bold(string memory self) internal view returns (string memory) {
+        return string.concat(BOLD, self, RESET);
+    }
+
+    function bold(uint256 self) internal view returns (string memory) {
+        return string.concat(BOLD, vm.toString(self), RESET);
+    }
+
+    function bold(int256 self) internal view returns (string memory) {
+        return string.concat(BOLD, vm.toString(self), RESET);
+    }
+
+    function bold(address self) internal view returns (string memory) {
+        return string.concat(BOLD, vm.toString(self), RESET);
+    }
+
+    function bold(bool self) internal view returns (string memory) {
+        return string.concat(BOLD, vm.toString(self), RESET);
+    }
+
+    function dim(string memory self) internal view returns (string memory) {
+        return string.concat(DIM, self, RESET);
+    }
+
+    function dim(uint256 self) internal view returns (string memory) {
+        return string.concat(DIM, vm.toString(self), RESET);
+    }
+
+    function dim(int256 self) internal view returns (string memory) {
+        return string.concat(DIM, vm.toString(self), RESET);
+    }
+
+    function dim(address self) internal view returns (string memory) {
+        return string.concat(DIM, vm.toString(self), RESET);
+    }
+
+    function dim(bool self) internal view returns (string memory) {
+        return string.concat(DIM, vm.toString(self), RESET);
+    }
+
+    function italic(string memory self) internal view returns (string memory) {
+        return string.concat(ITALIC, self, RESET);
+    }
+
+    function italic(uint256 self) internal view returns (string memory) {
+        return string.concat(ITALIC, vm.toString(self), RESET);
+    }
+
+    function italic(int256 self) internal view returns (string memory) {
+        return string.concat(ITALIC, vm.toString(self), RESET);
+    }
+
+    function italic(address self) internal view returns (string memory) {
+        return string.concat(ITALIC, vm.toString(self), RESET);
+    }
+
+    function italic(bool self) internal view returns (string memory) {
+        return string.concat(ITALIC, vm.toString(self), RESET);
+    }
+
+    function underline(string memory self) internal view returns (string memory) {
+        return string.concat(UNDERLINE, self, RESET);
+    }
+
+    function underline(uint256 self) internal view returns (string memory) {
+        return string.concat(UNDERLINE, vm.toString(self), RESET);
+    }
+
+    function underline(int256 self) internal view returns (string memory) {
+        return string.concat(UNDERLINE, vm.toString(self), RESET);
+    }
+
+    function underline(address self) internal view returns (string memory) {
+        return string.concat(UNDERLINE, vm.toString(self), RESET);
+    }
+
+    function underline(bool self) internal view returns (string memory) {
+        return string.concat(UNDERLINE, vm.toString(self), RESET);
+    }
+
+    function reverse(string memory self) internal view returns (string memory) {
+        return string.concat(REVERSE, self, RESET);
+    }
+
+    function reverse(uint256 self) internal view returns (string memory) {
+        return string.concat(REVERSE, vm.toString(self), RESET);
+    }
+
+    function reverse(int256 self) internal view returns (string memory) {
+        return string.concat(REVERSE, vm.toString(self), RESET);
+    }
+
+    function reverse(address self) internal view returns (string memory) {
+        return string.concat(REVERSE, vm.toString(self), RESET);
+    }
+
+    function reverse(bool self) internal view returns (string memory) {
+        return string.concat(REVERSE, vm.toString(self), RESET);
+    }
+}

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -19,6 +19,7 @@ import {stdMath} from "./StdMath.sol";
 import {StdStorage, stdStorage} from "./StdStorage.sol";
 import {StdUtils} from "./StdUtils.sol";
 import {Vm} from "./Vm.sol";
+import {StdStyle} from "./StdStyle.sol";
 
 // 📦 BOILERPLATE
 import {TestBase} from "./Base.sol";

--- a/test/StdStyle.t.sol
+++ b/test/StdStyle.t.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.7.0 <0.9.0;
+
+import "../src/Test.sol";
+
+contract StdStyleTest is Test {
+    function testStyleColor() public {
+        console2.log(StdStyle.red("StdStyle.red String Test"));
+        console2.log(StdStyle.red(uint256(10e18)));
+        console2.log(StdStyle.red(int256(-10e18)));
+        console2.log(StdStyle.red(true));
+        console2.log(StdStyle.red(address(0)));
+        console2.log(StdStyle.green("StdStyle.green String Test"));
+        console2.log(StdStyle.green(uint256(10e18)));
+        console2.log(StdStyle.green(int256(-10e18)));
+        console2.log(StdStyle.green(true));
+        console2.log(StdStyle.green(address(0)));
+        console2.log(StdStyle.yellow("StdStyle.yellow String Test"));
+        console2.log(StdStyle.yellow(uint256(10e18)));
+        console2.log(StdStyle.yellow(int256(-10e18)));
+        console2.log(StdStyle.yellow(true));
+        console2.log(StdStyle.yellow(address(0)));
+        console2.log(StdStyle.blue("StdStyle.blue String Test"));
+        console2.log(StdStyle.blue(uint256(10e18)));
+        console2.log(StdStyle.blue(int256(-10e18)));
+        console2.log(StdStyle.blue(true));
+        console2.log(StdStyle.blue(address(0)));
+        console2.log(StdStyle.magenta("StdStyle.magenta String Test"));
+        console2.log(StdStyle.magenta(uint256(10e18)));
+        console2.log(StdStyle.magenta(int256(-10e18)));
+        console2.log(StdStyle.magenta(true));
+        console2.log(StdStyle.magenta(address(0)));
+        console2.log(StdStyle.cyan("StdStyle.cyan String Test"));
+        console2.log(StdStyle.cyan(uint256(10e18)));
+        console2.log(StdStyle.cyan(int256(-10e18)));
+        console2.log(StdStyle.cyan(true));
+        console2.log(StdStyle.cyan(address(0)));
+    }
+
+    function testStyleFontWeight() public {
+        console2.log(StdStyle.bold("StdStyle.bold String Test"));
+        console2.log(StdStyle.bold(uint256(10e18)));
+        console2.log(StdStyle.bold(int256(-10e18)));
+        console2.log(StdStyle.bold(address(0)));
+        console2.log(StdStyle.bold(true));
+        console2.log(StdStyle.dim("StdStyle.dim String Test"));
+        console2.log(StdStyle.dim(uint256(10e18)));
+        console2.log(StdStyle.dim(int256(-10e18)));
+        console2.log(StdStyle.dim(address(0)));
+        console2.log(StdStyle.dim(true));
+        console2.log(StdStyle.italic("StdStyle.italic String Test"));
+        console2.log(StdStyle.italic(uint256(10e18)));
+        console2.log(StdStyle.italic(int256(-10e18)));
+        console2.log(StdStyle.italic(address(0)));
+        console2.log(StdStyle.italic(true));
+        console2.log(StdStyle.underline("StdStyle.underline String Test"));
+        console2.log(StdStyle.underline(uint256(10e18)));
+        console2.log(StdStyle.underline(int256(-10e18)));
+        console2.log(StdStyle.underline(address(0)));
+        console2.log(StdStyle.underline(true));
+        console2.log(StdStyle.reverse("StdStyle.reverse String Test"));
+        console2.log(StdStyle.reverse(uint256(10e18)));
+        console2.log(StdStyle.reverse(int256(-10e18)));
+        console2.log(StdStyle.reverse(address(0)));
+        console2.log(StdStyle.reverse(true));
+    }
+
+    function testStyleCombined() public {
+        console2.log(StdStyle.red(StdStyle.bold("Red Bold String Test")));
+        console2.log(StdStyle.green(StdStyle.dim(uint256(10e18))));
+        console2.log(StdStyle.yellow(StdStyle.italic(int256(-10e18))));
+        console2.log(StdStyle.blue(StdStyle.underline(address(0))));
+        console2.log(StdStyle.magenta(StdStyle.reverse(true)));
+    }
+
+    function testStyleCustom() public {
+        console2.log(h1("Custom Style 1"));
+        console2.log(h2("Custom Style 2"));
+    }
+
+    function h1(string memory a) private view returns (string memory) {
+        return StdStyle.cyan(StdStyle.reverse(StdStyle.bold(a)));
+    }
+
+    function h2(string memory a) private view returns (string memory) {
+        return StdStyle.magenta(StdStyle.bold(StdStyle.underline(a)));
+    }
+}

--- a/test/StdStyle.t.sol
+++ b/test/StdStyle.t.sol
@@ -10,31 +10,43 @@ contract StdStyleTest is Test {
         console2.log(StdStyle.red(int256(-10e18)));
         console2.log(StdStyle.red(true));
         console2.log(StdStyle.red(address(0)));
+        console2.log(StdStyle.redBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.redBytes32("StdStyle.redBytes32"));
         console2.log(StdStyle.green("StdStyle.green String Test"));
         console2.log(StdStyle.green(uint256(10e18)));
         console2.log(StdStyle.green(int256(-10e18)));
         console2.log(StdStyle.green(true));
         console2.log(StdStyle.green(address(0)));
+        console2.log(StdStyle.greenBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.greenBytes32("StdStyle.greenBytes32"));
         console2.log(StdStyle.yellow("StdStyle.yellow String Test"));
         console2.log(StdStyle.yellow(uint256(10e18)));
         console2.log(StdStyle.yellow(int256(-10e18)));
         console2.log(StdStyle.yellow(true));
         console2.log(StdStyle.yellow(address(0)));
+        console2.log(StdStyle.yellowBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.yellowBytes32("StdStyle.yellowBytes32"));
         console2.log(StdStyle.blue("StdStyle.blue String Test"));
         console2.log(StdStyle.blue(uint256(10e18)));
         console2.log(StdStyle.blue(int256(-10e18)));
         console2.log(StdStyle.blue(true));
         console2.log(StdStyle.blue(address(0)));
+        console2.log(StdStyle.blueBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.blueBytes32("StdStyle.blueBytes32"));
         console2.log(StdStyle.magenta("StdStyle.magenta String Test"));
         console2.log(StdStyle.magenta(uint256(10e18)));
         console2.log(StdStyle.magenta(int256(-10e18)));
         console2.log(StdStyle.magenta(true));
         console2.log(StdStyle.magenta(address(0)));
+        console2.log(StdStyle.magentaBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.magentaBytes32("StdStyle.magentaBytes32"));
         console2.log(StdStyle.cyan("StdStyle.cyan String Test"));
         console2.log(StdStyle.cyan(uint256(10e18)));
         console2.log(StdStyle.cyan(int256(-10e18)));
         console2.log(StdStyle.cyan(true));
         console2.log(StdStyle.cyan(address(0)));
+        console2.log(StdStyle.cyanBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.cyanBytes32("StdStyle.cyanBytes32"));
     }
 
     function testStyleFontWeight() public view {
@@ -43,26 +55,36 @@ contract StdStyleTest is Test {
         console2.log(StdStyle.bold(int256(-10e18)));
         console2.log(StdStyle.bold(address(0)));
         console2.log(StdStyle.bold(true));
+        console2.log(StdStyle.boldBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.boldBytes32("StdStyle.boldBytes32"));
         console2.log(StdStyle.dim("StdStyle.dim String Test"));
         console2.log(StdStyle.dim(uint256(10e18)));
         console2.log(StdStyle.dim(int256(-10e18)));
         console2.log(StdStyle.dim(address(0)));
         console2.log(StdStyle.dim(true));
+        console2.log(StdStyle.dimBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.dimBytes32("StdStyle.dimBytes32"));
         console2.log(StdStyle.italic("StdStyle.italic String Test"));
         console2.log(StdStyle.italic(uint256(10e18)));
         console2.log(StdStyle.italic(int256(-10e18)));
         console2.log(StdStyle.italic(address(0)));
         console2.log(StdStyle.italic(true));
+        console2.log(StdStyle.italicBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.italicBytes32("StdStyle.italicBytes32"));
         console2.log(StdStyle.underline("StdStyle.underline String Test"));
         console2.log(StdStyle.underline(uint256(10e18)));
         console2.log(StdStyle.underline(int256(-10e18)));
         console2.log(StdStyle.underline(address(0)));
         console2.log(StdStyle.underline(true));
+        console2.log(StdStyle.underlineBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.underlineBytes32("StdStyle.underlineBytes32"));
         console2.log(StdStyle.inverse("StdStyle.inverse String Test"));
         console2.log(StdStyle.inverse(uint256(10e18)));
         console2.log(StdStyle.inverse(int256(-10e18)));
         console2.log(StdStyle.inverse(address(0)));
         console2.log(StdStyle.inverse(true));
+        console2.log(StdStyle.inverseBytes(hex"7109709ECfa91a80626fF3989D68f67F5b1DD12D"));
+        console2.log(StdStyle.inverseBytes32("StdStyle.inverseBytes32"));
     }
 
     function testStyleCombined() public view {

--- a/test/StdStyle.t.sol
+++ b/test/StdStyle.t.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "../src/Test.sol";
 
 contract StdStyleTest is Test {
-    function testStyleColor() public {
+    function testStyleColor() public view {
         console2.log(StdStyle.red("StdStyle.red String Test"));
         console2.log(StdStyle.red(uint256(10e18)));
         console2.log(StdStyle.red(int256(-10e18)));
@@ -37,7 +37,7 @@ contract StdStyleTest is Test {
         console2.log(StdStyle.cyan(address(0)));
     }
 
-    function testStyleFontWeight() public {
+    function testStyleFontWeight() public view {
         console2.log(StdStyle.bold("StdStyle.bold String Test"));
         console2.log(StdStyle.bold(uint256(10e18)));
         console2.log(StdStyle.bold(int256(-10e18)));
@@ -58,31 +58,31 @@ contract StdStyleTest is Test {
         console2.log(StdStyle.underline(int256(-10e18)));
         console2.log(StdStyle.underline(address(0)));
         console2.log(StdStyle.underline(true));
-        console2.log(StdStyle.reverse("StdStyle.reverse String Test"));
-        console2.log(StdStyle.reverse(uint256(10e18)));
-        console2.log(StdStyle.reverse(int256(-10e18)));
-        console2.log(StdStyle.reverse(address(0)));
-        console2.log(StdStyle.reverse(true));
+        console2.log(StdStyle.inverse("StdStyle.inverse String Test"));
+        console2.log(StdStyle.inverse(uint256(10e18)));
+        console2.log(StdStyle.inverse(int256(-10e18)));
+        console2.log(StdStyle.inverse(address(0)));
+        console2.log(StdStyle.inverse(true));
     }
 
-    function testStyleCombined() public {
+    function testStyleCombined() public view {
         console2.log(StdStyle.red(StdStyle.bold("Red Bold String Test")));
         console2.log(StdStyle.green(StdStyle.dim(uint256(10e18))));
         console2.log(StdStyle.yellow(StdStyle.italic(int256(-10e18))));
         console2.log(StdStyle.blue(StdStyle.underline(address(0))));
-        console2.log(StdStyle.magenta(StdStyle.reverse(true)));
+        console2.log(StdStyle.magenta(StdStyle.inverse(true)));
     }
 
-    function testStyleCustom() public {
+    function testStyleCustom() public view {
         console2.log(h1("Custom Style 1"));
         console2.log(h2("Custom Style 2"));
     }
 
-    function h1(string memory a) private view returns (string memory) {
-        return StdStyle.cyan(StdStyle.reverse(StdStyle.bold(a)));
+    function h1(string memory a) private pure returns (string memory) {
+        return StdStyle.cyan(StdStyle.inverse(StdStyle.bold(a)));
     }
 
-    function h2(string memory a) private view returns (string memory) {
+    function h2(string memory a) private pure returns (string memory) {
         return StdStyle.magenta(StdStyle.bold(StdStyle.underline(a)));
     }
 }


### PR DESCRIPTION
After discussing with @mds1 and thanks to his help I've created an "styles" library that allows to use `console.log()` with different styles. As intended in #295.

### Syntax
Syntax is `StdStyle.[style_name]("Message")`. This must be used inside the standard console2.log(), and can be used with **string, uint256, int256, boolean and address** types. Moreover, they **can be nested** to apply multiple styles. Eg:
```solidity
  console2.log(StdStyle.red("Red Bold String Test"));
  console2.log(StdStyle.green(StdStyle.dim(uint256(10e18))));
  console2.log(StdStyle.yellow(StdStyle.bold(int256(-10e18))));
  console2.log(StdStyle.blue(StdStyle.underline(address(0))));
  console2.log(StdStyle.magenta(StdStyle.reverse(true)));
```
<img width="427" alt="image" src="https://user-images.githubusercontent.com/11537225/221508897-24baa848-f6f5-43a0-9491-d8e8eed73700.png">

### Styles
#### Colors
- ![#ff0000](https://placehold.co/15x15/ff0000/ff0000.png) `red`
- ![#00ff00](https://placehold.co/15x15/00ff00/00ff00.png) `green`
- ![#ffff00](https://placehold.co/15x15/ffff00/ffff00.png) `yellow`
- ![#0000ff](https://placehold.co/15x15/0000ff/0000ff.png) `blue`
- ![#ff00ff](https://placehold.co/15x15/ff00ff/ff00ff.png) `magenta`
- ![#00ffff](https://placehold.co/15x15/00ffff/00ffff.png) `cyan`
<img width="468" alt="image" src="https://user-images.githubusercontent.com/11537225/221508798-05367a06-5468-489c-b070-967379cb84ea.png">


#### Font
- bold
- dim
- italic
- underline
- reverse
<img width="492" alt="image" src="https://user-images.githubusercontent.com/11537225/221508668-aedb330e-bddf-4484-aa3e-e2418a2bb775.png">



### Custom Styles
If someone plans to use some "pre-defined" styles i.e: headers, errors, etc . Writing the full StdStyle.style syntax with nested styles multiple times can become tedious. To make this easier users can define custom styles in their test files with simple internal functions eg:

```solidity
    function testStyleCustom() public {
        console2.log(h1("Custom Style 1"));
        console2.log(h2("Custom Style 2"));
        console2.log(warning("Warning!"));
    }

    function h1(string memory a) private view returns (string memory) {
        return StdStyle.cyan(StdStyle.reverse(StdStyle.bold(a)));
    }

    function h2(string memory a) private view returns (string memory) {
        return StdStyle.magenta(StdStyle.bold(StdStyle.underline(a)));
    }

    function warning(string memory a) private view returns (string memory) {
        return StdStyle.yellow(StdStyle.bold(a));
    }
```
<img width="427" alt="image" src="https://user-images.githubusercontent.com/11537225/221508560-cbbde4d7-da75-49b4-93a7-2700dfabc889.png">



