### PR TITLE
add: destroyAccount cheatcode

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -416,10 +416,11 @@ abstract contract StdCheatsSafe {
         (addr,) = makeAddrAndKey(name);
     }
 
-    // destroys an account inmediatly, sending the balance to beneficiary 
-    // destroying means: balance will be zero, code will be empty, nonce will be zero
-    // similar to selfdestruct but not identical: selfdestruct destroys code and nonce
-    // only after tx ends, this will run inmediatly
+    // Destroys an account immediately, sending the balance to beneficiary.
+    // Destroying means: balance will be zero, code will be empty, and nonce will be 0
+    // for EOAs or 1 for contract accounts.
+    // This is similar to selfdestruct but not identical: selfdestruct destroys code and nonce
+    // only after tx ends, this will run immediately.
     function destroyAccount(address who, address beneficiary) internal virtual {
         uint256 currBalance = who.balance;
         vm.etch(who, abi.encode());

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -416,6 +416,20 @@ abstract contract StdCheatsSafe {
         (addr,) = makeAddrAndKey(name);
     }
 
+    // destroys an account inmediatly, sending the balance to beneficiary 
+    // destroying means: balance will be zero, code will be empty, nonce will be zero
+    // similar to selfdestruct but not identical: selfdestruct destroys code and nonce
+    // only after tx ends, this will run inmediatly
+    function destroyAccount(address who, address beneficiary) internal virtual {
+        uint256 currBalance = who.balance;
+        vm.etch(who, abi.encode());
+        vm.deal(who, 0);
+        vm.resetNonce(who);
+
+        uint256 beneficiaryBalance = beneficiary.balance;
+        vm.deal(beneficiary, currBalance + beneficiaryBalance);
+    }
+
     // creates a struct containing both a labeled address and the corresponding private key
     function makeAccount(string memory name) internal virtual returns (Account memory account) {
         (account.addr, account.key) = makeAddrAndKey(name);

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -418,7 +418,6 @@ abstract contract StdCheatsSafe {
 
     // Destroys an account immediately, sending the balance to beneficiary.
     // Destroying means: balance will be zero, code will be empty, and nonce will be 0
-    // for EOAs or 1 for contract accounts.
     // This is similar to selfdestruct but not identical: selfdestruct destroys code and nonce
     // only after tx ends, this will run immediately.
     function destroyAccount(address who, address beneficiary) internal virtual {

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -368,7 +368,7 @@ interface Vm is VmSafe {
     function setNonce(address account, uint64 newNonce) external;
     // Sets the nonce of an account to an arbitrary value
     function setNonceUnsafe(address account, uint64 newNonce) external;
-    // Resets the nonce of an account to zero.
+    // Resets the nonce of an account to 0 for EOAs and 1 for contract accounts
     function resetNonce(address account) external;
     // Sets the *next* call's msg.sender to be the input address
     function prank(address msgSender) external;

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -367,7 +367,7 @@ interface Vm is VmSafe {
     // Sets the nonce of an account; must be higher than the current nonce of the account
     function setNonce(address account, uint64 newNonce) external;
     // Sets the nonce of an account to an arbitrary value
-    function setNonceUnsafe(address account) external;
+    function setNonceUnsafe(address account, uint64 newNonce) external;
     // Resets the nonce of an account to zero.
     function resetNonce(address account) external;
     // Sets the *next* call's msg.sender to be the input address

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -366,6 +366,8 @@ interface Vm is VmSafe {
     function store(address target, bytes32 slot, bytes32 value) external;
     // Sets the nonce of an account; must be higher than the current nonce of the account
     function setNonce(address account, uint64 newNonce) external;
+    // Resets the nonce of an account to zero.
+    function resetNonce(address account) external;
     // Sets the *next* call's msg.sender to be the input address
     function prank(address msgSender) external;
     // Sets all subsequent calls' msg.sender to be the input address until `stopPrank` is called

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -366,6 +366,8 @@ interface Vm is VmSafe {
     function store(address target, bytes32 slot, bytes32 value) external;
     // Sets the nonce of an account; must be higher than the current nonce of the account
     function setNonce(address account, uint64 newNonce) external;
+    // Sets the nonce of an account to an arbitrary value
+    function setNonceUnsafe(address account) external;
     // Resets the nonce of an account to zero.
     function resetNonce(address account) external;
     // Sets the *next* call's msg.sender to be the input address

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -154,6 +154,33 @@ contract StdCheatsTest is Test {
         assertEq(string(getCode(deployed)), string(getCode(address(test))));
     }
 
+    function testDestroyAccount() public {
+        // deploy something to destroy it
+        BarERC721 barToken = new BarERC721();
+        address bar = address(barToken);
+        vm.setNonce(bar, 10);
+        deal(bar, 100);
+
+        uint256 prevThisBalance = address(this).balance;
+        uint256 size;
+        assembly {
+            size := extcodesize(bar)
+        }
+
+        assertGt(size, 0);
+        assertEq(bar.balance, 100);
+        assertEq(vm.getNonce(bar), 10);
+
+        destroyAccount(bar, address(this));
+        assembly {
+            size := extcodesize(bar)
+        }
+        assertEq(address(this).balance, prevThisBalance + 100);
+        assertEq(vm.getNonce(bar), 0);
+        assertEq(size, 0);
+        assertEq(bar.balance, 0);
+    }
+
     function testDeployCodeNoArgs() public {
         address deployed = deployCode("StdCheats.t.sol:Bar");
         assertEq(string(getCode(deployed)), string(getCode(address(test))));


### PR DESCRIPTION
Introduces a new std cheatcode, `destroyAccount`, which mimics `SELFDESTRUCT` behavior. 

This is a companion PR to the one that introduces `resetNonce` to Forge itself: see the [Forge PR](https://github.com/foundry-rs/foundry/pull/5033) for rationale. 