### PR TITLE
chore: add `Create2Factory` to `CommonBase`

### DIFF
--- a/src/Base.sol
+++ b/src/Base.sol
@@ -9,6 +9,8 @@ abstract contract CommonBase {
     address internal constant VM_ADDRESS = address(uint160(uint256(keccak256("hevm cheat code"))));
     // console.sol and console2.sol work by executing a staticcall to this address.
     address internal constant CONSOLE = 0x000000000000000000636F6e736F6c652e6c6f67;
+    // Used when deploying with create2, https://github.com/Arachnid/deterministic-deployment-proxy.
+    address internal constant CREATE2_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
     // Default address for tx.origin and msg.sender, 0x1804c8AB1F12E6bbf3894d4083f33e07309d1f38.
     address internal constant DEFAULT_SENDER = address(uint160(uint256(keccak256("foundry default caller"))));
     // Address of the test contract, deployed by the DEFAULT_SENDER.
@@ -29,8 +31,5 @@ abstract contract CommonBase {
 abstract contract TestBase is CommonBase {}
 
 abstract contract ScriptBase is CommonBase {
-    // Used when deploying with create2, https://github.com/Arachnid/deterministic-deployment-proxy.
-    address internal constant CREATE2_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
-
     VmSafe internal constant vmSafe = VmSafe(VM_ADDRESS);
 }


### PR DESCRIPTION
This PR moves the `CREATE2_FACTORY` address from `ScriptBase` to `CommonBase` to allow for its use in tests. Resolves #285 