### PR TITLE
Add checked_write_signed for int256

### DIFF
--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -239,7 +239,7 @@ library stdStorage {
         checked_write(self, bytes32(amt));
     }
 
-    function checked_write_signed(StdStorage storage self, int256 val) internal {
+    function checked_write_int(StdStorage storage self, int256 val) internal {
         checked_write(self, bytes32(uint256(val)));
     }
 

--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -239,6 +239,10 @@ library stdStorage {
         checked_write(self, bytes32(amt));
     }
 
+    function checked_write_signed(StdStorage storage self, int256 val) internal {
+        checked_write(self, bytes32(uint256(val)));
+    }
+
     function checked_write(StdStorage storage self, bool write) internal {
         bytes32 t;
         /// @solidity memory-safe-assembly

--- a/test/StdStorage.t.sol
+++ b/test/StdStorage.t.sol
@@ -31,6 +31,16 @@ contract StdStorageTest is Test {
         assertEq(test.exists(), 100);
     }
 
+    function testStorageCheckedWriteSignedIntegerHidden() public {
+        stdstore.target(address(test)).sig(test.hidden.selector).checked_write_signed(-100);
+        assertEq(int256(uint256(test.hidden())), -100);
+    }
+
+    function testStorageCheckedWriteSignedIntegerObvious() public {
+        stdstore.target(address(test)).sig(test.tG.selector).checked_write_signed(-100);
+        assertEq(test.tG(), -100);
+    }
+
     function testStorageMapStructA() public {
         uint256 slot =
             stdstore.target(address(test)).sig(test.map_struct.selector).with_key(address(this)).depth(0).find();

--- a/test/StdStorage.t.sol
+++ b/test/StdStorage.t.sol
@@ -32,12 +32,12 @@ contract StdStorageTest is Test {
     }
 
     function testStorageCheckedWriteSignedIntegerHidden() public {
-        stdstore.target(address(test)).sig(test.hidden.selector).checked_write_signed(-100);
+        stdstore.target(address(test)).sig(test.hidden.selector).checked_write_int(-100);
         assertEq(int256(uint256(test.hidden())), -100);
     }
 
     function testStorageCheckedWriteSignedIntegerObvious() public {
-        stdstore.target(address(test)).sig(test.tG.selector).checked_write_signed(-100);
+        stdstore.target(address(test)).sig(test.tG.selector).checked_write_int(-100);
         assertEq(test.tG(), -100);
     }
 


### PR DESCRIPTION
There is no `checked_write` function for `int256` param.
There are only `checked_write` functions with `address`, `uint256`, `bool` and `bytes32` parameters now.
Actually, for `int256` variables, the below code can be used.
```
int256 value = -100;
stdstore
    .target(address(addr))
    .sig("var()")
    .checked_write(uint256(value));
```
But it might be better if it has `checked_write` function for `int256` params since the above code is not good to understand.