### PR TITLE
feat(stdCheats): Introduce `grow` and `drop` cheats

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -636,4 +636,72 @@ abstract contract StdCheats is StdCheatsSafe {
         // update owner
         stdstore.target(token).sig(0x6352211e).with_key(id).checked_write(to);
     }
+
+    // Increases the ether balance of an account.
+    function grow(address to, uint256 give) internal virtual {
+        vm.deal(to, to.balance + give);
+    }
+
+    // Increases the balance of an account for any ERC20 token, updating `totalSupply`.
+    function grow(address token, address to, uint256 give) internal virtual {
+        // update balance
+        (, bytes memory balData) = token.call(abi.encodeWithSelector(0x70a08231, to));
+        uint256 prevBal = abi.decode(balData, (uint256));
+        stdstore.target(token).sig(0x70a08231).with_key(to).checked_write(prevBal + give);
+
+        // update total supply
+        (, bytes memory totSupData) = token.call(abi.encodeWithSelector(0x18160ddd));
+        uint256 totSup = abi.decode(totSupData, (uint256));
+        stdstore.target(token).sig(0x18160ddd).checked_write(totSup + give);
+    }
+
+    function growERC1155(address token, address to, uint256 id, uint256 give) internal virtual {
+        // update balance
+        (, bytes memory balData) = token.call(abi.encodeWithSelector(0x00fdd58e, to, id));
+        uint256 prevBal = abi.decode(balData, (uint256));
+        stdstore.target(token).sig(0x00fdd58e).with_key(to).with_key(id).checked_write(prevBal + give);
+
+        // update total supply
+        (, bytes memory totSupData) = token.call(abi.encodeWithSelector(0xbd85b039, id));
+        require(
+            totSupData.length != 0,
+            "StdCheats grow(address,address,uint,uint): target contract is not ERC1155Supply."
+        );
+        uint256 totSup = abi.decode(totSupData, (uint256));
+        stdstore.target(token).sig(0xbd85b039).with_key(id).checked_write(totSup + give);
+    }
+
+    // Decreases the ether balance of an account.
+    function drop(address to, uint256 give) internal virtual {
+        vm.deal(to, to.balance - give);
+    }
+
+    // Decreases the balance of an account for any ERC20 token, updating `totalSupply`.
+    function drop(address token, address to, uint256 give) internal virtual {
+        // update balance
+        (, bytes memory balData) = token.call(abi.encodeWithSelector(0x70a08231, to));
+        uint256 prevBal = abi.decode(balData, (uint256));
+        stdstore.target(token).sig(0x70a08231).with_key(to).checked_write(prevBal - give);
+
+        // update total supply
+        (, bytes memory totSupData) = token.call(abi.encodeWithSelector(0x18160ddd));
+        uint256 totSup = abi.decode(totSupData, (uint256));
+        stdstore.target(token).sig(0x18160ddd).checked_write(totSup - give);
+    }
+
+    function dropERC1155(address token, address to, uint256 id, uint256 give) internal virtual {
+        // update balance
+        (, bytes memory balData) = token.call(abi.encodeWithSelector(0x00fdd58e, to, id));
+        uint256 prevBal = abi.decode(balData, (uint256));
+        stdstore.target(token).sig(0x00fdd58e).with_key(to).with_key(id).checked_write(prevBal - give);
+
+        // update total supply
+        (, bytes memory totSupData) = token.call(abi.encodeWithSelector(0xbd85b039, id));
+        require(
+            totSupData.length != 0,
+            "StdCheats grow(address,address,uint,uint): target contract is not ERC1155Supply."
+        );
+        uint256 totSup = abi.decode(totSupData, (uint256));
+        stdstore.target(token).sig(0xbd85b039).with_key(id).checked_write(totSup - give);
+    }
 }

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -149,6 +149,65 @@ contract StdCheatsTest is Test {
         assertEq(barToken.balanceOf(bar), 1);
     }
 
+    function testGrow() public {
+        deal(address(this), 0 ether);
+        grow(address(this), 1 ether);
+        grow(address(this), 1 ether);
+        assertEq(address(this).balance, 2 ether);
+    }
+
+    function testGrowToken() public {
+        Bar barToken = new Bar();
+        address bar = address(barToken);
+        grow(bar, address(this), 10000e18);
+        assertEq(barToken.balanceOf(address(this)), 10000e18);
+        assertEq(barToken.totalSupply(), 20000e18);
+        grow(bar, address(this), 10000e18);
+        assertEq(barToken.balanceOf(address(this)), 20000e18);
+        assertEq(barToken.totalSupply(), 30000e18);
+    }
+
+    function testGrowTokenERC1155() public {
+        BarERC1155 barToken = new BarERC1155();
+        address bar = address(barToken);
+        growERC1155(bar, address(this), 0, 10000e18);
+        assertEq(barToken.balanceOf(address(this), 0), 10000e18);
+        assertEq(barToken.totalSupply(0), 20000e18);
+        growERC1155(bar, address(this), 0, 10000e18);
+        assertEq(barToken.balanceOf(address(this), 0), 20000e18);
+        assertEq(barToken.totalSupply(0), 30000e18);
+    }
+
+    function testDrop() public {
+        deal(address(this), 2 ether);
+        drop(address(this), 1 ether);
+        assertEq(address(this).balance, 1 ether);
+    }
+
+    function testDropToken() public {
+        Bar barToken = new Bar();
+        address bar = address(barToken);
+        deal(bar, address(this), 10000e18, true);
+        drop(bar, address(this), 5000e18);
+        assertEq(barToken.balanceOf(address(this)), 5000e18);
+        assertEq(barToken.totalSupply(), 15000e18);
+        drop(bar, address(this), 5000e18);
+        assertEq(barToken.balanceOf(address(this)), 0);
+        assertEq(barToken.totalSupply(), 10000e18);
+    }
+
+    function testDropTokenERC1155() public {
+        BarERC1155 barToken = new BarERC1155();
+        address bar = address(barToken);
+        dealERC1155(bar, address(this), 0, 10000e18, true);
+        dropERC1155(bar, address(this), 0, 5000e18);
+        assertEq(barToken.balanceOf(address(this), 0), 5000e18);
+        assertEq(barToken.totalSupply(0), 15000e18);
+        dropERC1155(bar, address(this), 0, 5000e18);
+        assertEq(barToken.balanceOf(address(this), 0), 0);
+        assertEq(barToken.totalSupply(0), 10000e18);
+    }
+
     function testDeployCode() public {
         address deployed = deployCode("StdCheats.t.sol:Bar", bytes(""));
         assertEq(string(getCode(deployed)), string(getCode(address(test))));


### PR DESCRIPTION
Sometimes, we need to adjust the amount of ether or tokens in an account without overwriting it completely. Currently, the only way to do this is as follows:

```Solidity
deal(address(this), address(this).balance + 1 ether);
deal(address(this), address(this).balance - 1 ether);
```

By using `grow` and `drop`, we can perform the same operation without having to consider the current amount of the specified account.

```Solidity
function testGrow() public {
    grow(address(this), 1 ether);
    grow(address(this), 1 ether);
    assertEq(address(this).balance, 2 ether);
}

function testDrop() public {
    grow(address(this), 2 ether);
    drop(address(this), 1 ether);
    assertEq(address(this).balance, 1 ether);
}
```

Enabling this functionality would enable users to avoid using mock tokens that expose mint and burn functionality, allowing them to create tests that better mimic real-world scenarios.
