### PR TITLE
fix(`StdAssertions`): Expect all events to be emitted, without omitting the first one

### DIFF
--- a/test/StdAssertions.t.sol
+++ b/test/StdAssertions.t.sol
@@ -686,11 +686,15 @@ contract StdAssertionsTest is Test {
         address targetB = address(new TestMockCall(returnDataB, SHOULD_REVERT));
 
         vm.expectEmit(true, true, true, true);
+        emit log("Error: Calls were not equal");
+        vm.expectEmit(true, true, true, true);
         emit log_named_bytes("  Left call return data", returnDataA);
         vm.expectEmit(true, true, true, true);
         emit log_named_bytes(" Right call revert data", returnDataB);
         t._assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData, EXPECT_FAIL);
 
+        vm.expectEmit(true, true, true, true);
+        emit log("Error: Calls were not equal");
         vm.expectEmit(true, true, true, true);
         emit log_named_bytes("  Left call revert data", returnDataB);
         vm.expectEmit(true, true, true, true);


### PR DESCRIPTION
This change stems from https://github.com/foundry-rs/foundry/pull/4920 — It will fail if we ignore the first `emit` of these assertions, as it expects to **strictly** match _all_ events performed in the next call and its subtree.