### PR TITLE
feat: add "SECP256K1_ORDER" constant

### DIFF
--- a/src/Base.sol
+++ b/src/Base.sol
@@ -15,6 +15,9 @@ abstract contract CommonBase {
     address internal constant DEFAULT_TEST_CONTRACT = 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f;
     // Deterministic deployment address of the Multicall3 contract.
     address internal constant MULTICALL3_ADDRESS = 0xcA11bde05977b3631167028862bE2a173976CA11;
+    // The order of the secp256k1 curve.
+    uint256 internal constant SECP256K1_ORDER =
+        115792089237316195423570985008687907852837564279074904382605163141518161494337;
 
     uint256 internal constant UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;


### PR DESCRIPTION
Useful when fuzzing private keys, e.g.

```solidity
function test_Something(uint256 privateKey) external {
    privateKey = bound(privateKey, 1, SECP256K1_ORDER - 1);
}
```