### PR TITLE
feat: add memory safe logging

### DIFF
--- a/src/safeconsole.sol
+++ b/src/safeconsole.sol
@@ -24,8 +24,8 @@ library safeconsole {
     }
 
     function _memcopy(uint256 fromOffset, uint256 toOffset, uint256 length) private pure {
-        function(uint256, uint256, uint) internal view fnIn = _memcopyView;
-        function(uint256, uint256, uint) internal pure pureMemcopy;
+        function(uint256, uint256, uint256) internal view fnIn = _memcopyView;
+        function(uint256, uint256, uint256) internal pure pureMemcopy;
         assembly {
             pureMemcopy := fnIn
         }

--- a/src/safeconsole.sol
+++ b/src/safeconsole.sol
@@ -1,0 +1,13182 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.2 <0.9.0;
+
+/// @author philogy <https://github.com/philogy>
+/// @dev Code generated automatically by script.
+library safeconsole {
+    uint256 constant CONSOLE_ADDR = 0x000000000000000000000000000000000000000000636F6e736F6c652e6c6f67;
+
+    function _viewCallLog(uint256 psize) private view {
+        assembly {
+            pop(staticcall(gas(), CONSOLE_ADDR, 0x1c, psize, 0x0, 0x0))
+        }
+    }
+
+    // Credit to [0age](https://twitter.com/z0age/status/1654922202930888704) and [0xdapper](https://github.com/foundry-rs/forge-std/pull/374)
+    // for the view-to-pure log trick.
+    function _getLog() private pure returns (function(uint256) internal pure logFn) {
+        function(uint256) internal view viewLog = _viewCallLog;
+        assembly {
+            logFn := viewLog
+        }
+    }
+
+    function log(address p0) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            // Selector of `log(address)`.
+            mstore(0x00, 0x2c2ecbc2)
+            mstore(0x20, p0)
+        }
+        _getLog()(0x24);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+        }
+    }
+
+    function log(bool p0) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            // Selector of `log(bool)`.
+            mstore(0x00, 0x32458eed)
+            mstore(0x20, p0)
+        }
+        _getLog()(0x24);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+        }
+    }
+
+    function log(uint256 p0) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            // Selector of `log(uint256)`.
+            mstore(0x00, 0xf82c50f1)
+            mstore(0x20, p0)
+        }
+        _getLog()(0x24);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+        }
+    }
+
+    function log(bytes32 p0) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(string)`.
+            mstore(0x00, 0x41304fac)
+            mstore(0x20, 0x20)
+            writeString(0x40, p0)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, address p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(address,address)`.
+            mstore(0x00, 0xdaf0d4aa)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _getLog()(0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(address p0, bool p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(address,bool)`.
+            mstore(0x00, 0x75b605d3)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _getLog()(0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(address p0, uint256 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(address,uint256)`.
+            mstore(0x00, 0x8309e8a8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _getLog()(0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(address p0, bytes32 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,string)`.
+            mstore(0x00, 0x759f86bb)
+            mstore(0x20, p0)
+            mstore(0x40, 0x40)
+            writeString(0x60, p1)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(bool,address)`.
+            mstore(0x00, 0x853c4849)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _getLog()(0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(bool p0, bool p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(bool,bool)`.
+            mstore(0x00, 0x2a110e83)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _getLog()(0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(bool p0, uint256 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(bool,uint256)`.
+            mstore(0x00, 0x399174d3)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _getLog()(0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(bool p0, bytes32 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,string)`.
+            mstore(0x00, 0x8feac525)
+            mstore(0x20, p0)
+            mstore(0x40, 0x40)
+            writeString(0x60, p1)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(uint256,address)`.
+            mstore(0x00, 0x69276c86)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _getLog()(0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(uint256 p0, bool p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(uint256,bool)`.
+            mstore(0x00, 0x1c9d7eb3)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _getLog()(0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            // Selector of `log(uint256,uint256)`.
+            mstore(0x00, 0xf666715a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+        }
+        _getLog()(0x44);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,string)`.
+            mstore(0x00, 0x643fd0df)
+            mstore(0x20, p0)
+            mstore(0x40, 0x40)
+            writeString(0x60, p1)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bytes32 p0, address p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(string,address)`.
+            mstore(0x00, 0x319af333)
+            mstore(0x20, 0x40)
+            mstore(0x40, p1)
+            writeString(0x60, p0)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bytes32 p0, bool p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(string,bool)`.
+            mstore(0x00, 0xc3b55635)
+            mstore(0x20, 0x40)
+            mstore(0x40, p1)
+            writeString(0x60, p0)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(string,uint256)`.
+            mstore(0x00, 0xb60e72cc)
+            mstore(0x20, 0x40)
+            mstore(0x40, p1)
+            writeString(0x60, p0)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,string)`.
+            mstore(0x00, 0x4b5c4277)
+            mstore(0x20, 0x40)
+            mstore(0x40, 0x80)
+            writeString(0x60, p0)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,address,address)`.
+            mstore(0x00, 0x018c84c2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, address p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,address,bool)`.
+            mstore(0x00, 0xf2a66286)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, address p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,address,uint256)`.
+            mstore(0x00, 0x17fe6185)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, address p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(address,address,string)`.
+            mstore(0x00, 0x007150be)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(address p0, bool p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,bool,address)`.
+            mstore(0x00, 0xf11699ed)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, bool p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,bool,bool)`.
+            mstore(0x00, 0xeb830c92)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, bool p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,bool,uint256)`.
+            mstore(0x00, 0x9c4f99fb)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, bool p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(address,bool,string)`.
+            mstore(0x00, 0x212255cc)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(address p0, uint256 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,uint256,address)`.
+            mstore(0x00, 0x7bc0d848)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, uint256 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,uint256,bool)`.
+            mstore(0x00, 0x678209a8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, uint256 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(address,uint256,uint256)`.
+            mstore(0x00, 0xb69bcaf6)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(address p0, uint256 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(address,uint256,string)`.
+            mstore(0x00, 0xa1f2e8aa)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(address p0, bytes32 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(address,string,address)`.
+            mstore(0x00, 0xf08744e8)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(address,string,bool)`.
+            mstore(0x00, 0xcf020fb1)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(address p0, bytes32 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(address,string,uint256)`.
+            mstore(0x00, 0x67dd6ff1)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(address,string,string)`.
+            mstore(0x00, 0xfb772265)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, 0xa0)
+            writeString(0x80, p1)
+            writeString(0xc0, p2)
+        }
+        _getLog()(0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bool p0, address p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,address,address)`.
+            mstore(0x00, 0xd2763667)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, address p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,address,bool)`.
+            mstore(0x00, 0x18c9c746)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, address p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,address,uint256)`.
+            mstore(0x00, 0x5f7b9afb)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, address p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(bool,address,string)`.
+            mstore(0x00, 0xde9a9270)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bool p0, bool p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,bool,address)`.
+            mstore(0x00, 0x1078f68d)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, bool p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,bool,bool)`.
+            mstore(0x00, 0x50709698)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, bool p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,bool,uint256)`.
+            mstore(0x00, 0x12f21602)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, bool p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(bool,bool,string)`.
+            mstore(0x00, 0x2555fa46)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bool p0, uint256 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,uint256,address)`.
+            mstore(0x00, 0x088ef9d2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,uint256,bool)`.
+            mstore(0x00, 0xe8defba9)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(bool,uint256,uint256)`.
+            mstore(0x00, 0x37103367)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(bool,uint256,string)`.
+            mstore(0x00, 0xc3fc3970)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(bool,string,address)`.
+            mstore(0x00, 0x9591b953)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(bool,string,bool)`.
+            mstore(0x00, 0xdbb4c247)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(bool,string,uint256)`.
+            mstore(0x00, 0x1093ee11)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(bool,string,string)`.
+            mstore(0x00, 0xb076847f)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, 0xa0)
+            writeString(0x80, p1)
+            writeString(0xc0, p2)
+        }
+        _getLog()(0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(uint256 p0, address p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,address,address)`.
+            mstore(0x00, 0xbcfd9be0)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, address p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,address,bool)`.
+            mstore(0x00, 0x9b6ec042)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, address p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,address,uint256)`.
+            mstore(0x00, 0x5a9b5ed5)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, address p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(uint256,address,string)`.
+            mstore(0x00, 0x63cb41f9)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(uint256 p0, bool p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,bool,address)`.
+            mstore(0x00, 0x35085f7b)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,bool,bool)`.
+            mstore(0x00, 0x20718650)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,bool,uint256)`.
+            mstore(0x00, 0x20098014)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(uint256,bool,string)`.
+            mstore(0x00, 0x85775021)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,uint256,address)`.
+            mstore(0x00, 0x5c96b331)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,uint256,bool)`.
+            mstore(0x00, 0x4766da72)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            // Selector of `log(uint256,uint256,uint256)`.
+            mstore(0x00, 0xd1ed7a3c)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+        }
+        _getLog()(0x64);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(uint256,uint256,string)`.
+            mstore(0x00, 0x71d04af2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x60)
+            writeString(0x80, p2)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(uint256,string,address)`.
+            mstore(0x00, 0x7afac959)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(uint256,string,bool)`.
+            mstore(0x00, 0x4ceda75a)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(uint256,string,uint256)`.
+            mstore(0x00, 0x37aa7d4c)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, p2)
+            writeString(0x80, p1)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(uint256,string,string)`.
+            mstore(0x00, 0xb115611f)
+            mstore(0x20, p0)
+            mstore(0x40, 0x60)
+            mstore(0x60, 0xa0)
+            writeString(0x80, p1)
+            writeString(0xc0, p2)
+        }
+        _getLog()(0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, address p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,address,address)`.
+            mstore(0x00, 0xfcec75e0)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,address,bool)`.
+            mstore(0x00, 0xc91d5ed4)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, address p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,address,uint256)`.
+            mstore(0x00, 0x0d26b925)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(string,address,string)`.
+            mstore(0x00, 0xe0e9ad4f)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, 0xa0)
+            writeString(0x80, p0)
+            writeString(0xc0, p2)
+        }
+        _getLog()(0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,bool,address)`.
+            mstore(0x00, 0x932bbb38)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,bool,bool)`.
+            mstore(0x00, 0x850b7ad6)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,bool,uint256)`.
+            mstore(0x00, 0xc95958d6)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(string,bool,string)`.
+            mstore(0x00, 0xe298f47d)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, 0xa0)
+            writeString(0x80, p0)
+            writeString(0xc0, p2)
+        }
+        _getLog()(0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,uint256,address)`.
+            mstore(0x00, 0x1c7ec448)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,uint256,bool)`.
+            mstore(0x00, 0xca7733b1)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            // Selector of `log(string,uint256,uint256)`.
+            mstore(0x00, 0xca47c4eb)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+        }
+        _getLog()(0xa4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(string,uint256,string)`.
+            mstore(0x00, 0x5970e089)
+            mstore(0x20, 0x60)
+            mstore(0x40, p1)
+            mstore(0x60, 0xa0)
+            writeString(0x80, p0)
+            writeString(0xc0, p2)
+        }
+        _getLog()(0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, address p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(string,string,address)`.
+            mstore(0x00, 0x95ed0195)
+            mstore(0x20, 0x60)
+            mstore(0x40, 0xa0)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+            writeString(0xc0, p1)
+        }
+        _getLog()(0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bool p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(string,string,bool)`.
+            mstore(0x00, 0xb0e0f9b5)
+            mstore(0x20, 0x60)
+            mstore(0x40, 0xa0)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+            writeString(0xc0, p1)
+        }
+        _getLog()(0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, uint256 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            // Selector of `log(string,string,uint256)`.
+            mstore(0x00, 0x5821efa1)
+            mstore(0x20, 0x60)
+            mstore(0x40, 0xa0)
+            mstore(0x60, p2)
+            writeString(0x80, p0)
+            writeString(0xc0, p1)
+        }
+        _getLog()(0xe4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bytes32 p2) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            // Selector of `log(string,string,string)`.
+            mstore(0x00, 0x2ced7cef)
+            mstore(0x20, 0x60)
+            mstore(0x40, 0xa0)
+            mstore(0x60, 0xe0)
+            writeString(0x80, p0)
+            writeString(0xc0, p1)
+            writeString(0x100, p2)
+        }
+        _getLog()(0x124);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+        }
+    }
+
+    function log(address p0, address p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,address,address)`.
+            mstore(0x00, 0x665bf134)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,address,bool)`.
+            mstore(0x00, 0x0e378994)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,address,uint256)`.
+            mstore(0x00, 0x94250d77)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,address,address,string)`.
+            mstore(0x00, 0xf808da20)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,bool,address)`.
+            mstore(0x00, 0x9f1bc36e)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,bool,bool)`.
+            mstore(0x00, 0x2cd4134a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,bool,uint256)`.
+            mstore(0x00, 0x3971e78c)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,address,bool,string)`.
+            mstore(0x00, 0xaa6540c8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,uint256,address)`.
+            mstore(0x00, 0x8da6def5)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,uint256,bool)`.
+            mstore(0x00, 0x9b4254e2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,address,uint256,uint256)`.
+            mstore(0x00, 0xbe553481)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, address p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,address,uint256,string)`.
+            mstore(0x00, 0xfdb4f990)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,address,string,address)`.
+            mstore(0x00, 0x8f736d16)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,address,string,bool)`.
+            mstore(0x00, 0x6f1a594e)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,address,string,uint256)`.
+            mstore(0x00, 0xef1cefe7)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, address p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,address,string,string)`.
+            mstore(0x00, 0x21bdaf25)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bool p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,address,address)`.
+            mstore(0x00, 0x660375dd)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,address,bool)`.
+            mstore(0x00, 0xa6f50b0f)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,address,uint256)`.
+            mstore(0x00, 0xa75c59de)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,bool,address,string)`.
+            mstore(0x00, 0x2dd778e6)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bool p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,bool,address)`.
+            mstore(0x00, 0xcf394485)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,bool,bool)`.
+            mstore(0x00, 0xcac43479)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,bool,uint256)`.
+            mstore(0x00, 0x8c4e5de6)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,bool,bool,string)`.
+            mstore(0x00, 0xdfc4a2e8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bool p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,uint256,address)`.
+            mstore(0x00, 0xccf790a1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,uint256,bool)`.
+            mstore(0x00, 0xc4643e20)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,bool,uint256,uint256)`.
+            mstore(0x00, 0x386ff5f4)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, bool p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,bool,uint256,string)`.
+            mstore(0x00, 0x0aa6cfad)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bool p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,bool,string,address)`.
+            mstore(0x00, 0x19fd4956)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bool p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,bool,string,bool)`.
+            mstore(0x00, 0x50ad461d)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bool p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,bool,string,uint256)`.
+            mstore(0x00, 0x80e6a20b)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bool p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,bool,string,string)`.
+            mstore(0x00, 0x475c5c33)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, uint256 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,address,address)`.
+            mstore(0x00, 0x478d1c62)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,address,bool)`.
+            mstore(0x00, 0xa1bcc9b3)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,address,uint256)`.
+            mstore(0x00, 0x100f650e)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,uint256,address,string)`.
+            mstore(0x00, 0x1da986ea)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, uint256 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,bool,address)`.
+            mstore(0x00, 0xa31bfdcc)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,bool,bool)`.
+            mstore(0x00, 0x3bf5e537)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,bool,uint256)`.
+            mstore(0x00, 0x22f6b999)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,uint256,bool,string)`.
+            mstore(0x00, 0xc5ad85f9)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, uint256 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,uint256,address)`.
+            mstore(0x00, 0x20e3984d)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,uint256,bool)`.
+            mstore(0x00, 0x66f1bc67)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(address,uint256,uint256,uint256)`.
+            mstore(0x00, 0x34f0e636)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(address p0, uint256 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,uint256,uint256,string)`.
+            mstore(0x00, 0x4a28c017)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, uint256 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,uint256,string,address)`.
+            mstore(0x00, 0x5c430d47)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, uint256 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,uint256,string,bool)`.
+            mstore(0x00, 0xcf18105c)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, uint256 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,uint256,string,uint256)`.
+            mstore(0x00, 0xbf01f891)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, uint256 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,uint256,string,string)`.
+            mstore(0x00, 0x88a8c406)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,address,address)`.
+            mstore(0x00, 0x0d36fa20)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,address,bool)`.
+            mstore(0x00, 0x0df12b76)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,address,uint256)`.
+            mstore(0x00, 0x457fe3cf)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,string,address,string)`.
+            mstore(0x00, 0xf7e36245)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,bool,address)`.
+            mstore(0x00, 0x205871c2)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,bool,bool)`.
+            mstore(0x00, 0x5f1d5c9f)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,bool,uint256)`.
+            mstore(0x00, 0x515e38b6)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,string,bool,string)`.
+            mstore(0x00, 0xbc0b61fe)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,uint256,address)`.
+            mstore(0x00, 0x63183678)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,uint256,bool)`.
+            mstore(0x00, 0x0ef7e050)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(address,string,uint256,uint256)`.
+            mstore(0x00, 0x1dc8e1b8)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(address p0, bytes32 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,string,uint256,string)`.
+            mstore(0x00, 0x448830a8)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,string,string,address)`.
+            mstore(0x00, 0xa04e2f87)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,string,string,bool)`.
+            mstore(0x00, 0x35a5071f)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(address,string,string,uint256)`.
+            mstore(0x00, 0x159f8927)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(address p0, bytes32 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(address,string,string,string)`.
+            mstore(0x00, 0x5d02c50b)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+            writeString(0x120, p3)
+        }
+        _getLog()(0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bool p0, address p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,address,address)`.
+            mstore(0x00, 0x1d14d001)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,address,bool)`.
+            mstore(0x00, 0x46600be0)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,address,uint256)`.
+            mstore(0x00, 0x0c66d1be)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,address,address,string)`.
+            mstore(0x00, 0xd812a167)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, address p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,bool,address)`.
+            mstore(0x00, 0x1c41a336)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,bool,bool)`.
+            mstore(0x00, 0x6a9c478b)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,bool,uint256)`.
+            mstore(0x00, 0x07831502)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,address,bool,string)`.
+            mstore(0x00, 0x4a66cb34)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, address p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,uint256,address)`.
+            mstore(0x00, 0x136b05dd)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,uint256,bool)`.
+            mstore(0x00, 0xd6019f1c)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,address,uint256,uint256)`.
+            mstore(0x00, 0x7bf181a1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, address p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,address,uint256,string)`.
+            mstore(0x00, 0x51f09ff8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, address p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,address,string,address)`.
+            mstore(0x00, 0x6f7c603e)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, address p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,address,string,bool)`.
+            mstore(0x00, 0xe2bfd60b)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, address p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,address,string,uint256)`.
+            mstore(0x00, 0xc21f64c7)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, address p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,address,string,string)`.
+            mstore(0x00, 0xa73c1db6)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bool p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,address,address)`.
+            mstore(0x00, 0xf4880ea4)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,address,bool)`.
+            mstore(0x00, 0xc0a302d8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,address,uint256)`.
+            mstore(0x00, 0x4c123d57)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,bool,address,string)`.
+            mstore(0x00, 0xa0a47963)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bool p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,bool,address)`.
+            mstore(0x00, 0x8c329b1a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,bool,bool)`.
+            mstore(0x00, 0x3b2a5ce0)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,bool,uint256)`.
+            mstore(0x00, 0x6d7045c1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,bool,bool,string)`.
+            mstore(0x00, 0x2ae408d4)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bool p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,uint256,address)`.
+            mstore(0x00, 0x54a7a9a0)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,uint256,bool)`.
+            mstore(0x00, 0x619e4d0e)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,bool,uint256,uint256)`.
+            mstore(0x00, 0x0bb00eab)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, bool p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,bool,uint256,string)`.
+            mstore(0x00, 0x7dd4d0e0)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bool p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,bool,string,address)`.
+            mstore(0x00, 0xf9ad2b89)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bool p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,bool,string,bool)`.
+            mstore(0x00, 0xb857163a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bool p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,bool,string,uint256)`.
+            mstore(0x00, 0xe3a9ca2f)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bool p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,bool,string,string)`.
+            mstore(0x00, 0x6d1e8751)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, uint256 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,address,address)`.
+            mstore(0x00, 0x26f560a8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,address,bool)`.
+            mstore(0x00, 0xb4c314ff)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,address,uint256)`.
+            mstore(0x00, 0x1537dc87)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,uint256,address,string)`.
+            mstore(0x00, 0x1bb3b09a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,bool,address)`.
+            mstore(0x00, 0x9acd3616)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,bool,bool)`.
+            mstore(0x00, 0xceb5f4d7)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,bool,uint256)`.
+            mstore(0x00, 0x7f9bbca2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,uint256,bool,string)`.
+            mstore(0x00, 0x9143dbb1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,uint256,address)`.
+            mstore(0x00, 0x00dd87b9)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,uint256,bool)`.
+            mstore(0x00, 0xbe984353)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(bool,uint256,uint256,uint256)`.
+            mstore(0x00, 0x374bb4b2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(bool p0, uint256 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,uint256,uint256,string)`.
+            mstore(0x00, 0x8e69fb5d)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,uint256,string,address)`.
+            mstore(0x00, 0xfedd1fff)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,uint256,string,bool)`.
+            mstore(0x00, 0xe5e70b2b)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,uint256,string,uint256)`.
+            mstore(0x00, 0x6a1199e2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, uint256 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,uint256,string,string)`.
+            mstore(0x00, 0xf5bc2249)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,address,address)`.
+            mstore(0x00, 0x2b2b18dc)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,address,bool)`.
+            mstore(0x00, 0x6dd434ca)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,address,uint256)`.
+            mstore(0x00, 0xa5cada94)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,string,address,string)`.
+            mstore(0x00, 0x12d6c788)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,bool,address)`.
+            mstore(0x00, 0x538e06ab)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,bool,bool)`.
+            mstore(0x00, 0xdc5e935b)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,bool,uint256)`.
+            mstore(0x00, 0x1606a393)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,string,bool,string)`.
+            mstore(0x00, 0x483d0416)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,uint256,address)`.
+            mstore(0x00, 0x1596a1ce)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,uint256,bool)`.
+            mstore(0x00, 0x6b0e5d53)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(bool,string,uint256,uint256)`.
+            mstore(0x00, 0x28863fcb)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,string,uint256,string)`.
+            mstore(0x00, 0x1ad96de6)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,string,string,address)`.
+            mstore(0x00, 0x97d394d8)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,string,string,bool)`.
+            mstore(0x00, 0x1e4b87e5)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(bool,string,string,uint256)`.
+            mstore(0x00, 0x7be0c3eb)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bool p0, bytes32 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(bool,string,string,string)`.
+            mstore(0x00, 0x1762e32a)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+            writeString(0x120, p3)
+        }
+        _getLog()(0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(uint256 p0, address p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,address,address)`.
+            mstore(0x00, 0x2488b414)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,address,bool)`.
+            mstore(0x00, 0x091ffaf5)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,address,uint256)`.
+            mstore(0x00, 0x736efbb6)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,address,address,string)`.
+            mstore(0x00, 0x031c6f73)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, address p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,bool,address)`.
+            mstore(0x00, 0xef72c513)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,bool,bool)`.
+            mstore(0x00, 0xe351140f)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,bool,uint256)`.
+            mstore(0x00, 0x5abd992a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,address,bool,string)`.
+            mstore(0x00, 0x90fb06aa)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, address p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,uint256,address)`.
+            mstore(0x00, 0x15c127b5)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,uint256,bool)`.
+            mstore(0x00, 0x5f743a7c)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,address,uint256,uint256)`.
+            mstore(0x00, 0x0c9cd9c1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, address p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,address,uint256,string)`.
+            mstore(0x00, 0xddb06521)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, address p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,address,string,address)`.
+            mstore(0x00, 0x9cba8fff)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, address p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,address,string,bool)`.
+            mstore(0x00, 0xcc32ab07)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, address p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,address,string,uint256)`.
+            mstore(0x00, 0x46826b5d)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, address p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,address,string,string)`.
+            mstore(0x00, 0x3e128ca3)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bool p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,address,address)`.
+            mstore(0x00, 0xa1ef4cbb)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,address,bool)`.
+            mstore(0x00, 0x454d54a5)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,address,uint256)`.
+            mstore(0x00, 0x078287f5)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,bool,address,string)`.
+            mstore(0x00, 0xade052c7)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,bool,address)`.
+            mstore(0x00, 0x69640b59)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,bool,bool)`.
+            mstore(0x00, 0xb6f577a1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,bool,uint256)`.
+            mstore(0x00, 0x7464ce23)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,bool,bool,string)`.
+            mstore(0x00, 0xdddb9561)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,uint256,address)`.
+            mstore(0x00, 0x88cb6041)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,uint256,bool)`.
+            mstore(0x00, 0x91a02e2a)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,bool,uint256,uint256)`.
+            mstore(0x00, 0xc6acc7a8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, bool p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,bool,uint256,string)`.
+            mstore(0x00, 0xde03e774)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,bool,string,address)`.
+            mstore(0x00, 0xef529018)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,bool,string,bool)`.
+            mstore(0x00, 0xeb928d7f)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,bool,string,uint256)`.
+            mstore(0x00, 0x2c1d0746)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bool p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,bool,string,string)`.
+            mstore(0x00, 0x68c8b8bd)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,address,address)`.
+            mstore(0x00, 0x56a5d1b1)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,address,bool)`.
+            mstore(0x00, 0x15cac476)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,address,uint256)`.
+            mstore(0x00, 0x88f6e4b2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,uint256,address,string)`.
+            mstore(0x00, 0x6cde40b8)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,bool,address)`.
+            mstore(0x00, 0x9a816a83)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,bool,bool)`.
+            mstore(0x00, 0xab085ae6)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,bool,uint256)`.
+            mstore(0x00, 0xeb7f6fd2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,uint256,bool,string)`.
+            mstore(0x00, 0xa5b4fc99)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,uint256,address)`.
+            mstore(0x00, 0xfa8185af)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,uint256,bool)`.
+            mstore(0x00, 0xc598d185)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        assembly {
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            // Selector of `log(uint256,uint256,uint256,uint256)`.
+            mstore(0x00, 0x193fb800)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+        }
+        _getLog()(0x84);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,uint256,uint256,string)`.
+            mstore(0x00, 0x59cfcbe3)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0x80)
+            writeString(0xa0, p3)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,uint256,string,address)`.
+            mstore(0x00, 0x42d21db7)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,uint256,string,bool)`.
+            mstore(0x00, 0x7af6ab25)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,uint256,string,uint256)`.
+            mstore(0x00, 0x5da297eb)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, p3)
+            writeString(0xa0, p2)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, uint256 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,uint256,string,string)`.
+            mstore(0x00, 0x27d8afd2)
+            mstore(0x20, p0)
+            mstore(0x40, p1)
+            mstore(0x60, 0x80)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p2)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,address,address)`.
+            mstore(0x00, 0x6168ed61)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,address,bool)`.
+            mstore(0x00, 0x90c30a56)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,address,uint256)`.
+            mstore(0x00, 0xe8d3018d)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,string,address,string)`.
+            mstore(0x00, 0x9c3adfa1)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,bool,address)`.
+            mstore(0x00, 0xae2ec581)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,bool,bool)`.
+            mstore(0x00, 0xba535d9c)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,bool,uint256)`.
+            mstore(0x00, 0xcf009880)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,string,bool,string)`.
+            mstore(0x00, 0xd2d423cd)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,uint256,address)`.
+            mstore(0x00, 0x3b2279b4)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,uint256,bool)`.
+            mstore(0x00, 0x691a8f74)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(uint256,string,uint256,uint256)`.
+            mstore(0x00, 0x82c25b74)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,string,uint256,string)`.
+            mstore(0x00, 0xb7b914ca)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p1)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,string,string,address)`.
+            mstore(0x00, 0xd583c602)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,string,string,bool)`.
+            mstore(0x00, 0xb3a6b6bd)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(uint256,string,string,uint256)`.
+            mstore(0x00, 0xb028c9bd)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(uint256 p0, bytes32 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(uint256,string,string,string)`.
+            mstore(0x00, 0x21ad0683)
+            mstore(0x20, p0)
+            mstore(0x40, 0x80)
+            mstore(0x60, 0xc0)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p1)
+            writeString(0xe0, p2)
+            writeString(0x120, p3)
+        }
+        _getLog()(0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, address p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,address,address)`.
+            mstore(0x00, 0xed8f28f6)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,address,bool)`.
+            mstore(0x00, 0xb59dbd60)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,address,uint256)`.
+            mstore(0x00, 0x8ef3f399)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,address,address,string)`.
+            mstore(0x00, 0x800a1c67)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,bool,address)`.
+            mstore(0x00, 0x223603bd)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,bool,bool)`.
+            mstore(0x00, 0x79884c2b)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,bool,uint256)`.
+            mstore(0x00, 0x3e9f866a)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,address,bool,string)`.
+            mstore(0x00, 0x0454c079)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, address p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,uint256,address)`.
+            mstore(0x00, 0x63fb8bc5)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,uint256,bool)`.
+            mstore(0x00, 0xfc4845f0)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,address,uint256,uint256)`.
+            mstore(0x00, 0xf8f51b1e)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, address p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,address,uint256,string)`.
+            mstore(0x00, 0x5a477632)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,address,string,address)`.
+            mstore(0x00, 0xaabc9a31)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,address,string,bool)`.
+            mstore(0x00, 0x5f15d28c)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,address,string,uint256)`.
+            mstore(0x00, 0x91d1112e)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, address p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,address,string,string)`.
+            mstore(0x00, 0x245986f2)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+            writeString(0x120, p3)
+        }
+        _getLog()(0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,address,address)`.
+            mstore(0x00, 0x33e9dd1d)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,address,bool)`.
+            mstore(0x00, 0x958c28c6)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,address,uint256)`.
+            mstore(0x00, 0x5d08bb05)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,bool,address,string)`.
+            mstore(0x00, 0x2d8e33a4)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,bool,address)`.
+            mstore(0x00, 0x7190a529)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,bool,bool)`.
+            mstore(0x00, 0x895af8c5)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,bool,uint256)`.
+            mstore(0x00, 0x8e3f78a9)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,bool,bool,string)`.
+            mstore(0x00, 0x9d22d5dd)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,uint256,address)`.
+            mstore(0x00, 0x935e09bf)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,uint256,bool)`.
+            mstore(0x00, 0x8af7cf8a)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,bool,uint256,uint256)`.
+            mstore(0x00, 0x64b5bb67)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,bool,uint256,string)`.
+            mstore(0x00, 0x742d6ee7)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,bool,string,address)`.
+            mstore(0x00, 0xe0625b29)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,bool,string,bool)`.
+            mstore(0x00, 0x3f8a701d)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,bool,string,uint256)`.
+            mstore(0x00, 0x24f91465)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bool p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,bool,string,string)`.
+            mstore(0x00, 0xa826caeb)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+            writeString(0x120, p3)
+        }
+        _getLog()(0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,address,address)`.
+            mstore(0x00, 0x5ea2b7ae)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,address,bool)`.
+            mstore(0x00, 0x82112a42)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,address,uint256)`.
+            mstore(0x00, 0x4f04fdc6)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,uint256,address,string)`.
+            mstore(0x00, 0x9ffb2f93)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,bool,address)`.
+            mstore(0x00, 0xe0e95b98)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,bool,bool)`.
+            mstore(0x00, 0x354c36d6)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,bool,uint256)`.
+            mstore(0x00, 0xe41b6f6f)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,uint256,bool,string)`.
+            mstore(0x00, 0xabf73a98)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,uint256,address)`.
+            mstore(0x00, 0xe21de278)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,uint256,bool)`.
+            mstore(0x00, 0x7626db92)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            // Selector of `log(string,uint256,uint256,uint256)`.
+            mstore(0x00, 0xa7a87853)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+        }
+        _getLog()(0xc4);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,uint256,uint256,string)`.
+            mstore(0x00, 0x854b3496)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, p2)
+            mstore(0x80, 0xc0)
+            writeString(0xa0, p0)
+            writeString(0xe0, p3)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,uint256,string,address)`.
+            mstore(0x00, 0x7c4632a4)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,uint256,string,bool)`.
+            mstore(0x00, 0x7d24491d)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,uint256,string,uint256)`.
+            mstore(0x00, 0xc67ea9d1)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, uint256 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,uint256,string,string)`.
+            mstore(0x00, 0x5ab84e1f)
+            mstore(0x20, 0x80)
+            mstore(0x40, p1)
+            mstore(0x60, 0xc0)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p0)
+            writeString(0xe0, p2)
+            writeString(0x120, p3)
+        }
+        _getLog()(0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, address p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,address,address)`.
+            mstore(0x00, 0x439c7bef)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, address p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,address,bool)`.
+            mstore(0x00, 0x5ccd4e37)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, address p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,address,uint256)`.
+            mstore(0x00, 0x7cc3c607)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, address p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,string,address,string)`.
+            mstore(0x00, 0xeb1bff80)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p3)
+        }
+        _getLog()(0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bool p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,bool,address)`.
+            mstore(0x00, 0xc371c7db)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bool p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,bool,bool)`.
+            mstore(0x00, 0x40785869)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bool p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,bool,uint256)`.
+            mstore(0x00, 0xd6aefad2)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bool p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,string,bool,string)`.
+            mstore(0x00, 0x5e84b0ea)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p3)
+        }
+        _getLog()(0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, uint256 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,uint256,address)`.
+            mstore(0x00, 0x1023f7b2)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, uint256 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,uint256,bool)`.
+            mstore(0x00, 0xc3a8a654)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, uint256 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            // Selector of `log(string,string,uint256,uint256)`.
+            mstore(0x00, 0xf45d7d2c)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+        }
+        _getLog()(0x104);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, uint256 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,string,uint256,string)`.
+            mstore(0x00, 0x5d1a971a)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, p2)
+            mstore(0x80, 0x100)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p3)
+        }
+        _getLog()(0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bytes32 p2, address p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,string,string,address)`.
+            mstore(0x00, 0x6d572f44)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, 0x100)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p2)
+        }
+        _getLog()(0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bytes32 p2, bool p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,string,string,bool)`.
+            mstore(0x00, 0x2c1754ed)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, 0x100)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p2)
+        }
+        _getLog()(0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bytes32 p2, uint256 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            // Selector of `log(string,string,string,uint256)`.
+            mstore(0x00, 0x8eafb02b)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, 0x100)
+            mstore(0x80, p3)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p2)
+        }
+        _getLog()(0x144);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+        }
+    }
+
+    function log(bytes32 p0, bytes32 p1, bytes32 p2, bytes32 p3) internal pure {
+        bytes32 m0;
+        bytes32 m1;
+        bytes32 m2;
+        bytes32 m3;
+        bytes32 m4;
+        bytes32 m5;
+        bytes32 m6;
+        bytes32 m7;
+        bytes32 m8;
+        bytes32 m9;
+        bytes32 m10;
+        bytes32 m11;
+        bytes32 m12;
+        assembly {
+            function writeString(pos, w) {
+                let length := 0
+                for {} lt(length, 0x20) { length := add(length, 1) } { if iszero(byte(length, w)) { break } }
+                mstore(pos, length)
+                let shift := sub(256, shl(3, length))
+                mstore(add(pos, 0x20), shl(shift, shr(shift, w)))
+            }
+            m0 := mload(0x00)
+            m1 := mload(0x20)
+            m2 := mload(0x40)
+            m3 := mload(0x60)
+            m4 := mload(0x80)
+            m5 := mload(0xa0)
+            m6 := mload(0xc0)
+            m7 := mload(0xe0)
+            m8 := mload(0x100)
+            m9 := mload(0x120)
+            m10 := mload(0x140)
+            m11 := mload(0x160)
+            m12 := mload(0x180)
+            // Selector of `log(string,string,string,string)`.
+            mstore(0x00, 0xde68f20a)
+            mstore(0x20, 0x80)
+            mstore(0x40, 0xc0)
+            mstore(0x60, 0x100)
+            mstore(0x80, 0x140)
+            writeString(0xa0, p0)
+            writeString(0xe0, p1)
+            writeString(0x120, p2)
+            writeString(0x160, p3)
+        }
+        _getLog()(0x184);
+        assembly {
+            mstore(0x00, m0)
+            mstore(0x20, m1)
+            mstore(0x40, m2)
+            mstore(0x60, m3)
+            mstore(0x80, m4)
+            mstore(0xa0, m5)
+            mstore(0xc0, m6)
+            mstore(0xe0, m7)
+            mstore(0x100, m8)
+            mstore(0x120, m9)
+            mstore(0x140, m10)
+            mstore(0x160, m11)
+            mstore(0x180, m12)
+        }
+    }
+}


### PR DESCRIPTION
Adds a new alternative logging library to `console` and `console2`, dubbed "safeconsole" that behaves almost identically to `console2` but leaves memory intact, making it useful for logging and debugging memory manipulating inline-assembly code. This is achieved by replacing string arguments with `bytes32` allowing you use the same string-syntax e.g. `safeconsole.log("My int: %d", 34);` without affecting memory (as long as your logging string is less than or equal to 32 characters long). The library also uses the [0age function pointer casting trick](https://twitter.com/z0age/status/1654922202930888704) to ensure that all logging functions are `pure` and don't require function visibility changes.

Carried over from my repo [forge-safe-log](https://github.com/Philogy/forge-safe-log) (renamed from "safelog" to avoid redundant sounding "safelog.log" writing). You'll also find the script that generated the library [here](https://github.com/Philogy/forge-safe-log/blob/main/script/generate-log-fns.py).