### PR TITLE
feat(cheats): ffi

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -578,6 +578,8 @@ abstract contract StdCheatsSafe {
         }
 
         out = vm.ffi(ffiInput_fs);
+
+        ffiInput_fs = new string[](0);
     }
 
     function raw(string memory text) internal pure virtual returns (string memory) {


### PR DESCRIPTION
## Motivation

When I started using Foundry, I didn't find `ffi` intuitive. I thought I could give it a command, but, I was supposed to initialize an array first, assign values, etc.

This cheat makes it work the way I thought it did. I'll let you decide if it's worth adding.

## Solution

**Before**

```solidity
string[] memory inputs = new string[](3);

inputs[0] = "echo";
inputs[1] = "-n";
inputs[2] = "hello world";

bytes memory res = vm.ffi(inputs);
```

**After**

```solidity
bytes memory res = ffi("echo -n", raw("hello world"));
```

Note: `raw` passes the text as-is.

<br>
<br>

**Before**

```solidity
string[] memory inputs = new string[](4);

inputs[0] = "yarn";
inputs[1] = "ts-node";
inputs[2] = "path/to/script.ts";
inputs[3] = vm.toString(
    abi.encode(
        user,
        data
    )
);

bytes memory res = vm.ffi(inputs);
```

**After**

```solidity
bytes memory res = ffi(
    "yarn ts-node path/to/script.ts",
    vm.toString(abi.encode(user, data))
);
```

Note: `ffi` accepts up to five arguments. Both examples used two.