### PR TITLE
Support Metis L2 network

### DIFF
--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -216,6 +216,8 @@ abstract contract StdChains {
             ChainData("BNB Smart Chain Testnet", 97, "https://rpc.ankr.com/bsc_testnet_chapel")
         );
         setChainWithDefaultRpcUrl("gnosis_chain", ChainData("Gnosis Chain", 100, "https://rpc.gnosischain.com"));
+        setChainWithDefaultRpcUrl("metis", ChainData("Metis L2", 1088, "https://andromeda.metis.io/?owner=1088"));
+        setChainWithDefaultRpcUrl("metis_goerli", ChainData("Metis Goerli", 599, "https://goerli.gateway.metisdevops.link"));
     }
 
     // set chain info, with priority to chainAlias' rpc url in foundry.toml

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -245,6 +245,9 @@ abstract contract StdCheatsSafe {
             vm.assume(addr < address(0x0100000000000000000000000000000000000000) || addr > address(0x01000000000000000000000000000000000000ff));
             vm.assume(addr < address(0x0200000000000000000000000000000000000000) || addr > address(0x02000000000000000000000000000000000000FF));
             vm.assume(addr < address(0x0300000000000000000000000000000000000000) || addr > address(0x03000000000000000000000000000000000000Ff));
+        } else if (chainId == 599 || chainId == 1088) {
+            // https://github.com/MetisProtocol/mvm/blob/81ca077e4c58791578531f108526840056a44b88/packages/contracts/src/predeploys.ts#L20
+            vm.assume(addr < address(0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000) || addr > address(0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000));
         }
         // forgefmt: disable-end
     }

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -27,6 +27,7 @@ contract StdChainsTest is Test {
         assertEq(getChain(1).rpcUrl, "https://mainnet.infura.io/v3/b1d3925804e74152b316ca7da97060d3");
         assertEq(getChain("optimism_goerli").rpcUrl, "https://goerli.optimism.io/");
         assertEq(getChain("arbitrum_one_goerli").rpcUrl, "https://goerli-rollup.arbitrum.io/rpc/");
+        assertEq(getChain("metis").rpcUrl, "https://andromeda.metis.io/?owner=1088");
 
         // Environment variables should be the next fallback
         assertEq(getChain("arbitrum_nova").rpcUrl, "https://nova.arbitrum.io/rpc");


### PR DESCRIPTION
## Description
This PR adds support for Metis L2 (and Metis Goerli) network to Foundry Forge

## References
- https://docs.metis.io/dev/readme/connection-details
- https://chainlist.org/chain/599
- https://chainlist.org/chain/1088