### PR TITLE
ci: use "push.tags" webhook event

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,14 +1,14 @@
 name: Sync Release Branch
 
 on:
-  release:
-    types:
-      - created
+  push:
+    tags:
+      - "v1.*"
 
 jobs:
   sync-release-branch:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.release.tag_name, 'v1')
+    if: startsWith(github.ref, 'refs/tags/v1.')
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Makes the workflow added in https://github.com/foundry-rs/forge-std/pull/366 more robust by using the [`push`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#push) webhook event instead of [`release`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release), which doesn't work with releases made by other GitHub Actions workflows.

For more information, see https://github.com/anton-yurchenko/git-release/discussions/100.