### PR TITLE
Allow forge-std to be installed as npm package

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "lib/ds-test"]
-	path = lib/ds-test
-	url = https://github.com/dapphub/ds-test
+[submodule "lib/ds-test"]	
+	path = lib/ds-test	
+	url = https://github.com/dapphub/ds-test	

--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/foundry-rs/forge-std.git"
+  },
+  "dependencies": {
+    "ds-test": "https://github.com/dapphub/ds-test"
   }
 }

--- a/src/StdAssertions.sol
+++ b/src/StdAssertions.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.6.2 <0.9.0;
 
-import {DSTest} from "ds-test/test.sol";
+import {DSTest} from "ds-test/src/test.sol";
 import {stdMath} from "./StdMath.sol";
 
 abstract contract StdAssertions is DSTest {

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -23,7 +23,7 @@ import {StdStyle} from "./StdStyle.sol";
 
 // 📦 BOILERPLATE
 import {TestBase} from "./Base.sol";
-import {DSTest} from "ds-test/test.sol";
+import {DSTest} from "ds-test/src/test.sol";
 
 // ⭐️ TEST
 abstract contract Test is DSTest, StdAssertions, StdChains, StdCheats, StdInvariant, StdUtils, TestBase {


### PR DESCRIPTION
## What's this do? 

Adds support for forge-std to be used through a node package manager, via `npm add forge-std` or equivalent (yarn, pnpm, etc)

## How to install

After this PR is merged: 

`npm add forge-std`

Before this PR is merged:

We've temporarily published the repo as an npm package `forge-std-no-submodules`. To use, just add this to your package.json:

```
"forge-std@npm:forge-std-no-submodules": "latest"
```

No other changes are necessary, importing forge-std should work + look the same. You can nuke your `lib/forge-std` directory and .gitmodules files if you'd like.

## Rationale

Foundry is such an incredible tool for smart contract devs. It's honestly so far beyond the alternatives, I'm not sure what I'd do without it at this point. Kudos to you and team 👏

Many of us find the git submodule only approach rather frustrating, mainly due to the fact that the vast majority of our contract dependencies are being installed via npm or equivalent.

I'd really like to make the pitch for foundry to switch from git submodules to a node package manager, and can furnish many developer opinions to the matter. 

Would you be open to a discussion?