### PR TITLE
feat: add "changePrank" variant

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -537,6 +537,11 @@ abstract contract StdCheats is StdCheatsSafe {
         vm.startPrank(msgSender);
     }
 
+    function changePrank(address msgSender, address txOrigin) internal virtual {
+        vm.stopPrank();
+        vm.startPrank(msgSender, txOrigin);
+    }
+
     // The same as Vm's `deal`
     // Use the alternative signature for ERC20 tokens
     function deal(address to, uint256 give) internal virtual {

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -57,13 +57,23 @@ contract StdCheatsTest is Test {
         test.bar(address(this));
     }
 
-    function testChangePrank() public {
+    function testChangePrankMsgSender() public {
         vm.startPrank(address(1337));
         test.bar(address(1337));
         changePrank(address(0xdead));
         test.bar(address(0xdead));
         changePrank(address(1337));
         test.bar(address(1337));
+        vm.stopPrank();
+    }
+
+    function testChangePrankMsgSenderAndTxOrigin() public {
+        vm.startPrank(address(1337), address(1338));
+        test.origin(address(1337), address(1338));
+        changePrank(address(0xdead), address(0xbeef));
+        test.origin(address(0xdead), address(0xbeef));
+        changePrank(address(1337), address(1338));
+        test.origin(address(1337), address(1338));
         vm.stopPrank();
     }
 
@@ -331,7 +341,7 @@ contract Bar {
         balanceOf[address(this)] = totalSupply;
     }
 
-    /// `HOAX` STDCHEATS
+    /// `HOAX` and `CHANGEPRANK` STDCHEATS
     function bar(address expectedSender) public payable {
         require(msg.sender == expectedSender, "!prank");
     }


### PR DESCRIPTION
Adds a `changePrank` invariant that accepts a new parameter `tx.origin` for changing the `msg.sender` and the `tx.origin` at the same time.