### PR TITLE
Issue when installing this package with yarn directly from GitHub.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "(Apache-2.0 OR MIT)",
   "author": "Contributors to Forge Standard Library",
   "files": [
-    "src/*"
+    "src/**/*"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Problem
The directory `src/interfaces` is not copied in `node_modules` with yarn (At least yarn version > 2).
The `files` property of `package.json` file doesn't match properly.

## Explanation
This property is an array of path to be include in the `npm package`.
It could be a relative path, a folder or a glob pattern.
Ex: `src`, `src/Contract.sol`, `src/*`, or `src/**/*`

`npm` use this property to know which file to bundle in the package.

When `yarn` or `npm` install directly a `npm package` from a GitHub url, they will read also this property to know which files to copy to node_modules.

But `yarn` is more strict than `npm`. With yarn (and in linux in general) the pattern`src/*` will match everything except slashes. So subdirectories will not match.

## Fix
To match the `interfaces` subdirectories we need to update the pattern to `src/**/*` to just to `src`.


## Links
https://docs.npmjs.com/cli/v6/configuring-npm/package-json#files








