### PR TITLE
perf: use unchecked for stdMath.delta(uint256,uint256)

### DIFF
--- a/src/StdMath.sol
+++ b/src/StdMath.sol
@@ -14,7 +14,11 @@ library stdMath {
     }
 
     function delta(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a > b ? a - b : b - a;
+        // SAFETY: The subtraction can never underflow as we explicitly sub the
+        // smaller value from the larger.
+        unchecked {
+            return a > b ? a - b : b - a;
+        }
     }
 
     function delta(int256 a, int256 b) internal pure returns (uint256) {


### PR DESCRIPTION
I have a downstream codebase that uses `stdMath.delta`, so this gas golf would be valuable to me. If not wanted I can maintain a copy of this function ofc, just let me know.