### PR TITLE
feat: add vm.skip(bool)

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -395,7 +395,7 @@ interface Vm is VmSafe {
     // Sets an address' code
     function etch(address target, bytes calldata newRuntimeBytecode) external;
     // Marks a test as skipped. Must be called at the top of the test.
-    function skip(bool skip) external;
+    function skip(bool skipTest) external;
     // Expects an error on next call
     function expectRevert(bytes calldata revertData) external;
     function expectRevert(bytes4 revertData) external;

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -394,6 +394,8 @@ interface Vm is VmSafe {
     function deal(address account, uint256 newBalance) external;
     // Sets an address' code
     function etch(address target, bytes calldata newRuntimeBytecode) external;
+    // Marks a test as skipped. Must be called at the top of the test.
+    function skip(bool skip) external;
     // Expects an error on next call
     function expectRevert(bytes calldata revertData) external;
     function expectRevert(bytes4 revertData) external;


### PR DESCRIPTION
Downstream from https://github.com/foundry-rs/foundry/pull/5205

Adds and documents the new `vm.skip(bool)` cheatcode.