### PR TITLE
Fix assumeNotForgeAddress in StdCheats.sol

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -341,8 +341,8 @@ abstract contract StdCheatsSafe {
     }
 
     function assumeNotForgeAddress(address addr) internal pure virtual {
-        // vm and console addresses
-        vm.assume(addr != address(vm) && addr != 0x000000000000000000636F6e736F6c652e6c6f67);
+        // vm, console, and Create2Deployer addresses
+        vm.assume(addr != address(vm) && addr != 0x000000000000000000636F6e736F6c652e6c6f67 && addr != 0x4e59b44847b379578588920cA78FbF26c0B4956C);
     }
 
     function readEIP1559ScriptArtifact(string memory path)

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -342,7 +342,7 @@ abstract contract StdCheatsSafe {
 
     function assumeNotForgeAddress(address addr) internal pure virtual {
         // vm and console addresses
-        vm.assume(addr != address(vm) || addr != 0x000000000000000000636F6e736F6c652e6c6f67);
+        vm.assume(addr != address(vm) && addr != 0x000000000000000000636F6e736F6c652e6c6f67);
     }
 
     function readEIP1559ScriptArtifact(string memory path)

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -342,7 +342,10 @@ abstract contract StdCheatsSafe {
 
     function assumeNotForgeAddress(address addr) internal pure virtual {
         // vm, console, and Create2Deployer addresses
-        vm.assume(addr != address(vm) && addr != 0x000000000000000000636F6e736F6c652e6c6f67 && addr != 0x4e59b44847b379578588920cA78FbF26c0B4956C);
+        vm.assume(
+            addr != address(vm) && addr != 0x000000000000000000636F6e736F6c652e6c6f67
+                && addr != 0x4e59b44847b379578588920cA78FbF26c0B4956C
+        );
     }
 
     function readEIP1559ScriptArtifact(string memory path)

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -408,6 +408,14 @@ contract StdCheatsTest is Test {
         );
     }
 
+    function testAssumeNotForgeAddress(address addr) external {
+        assumeNotForgeAddress(addr);
+        assertTrue(
+            addr != address(vm) && addr != 0x000000000000000000636F6e736F6c652e6c6f67
+                && addr != 0x4e59b44847b379578588920cA78FbF26c0B4956C
+        );
+    }
+
     function testCannotDeployCodeTo() external {
         vm.expectRevert("StdCheats deployCodeTo(string,bytes,uint256,address): Failed to create runtime bytecode.");
         this._revertDeployCodeTo();


### PR DESCRIPTION
`assumeNotForgeAddress` allowed any address to pass the assumption check. Unless `address(vm) == 0x000000000000000000636F6e736F6c652e6c6f67` (which is not), the condition always pass.

- Fixed by changing logical `or` to `and` in the condition. 
- Add check for Create2Deployer address