### PR TITLE
Add Account helper struct to StdCheats

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -188,6 +188,11 @@ abstract contract StdCheatsSafe {
         string value;
     }
 
+    struct Account {
+        address addr;
+        uint256 key;
+    }
+
     function assumeNoPrecompiles(address addr) internal virtual {
         // Assembly required since `block.chainid` was introduced in 0.8.0.
         uint256 chainId;
@@ -409,6 +414,11 @@ abstract contract StdCheatsSafe {
     // creates a labeled address
     function makeAddr(string memory name) internal virtual returns (address addr) {
         (addr,) = makeAddrAndKey(name);
+    }
+
+    // creates a struct containing both a labeled address and the corresponding private key
+    function makeAccount(string memory name) internal virtual returns (Account memory account) {
+        (account.addr, account.key) = makeAddrAndKey(name);
     }
 
     function deriveRememberKey(string memory mnemonic, uint32 index)

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -77,6 +77,13 @@ contract StdCheatsTest is Test {
         vm.stopPrank();
     }
 
+    function testMakeAccountEquivalence() public {
+        Account memory account = makeAccount("1337");
+        (address addr, uint256 key) = makeAddrAndKey("1337");
+        assertEq(account.addr, addr);
+        assertEq(account.key, key);
+    }
+
     function testMakeAddrEquivalence() public {
         (address addr,) = makeAddrAndKey("1337");
         assertEq(makeAddr("1337"), addr);


### PR DESCRIPTION
# Motivation

`makeAddrAndKey` is great for creating labeled accounts along with a private key for signing, but when working with multiple accounts, can get messy to track which key belongs to which account.

The `Account` struct contains both an address and its key. It's useful for packaging up information about arbitrary signers to be passed among different test methods.

Extremely basic use-case:

```solidity
function testFulfillOrder() public {
    Account memory offerer = makeAccount('offerer');
    // test setup logic...
    Order memory order = generateOrder(account);
    marketplace.fulfillOrder(order);
}

function generateOrder(Account memory account) internal returns (Order memory order) {
    // order generation logic...
    order.offerer = account.addr;
    order.signature = vm.sign(account.key, orderHash);
}
```

The `Account` struct is most useful when used with logic that requires an arbitrary number of accounts that need to make an arbitrary number of signatures, and assertions that require knowing an Account's address.