### PR TITLE
feat: add "boundPrivateKey" util

### DIFF
--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -16,6 +16,8 @@ abstract contract StdUtils {
     address private constant CONSOLE2_ADDRESS = 0x000000000000000000636F6e736F6c652e6c6f67;
     uint256 private constant INT256_MIN_ABS =
         57896044618658097711785492504343953926634992332820282019728792003956564819968;
+    uint256 private constant SECP256K1_ORDER =
+        115792089237316195423570985008687907852837564279074904382605163141518161494337;
     uint256 private constant UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
@@ -81,6 +83,10 @@ abstract contract StdUtils {
     function bound(int256 x, int256 min, int256 max) internal view virtual returns (int256 result) {
         result = _bound(x, min, max);
         console2_log("Bound result", vm.toString(result));
+    }
+
+    function boundPrivateKey(uint256 privateKey) internal view virtual returns (uint256 result) {
+        result = _bound(privateKey, 1, SECP256K1_ORDER - 1);
     }
 
     function bytesToUint(bytes memory b) internal pure virtual returns (uint256) {

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -191,7 +191,6 @@ contract StdUtilsTest is Test {
         assertEq(boundPrivateKey(UINT256_MAX), UINT256_MAX & SECP256K1_ORDER - 1); // x&y is equivalent to x-x%y
     }
 
-
     /*//////////////////////////////////////////////////////////////////////////
                                    BYTES TO UINT
     //////////////////////////////////////////////////////////////////////////*/

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -177,6 +177,22 @@ contract StdUtilsTest is Test {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
+                                BOUND PRIVATE KEY
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function testBoundPrivateKey() public {
+        assertEq(boundPrivateKey(0), 1);
+        assertEq(boundPrivateKey(1), 1);
+        assertEq(boundPrivateKey(300), 300);
+        assertEq(boundPrivateKey(9999), 9999);
+        assertEq(boundPrivateKey(SECP256K1_ORDER - 1), SECP256K1_ORDER - 1);
+        assertEq(boundPrivateKey(SECP256K1_ORDER), 1);
+        assertEq(boundPrivateKey(SECP256K1_ORDER + 1), 2);
+        assertEq(boundPrivateKey(UINT256_MAX), UINT256_MAX & SECP256K1_ORDER - 1); // x&y is equivalent to x-x%y
+    }
+
+
+    /*//////////////////////////////////////////////////////////////////////////
                                    BYTES TO UINT
     //////////////////////////////////////////////////////////////////////////*/
 


### PR DESCRIPTION
This PR adds a utility for bounding private keys between 1 and the SECP256k1 order minus 1.

As shown by the discussions in https://github.com/foundry-rs/foundry/issues/3031, it is not obvious that private keys have to be bounded between 1 and the curve order minus 1.

Note: I used the console log-free `_bound` due to security reasons (avoiding accidental leaks of private keys).