### PR TITLE
feat: Refactor `assumeNot*` std cheats

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -279,8 +279,14 @@ abstract contract StdCheatsSafe {
         assumeAddressIsNot(addressType4, addr);
     }
 
-    function _isPayable(address addr) private returns (bool) {
-        if (addr.code.length == 0) {
+    function _isPayable(address addr) private returns (bool) {        
+        uint256 size;
+        assembly {
+            size := extcodesize(addr)
+        }
+
+        if (size == 0) {
+            // return false if no code
             return false;
         } else {
             require(addr.balance < type(uint256).max, "balance exceeds max uint256");

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -233,7 +233,7 @@ abstract contract StdCheatsSafe {
         assumeNotBlacklisted(token, addr);
     }
 
-    function assumeAddressIsNot(AddressType addressType, address addr) internal virtual {
+    function assumeAddressIsNot(address addr, AddressType addressType) internal virtual {
         if (addressType == AddressType.Payable) {
             assumeNotPayable(addr);
         } else if (addressType == AddressType.NonPayable) {
@@ -248,8 +248,8 @@ abstract contract StdCheatsSafe {
     }
 
     function assumeAddressIsNot(address addr, AddressType addressType1, AddressType addressType2) internal virtual {
-        assumeAddressIsNot(addressType1, addr);
-        assumeAddressIsNot(addressType2, addr);
+        assumeAddressIsNot(addr, addressType1);
+        assumeAddressIsNot(addr, addressType2);
     }
 
     function assumeAddressIsNot(
@@ -258,9 +258,9 @@ abstract contract StdCheatsSafe {
         AddressType addressType2,
         AddressType addressType3
     ) internal virtual {
-        assumeAddressIsNot(addressType1, addr);
-        assumeAddressIsNot(addressType2, addr);
-        assumeAddressIsNot(addressType3, addr);
+        assumeAddressIsNot(addr, addressType1);
+        assumeAddressIsNot(addr, addressType2);
+        assumeAddressIsNot(addr, addressType3);
     }
 
     function assumeAddressIsNot(
@@ -270,16 +270,16 @@ abstract contract StdCheatsSafe {
         AddressType addressType3,
         AddressType addressType4
     ) internal virtual {
-        assumeAddressIsNot(addressType1, addr);
-        assumeAddressIsNot(addressType2, addr);
-        assumeAddressIsNot(addressType3, addr);
-        assumeAddressIsNot(addressType4, addr);
+        assumeAddressIsNot(addr, addressType1);
+        assumeAddressIsNot(addr, addressType2);
+        assumeAddressIsNot(addr, addressType3);
+        assumeAddressIsNot(addr, addressType4);
     }
 
-    // This function checks whether an address, `addr`, is payable. It returns true if addr has no code in which case
-    // it is an EOA. It will then send 1 wei to `addr` and check the success return value. There may be state changes
-    // depending on the fallback/receive logic implemented by `addr` which should be taken into account when
-    // this function is used.
+    // This function checks whether an address, `addr`, is payable. It works by sending 1 wei to
+    // `addr` and checking the `success` return value.
+    // NOTE: This function may result in state changes depending on the fallback/receive logic
+    // implemented by `addr`, which should be taken into account when this function is used.
     function _isPayable(address addr) private returns (bool) {
         require(
             addr.balance < UINT256_MAX,
@@ -298,6 +298,9 @@ abstract contract StdCheatsSafe {
         return success;
     }
 
+    // NOTE: This function may result in state changes depending on the fallback/receive logic
+    // implemented by `addr`, which should be taken into account when this function is used. See the
+    // `_isPayable` method for more information.
     function assumePayable(address addr) internal virtual {
         vm.assume(_isPayable(addr));
     }

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -221,7 +221,7 @@ abstract contract StdCheatsSafe {
         (success, returnData) = token.staticcall(abi.encodeWithSelector(0xe47d6060, addr));
         vm.assume(!success || abi.decode(returnData, (bool)) == false);
     }
-    
+
     // Checks that `addr` is not blacklisted by token contracts that have a blacklist.
     // This is identical to `assumeNotBlacklisted(address,address)` but with a different name, for
     // backwards compatibility, since this name was used in the original PR which has already has
@@ -306,6 +306,7 @@ abstract contract StdCheatsSafe {
 
     function assumeNoZeroAddress(address addr) internal virtual {
         vm.assume(addr != address(0));
+    }
 
     function assumeNoPrecompiles(address addr) internal pure virtual {
         assumeNoPrecompiles(addr, _pureChainId());

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -305,7 +305,7 @@ abstract contract StdCheatsSafe {
         // address), but the same rationale for excluding them applies so we include those too.
 
         // These should be present on all EVM-compatible chains.
-        vm.assume((addr < address(0x1) || addr > address(0x9)) && addr != address(vm));
+        vm.assume(addr < address(0x1) || addr > address(0x9));
 
         // forgefmt: disable-start
         if (chainId == 10 || chainId == 420) {
@@ -325,7 +325,9 @@ abstract contract StdCheatsSafe {
 
     function assumeNoForgeAddresses(address addr) internal virtual {
         // vm and console addresses
-        vm.assume(addr != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D && addr != 0x000000000000000000636F6e736F6c652e6c6f67);
+        vm.assume(
+            addr != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D && addr != 0x000000000000000000636F6e736F6c652e6c6f67
+        );
     }
 
     function readEIP1559ScriptArtifact(string memory path)

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -276,9 +276,9 @@ abstract contract StdCheatsSafe {
         assumeAddressIsNot(addressType4, addr);
     }
 
-    // This function checks whether an address, `addr`, is payable. It returns true if addr has no code in which case 
-    // it is an EOA. It will then send 1 wei to `addr` and check the success return value. There may be state changes 
-    // depending on the fallback/receive logic implemented by `addr` which should be taken into account when 
+    // This function checks whether an address, `addr`, is payable. It returns true if addr has no code in which case
+    // it is an EOA. It will then send 1 wei to `addr` and check the success return value. There may be state changes
+    // depending on the fallback/receive logic implemented by `addr` which should be taken into account when
     // this function is used.
     function _isPayable(address addr) private returns (bool) {
         uint256 size;
@@ -290,7 +290,10 @@ abstract contract StdCheatsSafe {
             // return true if no code
             return true;
         } else {
-            require(addr.balance < UINT256_MAX, "StdCheats _isPayable(address): Balance equals max uint256, so it cannot receive any more funds");
+            require(
+                addr.balance < UINT256_MAX,
+                "StdCheats _isPayable(address): Balance equals max uint256, so it cannot receive any more funds"
+            );
             uint256 origBalanceTest = address(this).balance;
             uint256 origBalanceAddr = address(addr).balance;
 
@@ -346,9 +349,7 @@ abstract contract StdCheatsSafe {
 
     function assumeNotForgeAddress(address addr) internal pure virtual {
         // vm and console addresses
-        vm.assume(
-            addr != address(vm) || addr != 0x000000000000000000636F6e736F6c652e6c6f67
-        );
+        vm.assume(addr != address(vm) || addr != 0x000000000000000000636F6e736F6c652e6c6f67);
     }
 
     function readEIP1559ScriptArtifact(string memory path)

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -228,7 +228,7 @@ abstract contract StdCheatsSafe {
         // address), but the same rationale for excluding them applies so we include those too.
 
         // These should be present on all EVM-compatible chains.
-        vm.assume(addr < address(0x1) || addr > address(0x9));
+        vm.assume((addr < address(0x1) || addr > address(0x9)) && addr != address(vm));
 
         // forgefmt: disable-start
         if (chainId == 10 || chainId == 420) {

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -313,7 +313,7 @@ abstract contract StdCheatsSafe {
         vm.assume(_isPayable(addr));
     }
 
-    function assumeNoZeroAddress(address addr) internal virtual {
+    function assumeNoZeroAddress(address addr) internal pure virtual {
         vm.assume(addr != address(0));
     }
 
@@ -344,7 +344,7 @@ abstract contract StdCheatsSafe {
         // forgefmt: disable-end
     }
 
-    function assumeNoForgeAddresses(address addr) internal virtual {
+    function assumeNoForgeAddresses(address addr) internal pure virtual {
         // vm and console addresses
         vm.assume(
             addr != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D && addr != 0x000000000000000000636F6e736F6c652e6c6f67

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -247,7 +247,7 @@ abstract contract StdCheatsSafe {
         } else if (addressType == AddressType.ZeroAddress) {
             assumeNoZeroAddress(addr);
         } else if (addressType == AddressType.Precompiles) {
-            assumeNoPrecompiles(addr, chainId);
+            assumeNoPrecompiles(addr);
         } else if (addressType == AddressType.ForgeAddresses) {
             assumeNoForgeAddresses(addr);
         }
@@ -347,7 +347,7 @@ abstract contract StdCheatsSafe {
     function assumeNoForgeAddresses(address addr) internal pure virtual {
         // vm and console addresses
         vm.assume(
-            addr != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D && addr != 0x000000000000000000636F6e736F6c652e6c6f67
+            addr != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D || addr != 0x000000000000000000636F6e736F6c652e6c6f67
         );
     }
 

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -234,12 +234,6 @@ abstract contract StdCheatsSafe {
     }
 
     function assumeAddressIsNot(AddressType addressType, address addr) internal virtual {
-        // Assembly required since `block.chainid` was introduced in 0.8.0.
-        uint256 chainId;
-        assembly {
-            chainId := chainid()
-        }
-
         if (addressType == AddressType.Payable) {
             assumeNoPayable(addr);
         } else if (addressType == AddressType.NonPayable) {

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -9,6 +9,9 @@ import {Vm} from "./Vm.sol";
 abstract contract StdCheatsSafe {
     Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
+    uint256 private constant UINT256_MAX =
+        115792089237316195423570985008687907853269984665640564039457584007913129639935;
+
     bool private gasMeteringOff;
 
     // Data structures to parse Transaction objects from the broadcast artifact
@@ -279,7 +282,7 @@ abstract contract StdCheatsSafe {
         assumeAddressIsNot(addressType4, addr);
     }
 
-    function _isPayable(address addr) private returns (bool) {        
+    function _isPayable(address addr) private returns (bool) {
         uint256 size;
         assembly {
             size := extcodesize(addr)
@@ -289,7 +292,7 @@ abstract contract StdCheatsSafe {
             // return false if no code
             return false;
         } else {
-            require(addr.balance < type(uint256).max, "balance exceeds max uint256");
+            require(addr.balance < UINT256_MAX, "balance exceeds max uint256");
             uint256 origBalanceTest = address(this).balance;
             uint256 origBalanceAddr = address(addr).balance;
             (bool success,) = payable(addr).call{value: 1}("");

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -343,9 +343,11 @@ contract StdCheatsTest is Test {
         assertTrue(addr != address(0));
         assertTrue(
             addr < address(1) || (addr > address(9) && addr < address(0x4200000000000000000000000000000000000000))
-                    || addr > address(0x4200000000000000000000000000000000000800)        
-            );
-        assertTrue(addr != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D && addr != 0x000000000000000000636F6e736F6c652e6c6f67);
+                || addr > address(0x4200000000000000000000000000000000000800)
+        );
+        assertTrue(
+            addr != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D && addr != 0x000000000000000000636F6e736F6c652e6c6f67
+        );
     }
 
     function testAssumeNoPayable() external {

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -340,8 +340,7 @@ contract StdCheatsTest is Test {
         assumeNoPrecompiles(addr, getChain("optimism_goerli").chainId);
         assertTrue(
             addr < address(1) || (addr > address(9) && addr < address(0x4200000000000000000000000000000000000000))
-                || (addr > address(0x4200000000000000000000000000000000000800) && addr < address(vm)) 
-                || addr > address(vm)
+                || (addr > address(0x4200000000000000000000000000000000000800) && addr < address(vm)) || addr > address(vm)
         );
     }
 

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "../src/StdCheats.sol";
 import "../src/Test.sol";
 import "../src/StdJson.sol";
+import "../src/console.sol";
 
 contract StdCheatsTest is Test {
     Bar test;
@@ -339,7 +340,8 @@ contract StdCheatsTest is Test {
         assumeNoPrecompiles(addr, getChain("optimism_goerli").chainId);
         assertTrue(
             addr < address(1) || (addr > address(9) && addr < address(0x4200000000000000000000000000000000000000))
-                || addr > address(0x4200000000000000000000000000000000000800)
+                || (addr > address(0x4200000000000000000000000000000000000800) && addr < address(vm)) 
+                || addr > address(vm)
         );
     }
 

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -342,15 +342,13 @@ contract StdCheatsTest is Test {
         }
         assertTrue(addr != address(0));
         assertTrue(addr < address(1) || addr > address(9));
-        assertTrue(
-            addr != address(vm) || addr != 0x000000000000000000636F6e736F6c652e6c6f67
-        );
+        assertTrue(addr != address(vm) || addr != 0x000000000000000000636F6e736F6c652e6c6f67);
     }
 
     function testAssumePayable() external {
         // We deploy a mock version so we can properly test the revert.
         StdCheatsMock stdCheatsMock = new StdCheatsMock();
-        
+
         // all should revert since these addresses are not payable
 
         // VM address
@@ -406,7 +404,6 @@ contract StdCheatsTest is Test {
 
         vm.expectRevert();
         stdCheatsMock.exposed_assumeNotPayable(address(cp));
-
     }
 
     function testAssumeNotPrecompile(address addr) external {

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -355,15 +355,14 @@ contract StdCheatsTest is Test {
         vm.expectRevert();
         stdCheatsMock.exposed_assumePayable(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
-        // Console address
-        vm.expectRevert();
-        stdCheatsMock.exposed_assumePayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
-
         // Create2Deployer
         vm.expectRevert();
         stdCheatsMock.exposed_assumePayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
 
         // all should pass since these addresses are payable
+
+        // Console address (no code)
+        stdCheatsMock.exposed_assumePayable(0x000000000000000000636F6e736F6c652e6c6f67);
 
         // vitalik.eth
         stdCheatsMock.exposed_assumePayable(0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045);
@@ -380,18 +379,19 @@ contract StdCheatsTest is Test {
         // We deploy a mock version so we can properly test the revert.
         StdCheatsMock stdCheatsMock = new StdCheatsMock();
 
-        // should pass since these addresses are not payable
+        // all should pass since these addresses are not payable
 
         // VM address
         stdCheatsMock.exposed_assumeNotPayable(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
-        // Console address
-        stdCheatsMock.exposed_assumeNotPayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
-
         // Create2Deployer
         stdCheatsMock.exposed_assumeNotPayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
 
-        // should fail since these addresses are payable
+        // all should revert since these addresses are payable
+
+        // Console address (no code)
+        vm.expectRevert();
+        stdCheatsMock.exposed_assumeNotPayable(0x000000000000000000636F6e736F6c652e6c6f67);
 
         // vitalik.eth
         vm.expectRevert();

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -346,7 +346,7 @@ contract StdCheatsTest is Test {
                 || addr > address(0x4200000000000000000000000000000000000800)
         );
         assertTrue(
-            addr != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D && addr != 0x000000000000000000636F6e736F6c652e6c6f67
+            addr != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D || addr != 0x000000000000000000636F6e736F6c652e6c6f67
         );
     }
 

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -355,14 +355,15 @@ contract StdCheatsTest is Test {
         vm.expectRevert();
         stdCheatsMock.exposed_assumePayable(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
+        // Console address
+        vm.expectRevert();
+        stdCheatsMock.exposed_assumePayable(0x000000000000000000636F6e736F6c652e6c6f67);
+
         // Create2Deployer
         vm.expectRevert();
         stdCheatsMock.exposed_assumePayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
 
         // all should pass since these addresses are payable
-
-        // Console address (no code)
-        stdCheatsMock.exposed_assumePayable(0x000000000000000000636F6e736F6c652e6c6f67);
 
         // vitalik.eth
         stdCheatsMock.exposed_assumePayable(0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045);
@@ -384,14 +385,13 @@ contract StdCheatsTest is Test {
         // VM address
         stdCheatsMock.exposed_assumeNotPayable(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
+        // Console address
+        stdCheatsMock.exposed_assumeNotPayable(0x000000000000000000636F6e736F6c652e6c6f67);
+
         // Create2Deployer
         stdCheatsMock.exposed_assumeNotPayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
 
         // all should revert since these addresses are payable
-
-        // Console address (no code)
-        vm.expectRevert();
-        stdCheatsMock.exposed_assumeNotPayable(0x000000000000000000636F6e736F6c652e6c6f67);
 
         // vitalik.eth
         vm.expectRevert();

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -341,10 +341,7 @@ contract StdCheatsTest is Test {
             assumeAddressIsNot(AddressType(i), addr);
         }
         assertTrue(addr != address(0));
-        assertTrue(
-            addr < address(1) || (addr > address(9) && addr < address(0x4200000000000000000000000000000000000000))
-                || addr > address(0x4200000000000000000000000000000000000800)
-        );
+        assertTrue(addr < address(1) || addr > address(9));
         assertTrue(
             addr != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D || addr != 0x000000000000000000636F6e736F6c652e6c6f67
         );
@@ -377,6 +374,14 @@ contract StdCheatsTest is Test {
         // Create2Deployer
         vm.expectRevert();
         assumeNoNonPayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
+    }
+
+    function testAssumeNoPrecompiles(address addr) external {
+        assumeNoPrecompiles(addr, getChain("optimism_goerli").chainId);
+        assertTrue(
+            addr < address(1) || (addr > address(9) && addr < address(0x4200000000000000000000000000000000000000))
+                || addr > address(0x4200000000000000000000000000000000000800)
+        );
     }
 
     function testCannotDeployCodeTo() external {

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -408,10 +408,6 @@ contract StdCheatsTest is Test {
 }
 
 contract StdCheatsMock is StdCheats {
-    function exposed_assumePayable(address addr) external {
-        assumePayable(addr);
-    }
-
     // We deploy a mock version so we can properly test expected reverts.
     function exposed_assumeNotBlacklisted(address token, address addr) external view {
         return assumeNotBlacklisted(token, addr);

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -335,36 +335,46 @@ contract StdCheatsTest is Test {
         return number;
     }
 
-    function testAssumeNoPrecompiles(address addr) external {
-        assumeNoPrecompiles(addr, getChain("optimism_goerli").chainId);
+    function testAssumeAddressIsNot(address addr) external {
+        // skip over Payable and NonPayable enums
+        for (uint8 i = 2; i < uint8(type(AddressType).max); i++) {
+            assumeAddressIsNot(AddressType(i), addr);
+        }
+        assertTrue(addr != address(0));
         assertTrue(
             addr < address(1) || (addr > address(9) && addr < address(0x4200000000000000000000000000000000000000))
-                || (addr > address(0x4200000000000000000000000000000000000800) && addr < address(vm)) || addr > address(vm)
-        );
+                    || addr > address(0x4200000000000000000000000000000000000800)        
+            );
+        assertTrue(addr != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D && addr != 0x000000000000000000636F6e736F6c652e6c6f67);
     }
 
-    function testAssumePayable() external {
+    function testAssumeNoPayable() external {
+        // all should pass since these addresses are not payable
+
+        // VM address
+        assumeNoPayable(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+
+        // Console address
+        assumeNoPayable(0x000000000000000000636F6e736F6c652e6c6f67);
+
+        // Create2Deployer
+        assumeNoPayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
+    }
+
+    function testAssumeNoNonPayable() external {
         // all should revert since these addresses are not payable
 
         // VM address
         vm.expectRevert();
-        assumePayable(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+        assumeNoNonPayable(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
         // Console address
         vm.expectRevert();
-        assumePayable(0x000000000000000000636F6e736F6c652e6c6f67);
+        assumeNoNonPayable(0x000000000000000000636F6e736F6c652e6c6f67);
 
         // Create2Deployer
         vm.expectRevert();
-        assumePayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
-    }
-
-    function testAssumePayable(address addr) external {
-        assumePayable(addr);
-        assertTrue(
-            addr != 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D && addr != 0x000000000000000000636F6e736F6c652e6c6f67
-                && addr != 0x4e59b44847b379578588920cA78FbF26c0B4956C
-        );
+        assumeNoNonPayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
     }
 }
 

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -338,7 +338,7 @@ contract StdCheatsTest is Test {
     function testAssumeAddressIsNot(address addr) external {
         // skip over Payable and NonPayable enums
         for (uint8 i = 2; i < uint8(type(AddressType).max); i++) {
-            assumeAddressIsNot(AddressType(i), addr);
+            assumeAddressIsNot(addr, AddressType(i));
         }
         assertTrue(addr != address(0));
         assertTrue(addr < address(1) || addr > address(9));
@@ -369,10 +369,7 @@ contract StdCheatsTest is Test {
         stdCheatsMock.exposed_assumePayable(0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045);
 
         // mock payable contract
-        address arbitraryAddress = makeAddr("arbitraryAddress");
-        deployCodeTo("StdCheats.t.sol:MockContractPayable", arbitraryAddress);
-        MockContractPayable cp = MockContractPayable(payable(arbitraryAddress));
-
+        MockContractPayable cp = new MockContractPayable();
         stdCheatsMock.exposed_assumePayable(address(cp));
     }
 
@@ -398,10 +395,7 @@ contract StdCheatsTest is Test {
         stdCheatsMock.exposed_assumeNotPayable(0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045);
 
         // mock payable contract
-        address arbitraryAddress = makeAddr("arbitraryAddress");
-        deployCodeTo("StdCheats.t.sol:MockContractPayable", arbitraryAddress);
-        MockContractPayable cp = MockContractPayable(payable(arbitraryAddress));
-
+        MockContractPayable cp = new MockContractPayable();
         vm.expectRevert();
         stdCheatsMock.exposed_assumeNotPayable(address(cp));
     }

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.7.0 <0.9.0;
 import "../src/StdCheats.sol";
 import "../src/Test.sol";
 import "../src/StdJson.sol";
-import "../src/console.sol";
 
 contract StdCheatsTest is Test {
     Bar test;


### PR DESCRIPTION
Excludes the `vm` address `0x7109709ECfa91a80626fF3989D68f67F5b1DD12D` from the `assumeNoPrecompiles` cheat code. 

Resolves #405 

Note that `address(vm)` is used instead of `address(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D)` (such as in  `testAssumePayable`) so that it fits squarely into the current implementation of the cheat code and respective test with minimal confusion. Open to changing this though.