### PR TITLE
feat(cheats): `deployCodeTo`

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -697,4 +697,20 @@ abstract contract StdCheats is StdCheatsSafe {
         // update owner
         stdstore.target(token).sig(0x6352211e).with_key(id).checked_write(to);
     }
+
+    function deployCodeTo(string memory what, address where) internal virtual {
+        deployCodeTo(what, "", 0, where);
+    }
+
+    function deployCodeTo(string memory what, bytes memory args, address where) internal virtual {
+        deployCodeTo(what, args, 0, where);
+    }
+
+    function deployCodeTo(string memory what, bytes memory args, uint256 value, address where) internal virtual {
+        bytes memory creationCode = vm.getCode(what);
+        vm.etch(where, abi.encodePacked(creationCode, args));
+        (bool success, bytes memory runtimeBytecode) = where.call{value: value}("");
+        require(success, "StdCheats deployCodeTo(bytes,address,bytes,uint256): Failed to create runtime bytecode.");
+        vm.etch(where, runtimeBytecode);
+    }
 }

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -710,7 +710,7 @@ abstract contract StdCheats is StdCheatsSafe {
         bytes memory creationCode = vm.getCode(what);
         vm.etch(where, abi.encodePacked(creationCode, args));
         (bool success, bytes memory runtimeBytecode) = where.call{value: value}("");
-        require(success, "StdCheats deployCodeTo(bytes,address,bytes,uint256): Failed to create runtime bytecode.");
+        require(success, "StdCheats deployCodeTo(string,bytes,uint256,address): Failed to create runtime bytecode.");
         vm.etch(where, runtimeBytecode);
     }
 }

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -366,6 +366,33 @@ contract StdCheatsTest is Test {
                 && addr != 0x4e59b44847b379578588920cA78FbF26c0B4956C
         );
     }
+
+    function testCannotDeployCodeTo() external {
+        vm.expectRevert("StdCheats deployCodeTo(bytes,address,bytes,uint256): Failed to create runtime bytecode.");
+        this._revertDeployCodeTo();
+    }
+
+    function _revertDeployCodeTo() external {
+        deployCodeTo("StdCheats.t.sol:RevertingContract", address(0));
+    }
+
+    function testDeployCodeTo() external {
+        address arbitraryAddress = makeAddr("arbitraryAddress");
+
+        deployCodeTo(
+            "StdCheats.t.sol:MockContractWithConstructorArgs",
+            abi.encode(uint256(6), true, bytes20(arbitraryAddress)),
+            1 ether,
+            arbitraryAddress
+        );
+
+        MockContractWithConstructorArgs ct = MockContractWithConstructorArgs(arbitraryAddress);
+
+        assertEq(arbitraryAddress.balance, 1 ether);
+        assertEq(ct.x(), 6);
+        assertTrue(ct.y());
+        assertEq(ct.z(), bytes20(arbitraryAddress));
+    }
 }
 
 contract StdCheatsMock is StdCheats {
@@ -503,5 +530,17 @@ interface USDTLike {
 contract RevertingContract {
     constructor() {
         revert();
+    }
+}
+
+contract MockContractWithConstructorArgs {
+    uint256 public immutable x;
+    bool public y;
+    bytes20 public z;
+
+    constructor(uint256 _x, bool _y, bytes20 _z) payable {
+        x = _x;
+        y = _y;
+        z = _z;
     }
 }

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -368,7 +368,7 @@ contract StdCheatsTest is Test {
     }
 
     function testCannotDeployCodeTo() external {
-        vm.expectRevert("StdCheats deployCodeTo(bytes,address,bytes,uint256): Failed to create runtime bytecode.");
+        vm.expectRevert("StdCheats deployCodeTo(string,bytes,uint256,address): Failed to create runtime bytecode.");
         this._revertDeployCodeTo();
     }
 


### PR DESCRIPTION
## Motivation

There's `vm.etch`, which sets the _runtime_ bytecode on an _arbitrary_ address, and `deployCode`, which takes a _creation_ code, and returns the _deployment_ address.

However, there's no option in-between.

## Solution

`deployCodeTo` lets you pseudo-deploy a contract from its _creation_ code on an _arbitrary_ address.