### PR TITLE
chore: conform test naming to style guide

### DIFF
--- a/test/StdAssertions.t.sol
+++ b/test/StdAssertions.t.sol
@@ -422,13 +422,17 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_ABS_DECIMAL(INT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertApproxEqAbsDecimal_Int_Pass(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
+    function testFuzz_AssertApproxEqAbsDecimal_Int_Pass(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
+        external
+    {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
         t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_PASS);
     }
 
-    function testFuzz_AssertApproxEqAbsDecimal_Int_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
+    function testFuzz_AssertApproxEqAbsDecimal_Int_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
+        external
+    {
         vm.assume(stdMath.delta(a, b) > maxDelta);
 
         vm.expectEmit(false, false, false, true);
@@ -494,18 +498,24 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_REL_DECIMAL(UINT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertApproxEqRelDecimal_Uint_Pass(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
-        external
-    {
+    function testFuzz_AssertApproxEqRelDecimal_Uint_Pass(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta,
+        uint256 decimals
+    ) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
         t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_PASS);
     }
 
-    function testFuzz_AssertApproxEqRelDecimal_Uint_Fail(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
-        external
-    {
+    function testFuzz_AssertApproxEqRelDecimal_Uint_Fail(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta,
+        uint256 decimals
+    ) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
 
@@ -514,18 +524,24 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertApproxEqRelDecimal_UintErr_Pass(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
-        external
-    {
+    function testFuzz_AssertApproxEqRelDecimal_UintErr_Pass(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta,
+        uint256 decimals
+    ) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
         t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
     }
 
-    function testFuzz_AssertApproxEqRelDecimal_UintErr_Fail(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
-        external
-    {
+    function testFuzz_AssertApproxEqRelDecimal_UintErr_Fail(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta,
+        uint256 decimals
+    ) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
 

--- a/test/StdAssertions.t.sol
+++ b/test/StdAssertions.t.sol
@@ -31,21 +31,21 @@ contract StdAssertionsTest is Test {
                                     ASSERT_FALSE
     //////////////////////////////////////////////////////////////////////////*/
 
-    function test_AssertFalse() external {
+    function test_AssertFalse_Pass() external {
         t._assertFalse(false, EXPECT_PASS);
     }
 
-    function testFail_AssertFalse() external {
+    function test_AssertFalse_Fail() external {
         vm.expectEmit(false, false, false, true);
         emit log("Error: Assertion Failed");
         t._assertFalse(true, EXPECT_FAIL);
     }
 
-    function test_AssertFalse_Err() external {
+    function test_AssertFalse_Err_Pass() external {
         t._assertFalse(false, CUSTOM_ERROR, EXPECT_PASS);
     }
 
-    function testFail_AssertFalse_Err() external {
+    function test_AssertFalse_Err_Fail() external {
         vm.expectEmit(false, false, false, true);
         emit log_named_string("Error", CUSTOM_ERROR);
         t._assertFalse(true, CUSTOM_ERROR, EXPECT_FAIL);
@@ -55,11 +55,11 @@ contract StdAssertionsTest is Test {
                                     ASSERT_EQ(BOOL)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertEq_Bool(bool a) external {
+    function testFuzz_AssertEq_Bool_Pass(bool a) external {
         t._assertEq(a, a, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertEq_Bool(bool a, bool b) external {
+    function testFuzz_AssertEq_Bool_Fail(bool a, bool b) external {
         vm.assume(a != b);
 
         vm.expectEmit(false, false, false, true);
@@ -67,11 +67,11 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertEq_BoolErr(bool a) external {
+    function testFuzz_AssertEq_BoolErr_Pass(bool a) external {
         t._assertEq(a, a, CUSTOM_ERROR, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertEq_BoolErr(bool a, bool b) external {
+    function testFuzz_AssertEq_BoolErr_Fail(bool a, bool b) external {
         vm.assume(a != b);
 
         vm.expectEmit(false, false, false, true);
@@ -83,11 +83,11 @@ contract StdAssertionsTest is Test {
                                     ASSERT_EQ(BYTES)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertEq_Bytes(bytes calldata a) external {
+    function testFuzz_AssertEq_Bytes_Pass(bytes calldata a) external {
         t._assertEq(a, a, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertEq_Bytes(bytes calldata a, bytes calldata b) external {
+    function testFuzz_AssertEq_Bytes_Fail(bytes calldata a, bytes calldata b) external {
         vm.assume(keccak256(a) != keccak256(b));
 
         vm.expectEmit(false, false, false, true);
@@ -95,11 +95,11 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertEq_BytesErr(bytes calldata a) external {
+    function testFuzz_AssertEq_BytesErr_Pass(bytes calldata a) external {
         t._assertEq(a, a, CUSTOM_ERROR, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertEq_BytesErr(bytes calldata a, bytes calldata b) external {
+    function testFuzz_AssertEq_BytesErr_Fail(bytes calldata a, bytes calldata b) external {
         vm.assume(keccak256(a) != keccak256(b));
 
         vm.expectEmit(false, false, false, true);
@@ -111,7 +111,7 @@ contract StdAssertionsTest is Test {
                                     ASSERT_EQ(ARRAY)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertEq_UintArr(uint256 e0, uint256 e1, uint256 e2) public {
+    function testFuzz_AssertEq_UintArr_Pass(uint256 e0, uint256 e1, uint256 e2) public {
         uint256[] memory a = new uint256[](3);
         a[0] = e0;
         a[1] = e1;
@@ -124,7 +124,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_PASS);
     }
 
-    function testFuzz_AssertEq_IntArr(int256 e0, int256 e1, int256 e2) public {
+    function testFuzz_AssertEq_IntArr_Pass(int256 e0, int256 e1, int256 e2) public {
         int256[] memory a = new int256[](3);
         a[0] = e0;
         a[1] = e1;
@@ -137,7 +137,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_PASS);
     }
 
-    function testFuzz_AssertEq_AddressArr(address e0, address e1, address e2) public {
+    function testFuzz_AssertEq_AddressArr_Pass(address e0, address e1, address e2) public {
         address[] memory a = new address[](3);
         a[0] = e0;
         a[1] = e1;
@@ -150,7 +150,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertEq_UintArr(uint256 e1) public {
+    function testFuzz_AssertEq_UintArr_FailEl(uint256 e1) public {
         vm.assume(e1 != 0);
         uint256[] memory a = new uint256[](3);
         uint256[] memory b = new uint256[](3);
@@ -161,7 +161,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testFailFuzz_AssertEq_IntArr(int256 e1) public {
+    function testFuzz_AssertEq_IntArr_FailEl(int256 e1) public {
         vm.assume(e1 != 0);
         int256[] memory a = new int256[](3);
         int256[] memory b = new int256[](3);
@@ -172,7 +172,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testFailFuzz_AssertEq_AddressArr(address e1) public {
+    function testFuzz_AssertEq_AddressArr_FailEl(address e1) public {
         vm.assume(e1 != address(0));
         address[] memory a = new address[](3);
         address[] memory b = new address[](3);
@@ -183,7 +183,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testFailFuzz_AssertEq_UintArrErr(uint256 e1) public {
+    function testFuzz_AssertEq_UintArrErr_FailEl(uint256 e1) public {
         vm.assume(e1 != 0);
         uint256[] memory a = new uint256[](3);
         uint256[] memory b = new uint256[](3);
@@ -196,7 +196,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
     }
 
-    function testFailFuzz_AssertEq_IntArrErr(int256 e1) public {
+    function testFuzz_AssertEq_IntArrErr_FailEl(int256 e1) public {
         vm.assume(e1 != 0);
         int256[] memory a = new int256[](3);
         int256[] memory b = new int256[](3);
@@ -209,7 +209,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
     }
 
-    function testFailFuzz_AssertEq_AddressArrErr(address e1) public {
+    function testFuzz_AssertEq_AddressArrErr_FailEl(address e1) public {
         vm.assume(e1 != address(0));
         address[] memory a = new address[](3);
         address[] memory b = new address[](3);
@@ -222,7 +222,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
     }
 
-    function testFailFuzz_AssertEq_UintArrLen(uint256 lenA, uint256 lenB) public {
+    function testFuzz_AssertEq_UintArr_FailLen(uint256 lenA, uint256 lenB) public {
         vm.assume(lenA != lenB);
         vm.assume(lenA <= 10000);
         vm.assume(lenB <= 10000);
@@ -234,7 +234,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testFailFuzz_AssertEq_IntArrLen(uint256 lenA, uint256 lenB) public {
+    function testFuzz_AssertEq_IntArr_FailLen(uint256 lenA, uint256 lenB) public {
         vm.assume(lenA != lenB);
         vm.assume(lenA <= 10000);
         vm.assume(lenB <= 10000);
@@ -246,7 +246,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testFailFuzz_AssertEq_AddressArrLen(uint256 lenA, uint256 lenB) public {
+    function testFuzz_AssertEq_AddressArr_FailLen(uint256 lenA, uint256 lenB) public {
         vm.assume(lenA != lenB);
         vm.assume(lenA <= 10000);
         vm.assume(lenB <= 10000);
@@ -258,7 +258,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testFailFuzz_AssertEq_UintArrErr_Len(uint256 lenA, uint256 lenB) public {
+    function testFuzz_AssertEq_UintArrErr_FailLen(uint256 lenA, uint256 lenB) public {
         vm.assume(lenA != lenB);
         vm.assume(lenA <= 10000);
         vm.assume(lenB <= 10000);
@@ -272,7 +272,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
     }
 
-    function testFailFuzz_AssertEq_IntArrErr_Len(uint256 lenA, uint256 lenB) public {
+    function testFuzz_AssertEq_IntArrErr_FailLen(uint256 lenA, uint256 lenB) public {
         vm.assume(lenA != lenB);
         vm.assume(lenA <= 10000);
         vm.assume(lenB <= 10000);
@@ -286,7 +286,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
     }
 
-    function testFailFuzz_AssertEq_AddressArrErr_Len(uint256 lenA, uint256 lenB) public {
+    function testFuzz_AssertEq_AddressArrErr_FailLen(uint256 lenA, uint256 lenB) public {
         vm.assume(lenA != lenB);
         vm.assume(lenA <= 10000);
         vm.assume(lenB <= 10000);
@@ -318,7 +318,7 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_ABS(UINT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertApproxEqAbs_Uint(uint256 a, uint256 b, uint256 maxDelta) external {
+    function testFuzz_AssertApproxEqAbs_Uint_Pass(uint256 a, uint256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
         t._assertApproxEqAbs(a, b, maxDelta, EXPECT_PASS);
@@ -332,7 +332,7 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqAbs(a, b, maxDelta, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertApproxEqAbs_UintErr(uint256 a, uint256 b, uint256 maxDelta) external {
+    function testFuzz_AssertApproxEqAbs_UintErr_Pass(uint256 a, uint256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
         t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_PASS);
@@ -350,7 +350,7 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_ABS_DECIMAL(UINT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertApproxEqAbsDecimal_Uint(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqAbsDecimal_Uint_Pass(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
         external
     {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
@@ -368,7 +368,7 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertApproxEqAbsDecimal_UintErr(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqAbsDecimal_UintErr_Pass(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
         external
     {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
@@ -390,7 +390,7 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_ABS(INT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertApproxEqAbs_Int(int256 a, int256 b, uint256 maxDelta) external {
+    function testFuzz_AssertApproxEqAbs_Int_Pass(int256 a, int256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
         t._assertApproxEqAbs(a, b, maxDelta, EXPECT_PASS);
@@ -404,7 +404,7 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqAbs(a, b, maxDelta, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertApproxEqAbs_IntErr(int256 a, int256 b, uint256 maxDelta) external {
+    function testFuzz_AssertApproxEqAbs_IntErr_Pass(int256 a, int256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
         t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_PASS);
@@ -422,15 +422,13 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_ABS_DECIMAL(INT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertApproxEqAbsDecimal_Int(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
+    function testFuzz_AssertApproxEqAbsDecimal_Int_Pass(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
         t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_PASS);
     }
 
-    function testFuzz_AssertApproxEqAbsDecimal_Int_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
-        external
-    {
+    function testFuzz_AssertApproxEqAbsDecimal_Int_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
         vm.assume(stdMath.delta(a, b) > maxDelta);
 
         vm.expectEmit(false, false, false, true);
@@ -438,7 +436,7 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertApproxEqAbsDecimal_IntErr(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqAbsDecimal_IntErr_Pass(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
         external
     {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
@@ -460,14 +458,14 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_REL(UINT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertApproxEqRel_Uint(uint256 a, uint256 b, uint256 maxPercentDelta) external {
+    function testFuzz_AssertApproxEqRel_Uint_Pass(uint256 a, uint256 b, uint256 maxPercentDelta) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
         t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertApproxEqRel_Uint(uint256 a, uint256 b, uint256 maxPercentDelta) external {
+    function testFuzz_AssertApproxEqRel_Uint_Fail(uint256 a, uint256 b, uint256 maxPercentDelta) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
 
@@ -476,14 +474,14 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertApproxEqRel_UintErr(uint256 a, uint256 b, uint256 maxPercentDelta) external {
+    function testFuzz_AssertApproxEqRel_UintErr_Pass(uint256 a, uint256 b, uint256 maxPercentDelta) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
         t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertApproxEqRel_UintErr(uint256 a, uint256 b, uint256 maxPercentDelta) external {
+    function testFuzz_AssertApproxEqRel_UintErr_Fail(uint256 a, uint256 b, uint256 maxPercentDelta) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
 
@@ -496,7 +494,7 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_REL_DECIMAL(UINT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertApproxEqRelDecimal_Uint(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqRelDecimal_Uint_Pass(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
         external
     {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
@@ -505,7 +503,7 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertApproxEqRelDecimal_Uint(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqRelDecimal_Uint_Fail(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
         external
     {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
@@ -516,7 +514,7 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertApproxEqRelDecimal_UintErr(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqRelDecimal_UintErr_Pass(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
         external
     {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
@@ -525,12 +523,9 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertApproxEqRelDecimal_UintErr(
-        uint256 a,
-        uint256 b,
-        uint256 maxPercentDelta,
-        uint256 decimals
-    ) external {
+    function testFuzz_AssertApproxEqRelDecimal_UintErr_Fail(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
+        external
+    {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
 
@@ -543,14 +538,14 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_REL(INT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertApproxEqRel_Int(int128 a, int128 b, uint128 maxPercentDelta) external {
+    function testFuzz_AssertApproxEqRel_Int_Pass(int128 a, int128 b, uint128 maxPercentDelta) external {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
         t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertApproxEqRel_Int(int128 a, int128 b, uint128 maxPercentDelta) external {
+    function testFuzz_AssertApproxEqRel_Int_Fail(int128 a, int128 b, uint128 maxPercentDelta) external {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
 
@@ -559,14 +554,14 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertApproxEqRel_IntErr(int128 a, int128 b, uint128 maxPercentDelta) external {
+    function testFuzz_AssertApproxEqRel_IntErr_Pass(int128 a, int128 b, uint128 maxPercentDelta) external {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
         t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertApproxEqRel_IntErr(int128 a, int128 b, uint128 maxPercentDelta) external {
+    function testFuzz_AssertApproxEqRel_IntErr_Fail(int128 a, int128 b, uint128 maxPercentDelta) external {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
 
@@ -579,7 +574,7 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_REL_DECIMAL(INT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertApproxEqRelDecimal_Int(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
+    function testAssertApproxEqRelDecimal_Int_Pass(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
         external
     {
         vm.assume(b != 0);
@@ -588,7 +583,7 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertApproxEqRelDecimal_Int(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
+    function testAssertApproxEqRelDecimal_Int_Fail(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
         external
     {
         vm.assume(b != 0);
@@ -599,7 +594,7 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertApproxEqRelDecimal_IntErr(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
+    function testAssertApproxEqRelDecimal_IntErr_Pass(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
         external
     {
         vm.assume(b != 0);
@@ -608,7 +603,7 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertApproxEqRelDecimal_IntErr(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
+    function testAssertApproxEqRelDecimal_IntErr_Fail(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
         external
     {
         vm.assume(b != 0);
@@ -623,7 +618,7 @@ contract StdAssertionsTest is Test {
                                     ASSERT_EQ_CALL
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertEqCall_Return(
+    function testFuzz_AssertEqCall_Return_Pass(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory returnData,
@@ -635,7 +630,7 @@ contract StdAssertionsTest is Test {
         t._assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertEqCall_Return(
+    function testFuzz_AssertEqCall_Return_Fail(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory returnDataA,
@@ -652,7 +647,7 @@ contract StdAssertionsTest is Test {
         t._assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertEqCall_Revert(
+    function testFuzz_AssertEqCall_Revert_Pass(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory revertDataA,
@@ -664,7 +659,7 @@ contract StdAssertionsTest is Test {
         t._assertEqCall(targetA, callDataA, targetB, callDataB, NON_STRICT_REVERT_DATA, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertEqCall_Revert(
+    function testFuzz_AssertEqCall_Revert_Fail(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory revertDataA,
@@ -680,7 +675,7 @@ contract StdAssertionsTest is Test {
         t._assertEqCall(targetA, callDataA, targetB, callDataB, STRICT_REVERT_DATA, EXPECT_FAIL);
     }
 
-    function testFailFuzz_AssertEqCall(
+    function testFuzz_AssertEqCall_Fail(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory returnDataA,
@@ -707,23 +702,23 @@ contract StdAssertionsTest is Test {
                                 ASSERT_NOT_EQ(BYTES)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testFuzz_AssertNotEq_Bytes(bytes32 a, bytes32 b) external {
+    function testFuzz_AssertNotEq_Bytes_Pass(bytes32 a, bytes32 b) external {
         vm.assume(a != b);
         t._assertNotEq(a, b, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertNotEq_Bytes(bytes32 a) external {
+    function testFuzz_AssertNotEq_Bytes_Fail(bytes32 a) external {
         vm.expectEmit(false, false, false, true);
         emit log("Error: a != b not satisfied [bytes32]");
         t._assertNotEq(a, a, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertNotEq_BytesErr(bytes32 a, bytes32 b) external {
+    function testFuzz_AssertNotEq_BytesErr_Pass(bytes32 a, bytes32 b) external {
         vm.assume(a != b);
         t._assertNotEq(a, b, CUSTOM_ERROR, EXPECT_PASS);
     }
 
-    function testFailFuzz_AsserNottEq_BytesErr(bytes32 a) external {
+    function testFuzz_AsserNottEq_BytesErr_Fail(bytes32 a) external {
         vm.expectEmit(false, false, false, true);
         emit log_named_string("Error", CUSTOM_ERROR);
         t._assertNotEq(a, a, CUSTOM_ERROR, EXPECT_FAIL);

--- a/test/StdAssertions.t.sol
+++ b/test/StdAssertions.t.sol
@@ -21,7 +21,7 @@ contract StdAssertionsTest is Test {
                                     FAIL(STRING)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testShouldFail() external {
+    function test_ShouldFail() external {
         vm.expectEmit(false, false, false, true);
         emit log_named_string("Error", CUSTOM_ERROR);
         t._fail(CUSTOM_ERROR);
@@ -31,21 +31,21 @@ contract StdAssertionsTest is Test {
                                     ASSERT_FALSE
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertFalse_Pass() external {
-        t._assertFalse(false, EXPECT_PASS);
+    function test_AssertFalse() external {
+        t._assertFalse(false, EXPECT);
     }
 
-    function testAssertFalse_Fail() external {
+    function testFail_AssertFalse() external {
         vm.expectEmit(false, false, false, true);
         emit log("Error: Assertion Failed");
         t._assertFalse(true, EXPECT_FAIL);
     }
 
-    function testAssertFalse_Err_Pass() external {
-        t._assertFalse(false, CUSTOM_ERROR, EXPECT_PASS);
+    function test_AssertFalse_Err() external {
+        t._assertFalse(false, CUSTOM_ERROR, EXPECT);
     }
 
-    function testAssertFalse_Err_Fail() external {
+    function testFail_AssertFalse_Err() external {
         vm.expectEmit(false, false, false, true);
         emit log_named_string("Error", CUSTOM_ERROR);
         t._assertFalse(true, CUSTOM_ERROR, EXPECT_FAIL);
@@ -55,11 +55,11 @@ contract StdAssertionsTest is Test {
                                     ASSERT_EQ(BOOL)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertEq_Bool_Pass(bool a) external {
-        t._assertEq(a, a, EXPECT_PASS);
+    function testFuzz_AssertEq_Bool(bool a) external {
+        t._assertEq(a, a, EXPECT);
     }
 
-    function testAssertEq_Bool_Fail(bool a, bool b) external {
+    function testFailFuzz_AssertEq_Bool(bool a, bool b) external {
         vm.assume(a != b);
 
         vm.expectEmit(false, false, false, true);
@@ -67,11 +67,11 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testAssertEq_BoolErr_Pass(bool a) external {
-        t._assertEq(a, a, CUSTOM_ERROR, EXPECT_PASS);
+    function testFuzz_AssertEq_BoolErr(bool a) external {
+        t._assertEq(a, a, CUSTOM_ERROR, EXPECT);
     }
 
-    function testAssertEq_BoolErr_Fail(bool a, bool b) external {
+    function testFailFuzz_AssertEq_BoolErr(bool a, bool b) external {
         vm.assume(a != b);
 
         vm.expectEmit(false, false, false, true);
@@ -83,11 +83,11 @@ contract StdAssertionsTest is Test {
                                     ASSERT_EQ(BYTES)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertEq_Bytes_Pass(bytes calldata a) external {
-        t._assertEq(a, a, EXPECT_PASS);
+    function testFuzz_AssertEq_Bytes(bytes calldata a) external {
+        t._assertEq(a, a, EXPECT);
     }
 
-    function testAssertEq_Bytes_Fail(bytes calldata a, bytes calldata b) external {
+    function testFailFuzz_AssertEq_Bytes(bytes calldata a, bytes calldata b) external {
         vm.assume(keccak256(a) != keccak256(b));
 
         vm.expectEmit(false, false, false, true);
@@ -95,11 +95,11 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testAssertEq_BytesErr_Pass(bytes calldata a) external {
-        t._assertEq(a, a, CUSTOM_ERROR, EXPECT_PASS);
+    function testFuzz_AssertEq_BytesErr(bytes calldata a) external {
+        t._assertEq(a, a, CUSTOM_ERROR, EXPECT);
     }
 
-    function testAssertEq_BytesErr_Fail(bytes calldata a, bytes calldata b) external {
+    function testFailFuzz_AssertEq_BytesErr(bytes calldata a, bytes calldata b) external {
         vm.assume(keccak256(a) != keccak256(b));
 
         vm.expectEmit(false, false, false, true);
@@ -111,7 +111,7 @@ contract StdAssertionsTest is Test {
                                     ASSERT_EQ(ARRAY)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertEq_UintArr_Pass(uint256 e0, uint256 e1, uint256 e2) public {
+    function testFuzz_AssertEq_UintArr(uint256 e0, uint256 e1, uint256 e2) public {
         uint256[] memory a = new uint256[](3);
         a[0] = e0;
         a[1] = e1;
@@ -121,10 +121,10 @@ contract StdAssertionsTest is Test {
         b[1] = e1;
         b[2] = e2;
 
-        t._assertEq(a, b, EXPECT_PASS);
+        t._assertEq(a, b, EXPECT);
     }
 
-    function testAssertEq_IntArr_Pass(int256 e0, int256 e1, int256 e2) public {
+    function testFuzz_AssertEq_IntArr(int256 e0, int256 e1, int256 e2) public {
         int256[] memory a = new int256[](3);
         a[0] = e0;
         a[1] = e1;
@@ -134,10 +134,10 @@ contract StdAssertionsTest is Test {
         b[1] = e1;
         b[2] = e2;
 
-        t._assertEq(a, b, EXPECT_PASS);
+        t._assertEq(a, b, EXPECT);
     }
 
-    function testAssertEq_AddressArr_Pass(address e0, address e1, address e2) public {
+    function testFuzz_AssertEq_AddressArr(address e0, address e1, address e2) public {
         address[] memory a = new address[](3);
         a[0] = e0;
         a[1] = e1;
@@ -147,10 +147,10 @@ contract StdAssertionsTest is Test {
         b[1] = e1;
         b[2] = e2;
 
-        t._assertEq(a, b, EXPECT_PASS);
+        t._assertEq(a, b, EXPECT);
     }
 
-    function testAssertEq_UintArr_FailEl(uint256 e1) public {
+    function testFailFuzz_AssertEq_UintArr(uint256 e1) public {
         vm.assume(e1 != 0);
         uint256[] memory a = new uint256[](3);
         uint256[] memory b = new uint256[](3);
@@ -161,7 +161,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testAssertEq_IntArr_FailEl(int256 e1) public {
+    function testFailFuzz_AssertEq_IntArr(int256 e1) public {
         vm.assume(e1 != 0);
         int256[] memory a = new int256[](3);
         int256[] memory b = new int256[](3);
@@ -172,7 +172,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testAssertEq_AddressArr_FailEl(address e1) public {
+    function testFailFuzz_AssertEq_AddressArr(address e1) public {
         vm.assume(e1 != address(0));
         address[] memory a = new address[](3);
         address[] memory b = new address[](3);
@@ -183,7 +183,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testAssertEq_UintArrErr_FailEl(uint256 e1) public {
+    function testFailFuzz_AssertEq_UintArrErr(uint256 e1) public {
         vm.assume(e1 != 0);
         uint256[] memory a = new uint256[](3);
         uint256[] memory b = new uint256[](3);
@@ -196,7 +196,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
     }
 
-    function testAssertEq_IntArrErr_FailEl(int256 e1) public {
+    function testFailFuzz_AssertEq_IntArrErr(int256 e1) public {
         vm.assume(e1 != 0);
         int256[] memory a = new int256[](3);
         int256[] memory b = new int256[](3);
@@ -209,7 +209,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
     }
 
-    function testAssertEq_AddressArrErr_FailEl(address e1) public {
+    function testFailFuzz_AssertEq_AddressArrErr(address e1) public {
         vm.assume(e1 != address(0));
         address[] memory a = new address[](3);
         address[] memory b = new address[](3);
@@ -222,7 +222,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
     }
 
-    function testAssertEq_UintArr_FailLen(uint256 lenA, uint256 lenB) public {
+    function testFailFuzz_AssertEq_UintArrLen(uint256 lenA, uint256 lenB) public {
         vm.assume(lenA != lenB);
         vm.assume(lenA <= 10000);
         vm.assume(lenB <= 10000);
@@ -234,7 +234,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testAssertEq_IntArr_FailLen(uint256 lenA, uint256 lenB) public {
+    function testFailFuzz_AssertEq_IntArrLen(uint256 lenA, uint256 lenB) public {
         vm.assume(lenA != lenB);
         vm.assume(lenA <= 10000);
         vm.assume(lenB <= 10000);
@@ -246,7 +246,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testAssertEq_AddressArr_FailLen(uint256 lenA, uint256 lenB) public {
+    function testFailFuzz_AssertEq_AddressArrLen(uint256 lenA, uint256 lenB) public {
         vm.assume(lenA != lenB);
         vm.assume(lenA <= 10000);
         vm.assume(lenB <= 10000);
@@ -258,7 +258,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, EXPECT_FAIL);
     }
 
-    function testAssertEq_UintArrErr_FailLen(uint256 lenA, uint256 lenB) public {
+    function testFailFuzz_AssertEq_UintArrErr_Len(uint256 lenA, uint256 lenB) public {
         vm.assume(lenA != lenB);
         vm.assume(lenA <= 10000);
         vm.assume(lenB <= 10000);
@@ -272,7 +272,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
     }
 
-    function testAssertEq_IntArrErr_FailLen(uint256 lenA, uint256 lenB) public {
+    function testFailFuzz_AssertEq_IntArrErr_Len(uint256 lenA, uint256 lenB) public {
         vm.assume(lenA != lenB);
         vm.assume(lenA <= 10000);
         vm.assume(lenB <= 10000);
@@ -286,7 +286,7 @@ contract StdAssertionsTest is Test {
         t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
     }
 
-    function testAssertEq_AddressArrErr_FailLen(uint256 lenA, uint256 lenB) public {
+    function testFailFuzz_AssertEq_AddressArrErr_Len(uint256 lenA, uint256 lenB) public {
         vm.assume(lenA != lenB);
         vm.assume(lenA <= 10000);
         vm.assume(lenB <= 10000);
@@ -304,12 +304,12 @@ contract StdAssertionsTest is Test {
                                     ASSERT_EQ(UINT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertEqUint() public {
+    function test_AssertEqUint() public {
         assertEqUint(uint8(1), uint128(1));
         assertEqUint(uint64(2), uint64(2));
     }
 
-    function testFailAssertEqUint() public {
+    function testFail_AssertEqUint() public {
         assertEqUint(uint64(1), uint96(2));
         assertEqUint(uint160(3), uint160(4));
     }
@@ -318,13 +318,13 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_ABS(UINT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertApproxEqAbs_Uint_Pass(uint256 a, uint256 b, uint256 maxDelta) external {
+    function testFuzz_AssertApproxEqAbs_Uint(uint256 a, uint256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbs(a, b, maxDelta, EXPECT_PASS);
+        t._assertApproxEqAbs(a, b, maxDelta, EXPECT);
     }
 
-    function testAssertApproxEqAbs_Uint_Fail(uint256 a, uint256 b, uint256 maxDelta) external {
+    function testFuzz_AssertApproxEqAbs_Uint_Fail(uint256 a, uint256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) > maxDelta);
 
         vm.expectEmit(false, false, false, true);
@@ -332,13 +332,13 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqAbs(a, b, maxDelta, EXPECT_FAIL);
     }
 
-    function testAssertApproxEqAbs_UintErr_Pass(uint256 a, uint256 b, uint256 maxDelta) external {
+    function testFuzz_AssertApproxEqAbs_UintErr(uint256 a, uint256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_PASS);
+        t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT);
     }
 
-    function testAssertApproxEqAbs_UintErr_Fail(uint256 a, uint256 b, uint256 maxDelta) external {
+    function testFuzz_AssertApproxEqAbs_UintErr_Fail(uint256 a, uint256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) > maxDelta);
 
         vm.expectEmit(false, false, false, true);
@@ -350,15 +350,15 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_ABS_DECIMAL(UINT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertApproxEqAbsDecimal_Uint_Pass(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqAbsDecimal_Uint(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
         external
     {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_PASS);
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT);
     }
 
-    function testAssertApproxEqAbsDecimal_Uint_Fail(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqAbsDecimal_Uint_Fail(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
         external
     {
         vm.assume(stdMath.delta(a, b) > maxDelta);
@@ -368,15 +368,15 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_FAIL);
     }
 
-    function testAssertApproxEqAbsDecimal_UintErr_Pass(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqAbsDecimal_UintErr(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
         external
     {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT);
     }
 
-    function testAssertApproxEqAbsDecimal_UintErr_Fail(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqAbsDecimal_UintErr_Fail(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
         external
     {
         vm.assume(stdMath.delta(a, b) > maxDelta);
@@ -390,13 +390,13 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_ABS(INT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertApproxEqAbs_Int_Pass(int256 a, int256 b, uint256 maxDelta) external {
+    function testFuzz_AssertApproxEqAbs_Int(int256 a, int256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbs(a, b, maxDelta, EXPECT_PASS);
+        t._assertApproxEqAbs(a, b, maxDelta, EXPECT);
     }
 
-    function testAssertApproxEqAbs_Int_Fail(int256 a, int256 b, uint256 maxDelta) external {
+    function testFuzz_AssertApproxEqAbs_Int_Fail(int256 a, int256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) > maxDelta);
 
         vm.expectEmit(false, false, false, true);
@@ -404,13 +404,13 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqAbs(a, b, maxDelta, EXPECT_FAIL);
     }
 
-    function testAssertApproxEqAbs_IntErr_Pass(int256 a, int256 b, uint256 maxDelta) external {
+    function testFuzz_AssertApproxEqAbs_IntErr(int256 a, int256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_PASS);
+        t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT);
     }
 
-    function testAssertApproxEqAbs_IntErr_Fail(int256 a, int256 b, uint256 maxDelta) external {
+    function testFuzz_AssertApproxEqAbs_IntErr_Fail(int256 a, int256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) > maxDelta);
 
         vm.expectEmit(false, false, false, true);
@@ -422,13 +422,13 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_ABS_DECIMAL(INT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertApproxEqAbsDecimal_Int_Pass(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
+    function testFuzz_AssertApproxEqAbsDecimal_Int(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_PASS);
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT);
     }
 
-    function testAssertApproxEqAbsDecimal_Int_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
+    function testFuzz_AssertApproxEqAbsDecimal_Int_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
         vm.assume(stdMath.delta(a, b) > maxDelta);
 
         vm.expectEmit(false, false, false, true);
@@ -436,15 +436,15 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_FAIL);
     }
 
-    function testAssertApproxEqAbsDecimal_IntErr_Pass(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqAbsDecimal_IntErr(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
         external
     {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT);
     }
 
-    function testAssertApproxEqAbsDecimal_IntErr_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqAbsDecimal_IntErr_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
         external
     {
         vm.assume(stdMath.delta(a, b) > maxDelta);
@@ -458,14 +458,14 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_REL(UINT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertApproxEqRel_Uint_Pass(uint256 a, uint256 b, uint256 maxPercentDelta) external {
+    function testFuzz_AssertApproxEqRel_Uint(uint256 a, uint256 b, uint256 maxPercentDelta) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_PASS);
+        t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT);
     }
 
-    function testAssertApproxEqRel_Uint_Fail(uint256 a, uint256 b, uint256 maxPercentDelta) external {
+    function testFailFuzz_AssertApproxEqRel_Uint(uint256 a, uint256 b, uint256 maxPercentDelta) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
 
@@ -474,14 +474,14 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_FAIL);
     }
 
-    function testAssertApproxEqRel_UintErr_Pass(uint256 a, uint256 b, uint256 maxPercentDelta) external {
+    function testFuzz_AssertApproxEqRel_UintErr(uint256 a, uint256 b, uint256 maxPercentDelta) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_PASS);
+        t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT);
     }
 
-    function testAssertApproxEqRel_UintErr_Fail(uint256 a, uint256 b, uint256 maxPercentDelta) external {
+    function testFailFuzz_AssertApproxEqRel_UintErr(uint256 a, uint256 b, uint256 maxPercentDelta) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
 
@@ -494,16 +494,16 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_REL_DECIMAL(UINT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertApproxEqRelDecimal_Uint_Pass(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqRelDecimal_Uint(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
         external
     {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_PASS);
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT);
     }
 
-    function testAssertApproxEqRelDecimal_Uint_Fail(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
+    function testFailFuzz_AssertApproxEqRelDecimal_Uint(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
         external
     {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
@@ -514,16 +514,16 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_FAIL);
     }
 
-    function testAssertApproxEqRelDecimal_UintErr_Pass(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
+    function testFuzz_AssertApproxEqRelDecimal_UintErr(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
         external
     {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT);
     }
 
-    function testAssertApproxEqRelDecimal_UintErr_Fail(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
+    function testFailFuzz_AssertApproxEqRelDecimal_UintErr(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
         external
     {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
@@ -538,14 +538,14 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_REL(INT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertApproxEqRel_Int_Pass(int128 a, int128 b, uint128 maxPercentDelta) external {
+    function testFuzz_AssertApproxEqRel_Int(int128 a, int128 b, uint128 maxPercentDelta) external {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_PASS);
+        t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT);
     }
 
-    function testAssertApproxEqRel_Int_Fail(int128 a, int128 b, uint128 maxPercentDelta) external {
+    function testFailFuzz_AssertApproxEqRel_Int(int128 a, int128 b, uint128 maxPercentDelta) external {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
 
@@ -554,14 +554,14 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_FAIL);
     }
 
-    function testAssertApproxEqRel_IntErr_Pass(int128 a, int128 b, uint128 maxPercentDelta) external {
+    function testFuzz_AssertApproxEqRel_IntErr(int128 a, int128 b, uint128 maxPercentDelta) external {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_PASS);
+        t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT);
     }
 
-    function testAssertApproxEqRel_IntErr_Fail(int128 a, int128 b, uint128 maxPercentDelta) external {
+    function testFailFuzz_AssertApproxEqRel_IntErr(int128 a, int128 b, uint128 maxPercentDelta) external {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
 
@@ -574,16 +574,16 @@ contract StdAssertionsTest is Test {
                                     APPROX_EQ_REL_DECIMAL(INT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertApproxEqRelDecimal_Int_Pass(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
+    function testFuzz_AssertApproxEqRelDecimal_Int(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
         external
     {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_PASS);
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT);
     }
 
-    function testAssertApproxEqRelDecimal_Int_Fail(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
+    function testFailFuzz_AssertApproxEqRelDecimal_Int(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
         external
     {
         vm.assume(b != 0);
@@ -594,16 +594,16 @@ contract StdAssertionsTest is Test {
         t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_FAIL);
     }
 
-    function testAssertApproxEqRelDecimal_IntErr_Pass(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
+    function testFuzz_AssertApproxEqRelDecimal_IntErr(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
         external
     {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT);
     }
 
-    function testAssertApproxEqRelDecimal_IntErr_Fail(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
+    function testFailFuzz_AssertApproxEqRelDecimal_IntErr(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
         external
     {
         vm.assume(b != 0);
@@ -618,7 +618,7 @@ contract StdAssertionsTest is Test {
                                     ASSERT_EQ_CALL
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertEqCall_Return_Pass(
+    function testFuzz_AssertEqCall_Return(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory returnData,
@@ -627,10 +627,10 @@ contract StdAssertionsTest is Test {
         address targetA = address(new TestMockCall(returnData, SHOULD_RETURN));
         address targetB = address(new TestMockCall(returnData, SHOULD_RETURN));
 
-        t._assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData, EXPECT_PASS);
+        t._assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData, EXPECT);
     }
 
-    function testAssertEqCall_Return_Fail(
+    function testFailFuzz_AssertEqCall_Return(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory returnDataA,
@@ -647,7 +647,7 @@ contract StdAssertionsTest is Test {
         t._assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData, EXPECT_FAIL);
     }
 
-    function testAssertEqCall_Revert_Pass(
+    function testFuzz_AssertEqCall_Revert(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory revertDataA,
@@ -656,10 +656,10 @@ contract StdAssertionsTest is Test {
         address targetA = address(new TestMockCall(revertDataA, SHOULD_REVERT));
         address targetB = address(new TestMockCall(revertDataB, SHOULD_REVERT));
 
-        t._assertEqCall(targetA, callDataA, targetB, callDataB, NON_STRICT_REVERT_DATA, EXPECT_PASS);
+        t._assertEqCall(targetA, callDataA, targetB, callDataB, NON_STRICT_REVERT_DATA, EXPECT);
     }
 
-    function testAssertEqCall_Revert_Fail(
+    function testFailFuzz_AssertEqCall_Revert(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory revertDataA,
@@ -675,7 +675,7 @@ contract StdAssertionsTest is Test {
         t._assertEqCall(targetA, callDataA, targetB, callDataB, STRICT_REVERT_DATA, EXPECT_FAIL);
     }
 
-    function testAssertEqCall_Fail(
+    function testFailFuzz_AssertEqCall(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory returnDataA,
@@ -702,23 +702,23 @@ contract StdAssertionsTest is Test {
                                 ASSERT_NOT_EQ(BYTES)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertNotEq_Bytes_Pass(bytes32 a, bytes32 b) external {
+    function testFuzz_AssertNotEq_Bytes(bytes32 a, bytes32 b) external {
         vm.assume(a != b);
-        t._assertNotEq(a, b, EXPECT_PASS);
+        t._assertNotEq(a, b, EXPECT);
     }
 
-    function testAssertNotEq_Bytes_Fail(bytes32 a) external {
+    function testFailFuzz_AssertNotEq_Bytes(bytes32 a) external {
         vm.expectEmit(false, false, false, true);
         emit log("Error: a != b not satisfied [bytes32]");
         t._assertNotEq(a, a, EXPECT_FAIL);
     }
 
-    function testAssertNotEq_BytesErr_Pass(bytes32 a, bytes32 b) external {
+    function testFuzz_AssertNotEq_BytesErr(bytes32 a, bytes32 b) external {
         vm.assume(a != b);
-        t._assertNotEq(a, b, CUSTOM_ERROR, EXPECT_PASS);
+        t._assertNotEq(a, b, CUSTOM_ERROR, EXPECT);
     }
 
-    function testAsserNottEq_BytesErr_Fail(bytes32 a) external {
+    function testFailFuzz_AsserNottEq_BytesErr(bytes32 a) external {
         vm.expectEmit(false, false, false, true);
         emit log_named_string("Error", CUSTOM_ERROR);
         t._assertNotEq(a, a, CUSTOM_ERROR, EXPECT_FAIL);
@@ -728,12 +728,12 @@ contract StdAssertionsTest is Test {
                                 ASSERT_NOT_EQ(UINT)
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testAssertNotEqUint() public {
+    function test_AssertNotEqUint() public {
         assertNotEq(uint8(1), uint128(2));
         assertNotEq(uint64(3), uint64(4));
     }
 
-    function testFailAssertNotEqUint() public {
+    function testFail_AssertNotEqUint() public {
         assertNotEq(uint64(1), uint96(1));
         assertNotEq(uint160(2), uint160(2));
     }

--- a/test/StdAssertions.t.sol
+++ b/test/StdAssertions.t.sol
@@ -646,7 +646,7 @@ contract StdAssertionsTest is Test {
         t._assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData, EXPECT_PASS);
     }
 
-    function testFuzz_AssertEqCall_Return_Fail(
+    function testFuzz_RevertWhenCalled_AssertEqCall_Return_Fail(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory returnDataA,
@@ -675,7 +675,7 @@ contract StdAssertionsTest is Test {
         t._assertEqCall(targetA, callDataA, targetB, callDataB, NON_STRICT_REVERT_DATA, EXPECT_PASS);
     }
 
-    function testFuzz_AssertEqCall_Revert_Fail(
+    function testFuzz_RevertWhenCalled_AssertEqCall_Revert_Fail(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory revertDataA,
@@ -691,7 +691,7 @@ contract StdAssertionsTest is Test {
         t._assertEqCall(targetA, callDataA, targetB, callDataB, STRICT_REVERT_DATA, EXPECT_FAIL);
     }
 
-    function testFuzz_AssertEqCall_Fail(
+    function testFuzz_RevertWhenCalled_AssertEqCall_Fail(
         bytes memory callDataA,
         bytes memory callDataB,
         bytes memory returnDataA,

--- a/test/StdAssertions.t.sol
+++ b/test/StdAssertions.t.sol
@@ -32,7 +32,7 @@ contract StdAssertionsTest is Test {
     //////////////////////////////////////////////////////////////////////////*/
 
     function test_AssertFalse() external {
-        t._assertFalse(false, EXPECT);
+        t._assertFalse(false, EXPECT_PASS);
     }
 
     function testFail_AssertFalse() external {
@@ -42,7 +42,7 @@ contract StdAssertionsTest is Test {
     }
 
     function test_AssertFalse_Err() external {
-        t._assertFalse(false, CUSTOM_ERROR, EXPECT);
+        t._assertFalse(false, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testFail_AssertFalse_Err() external {
@@ -56,7 +56,7 @@ contract StdAssertionsTest is Test {
     //////////////////////////////////////////////////////////////////////////*/
 
     function testFuzz_AssertEq_Bool(bool a) external {
-        t._assertEq(a, a, EXPECT);
+        t._assertEq(a, a, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertEq_Bool(bool a, bool b) external {
@@ -68,7 +68,7 @@ contract StdAssertionsTest is Test {
     }
 
     function testFuzz_AssertEq_BoolErr(bool a) external {
-        t._assertEq(a, a, CUSTOM_ERROR, EXPECT);
+        t._assertEq(a, a, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertEq_BoolErr(bool a, bool b) external {
@@ -84,7 +84,7 @@ contract StdAssertionsTest is Test {
     //////////////////////////////////////////////////////////////////////////*/
 
     function testFuzz_AssertEq_Bytes(bytes calldata a) external {
-        t._assertEq(a, a, EXPECT);
+        t._assertEq(a, a, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertEq_Bytes(bytes calldata a, bytes calldata b) external {
@@ -96,7 +96,7 @@ contract StdAssertionsTest is Test {
     }
 
     function testFuzz_AssertEq_BytesErr(bytes calldata a) external {
-        t._assertEq(a, a, CUSTOM_ERROR, EXPECT);
+        t._assertEq(a, a, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertEq_BytesErr(bytes calldata a, bytes calldata b) external {
@@ -121,7 +121,7 @@ contract StdAssertionsTest is Test {
         b[1] = e1;
         b[2] = e2;
 
-        t._assertEq(a, b, EXPECT);
+        t._assertEq(a, b, EXPECT_PASS);
     }
 
     function testFuzz_AssertEq_IntArr(int256 e0, int256 e1, int256 e2) public {
@@ -134,7 +134,7 @@ contract StdAssertionsTest is Test {
         b[1] = e1;
         b[2] = e2;
 
-        t._assertEq(a, b, EXPECT);
+        t._assertEq(a, b, EXPECT_PASS);
     }
 
     function testFuzz_AssertEq_AddressArr(address e0, address e1, address e2) public {
@@ -147,7 +147,7 @@ contract StdAssertionsTest is Test {
         b[1] = e1;
         b[2] = e2;
 
-        t._assertEq(a, b, EXPECT);
+        t._assertEq(a, b, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertEq_UintArr(uint256 e1) public {
@@ -321,7 +321,7 @@ contract StdAssertionsTest is Test {
     function testFuzz_AssertApproxEqAbs_Uint(uint256 a, uint256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbs(a, b, maxDelta, EXPECT);
+        t._assertApproxEqAbs(a, b, maxDelta, EXPECT_PASS);
     }
 
     function testFuzz_AssertApproxEqAbs_Uint_Fail(uint256 a, uint256 b, uint256 maxDelta) external {
@@ -335,7 +335,7 @@ contract StdAssertionsTest is Test {
     function testFuzz_AssertApproxEqAbs_UintErr(uint256 a, uint256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT);
+        t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testFuzz_AssertApproxEqAbs_UintErr_Fail(uint256 a, uint256 b, uint256 maxDelta) external {
@@ -355,7 +355,7 @@ contract StdAssertionsTest is Test {
     {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT);
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_PASS);
     }
 
     function testFuzz_AssertApproxEqAbsDecimal_Uint_Fail(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
@@ -373,7 +373,7 @@ contract StdAssertionsTest is Test {
     {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT);
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testFuzz_AssertApproxEqAbsDecimal_UintErr_Fail(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
@@ -393,7 +393,7 @@ contract StdAssertionsTest is Test {
     function testFuzz_AssertApproxEqAbs_Int(int256 a, int256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbs(a, b, maxDelta, EXPECT);
+        t._assertApproxEqAbs(a, b, maxDelta, EXPECT_PASS);
     }
 
     function testFuzz_AssertApproxEqAbs_Int_Fail(int256 a, int256 b, uint256 maxDelta) external {
@@ -407,7 +407,7 @@ contract StdAssertionsTest is Test {
     function testFuzz_AssertApproxEqAbs_IntErr(int256 a, int256 b, uint256 maxDelta) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT);
+        t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testFuzz_AssertApproxEqAbs_IntErr_Fail(int256 a, int256 b, uint256 maxDelta) external {
@@ -425,10 +425,12 @@ contract StdAssertionsTest is Test {
     function testFuzz_AssertApproxEqAbsDecimal_Int(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT);
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_PASS);
     }
 
-    function testFuzz_AssertApproxEqAbsDecimal_Int_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals) external {
+    function testFuzz_AssertApproxEqAbsDecimal_Int_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
+        external
+    {
         vm.assume(stdMath.delta(a, b) > maxDelta);
 
         vm.expectEmit(false, false, false, true);
@@ -441,7 +443,7 @@ contract StdAssertionsTest is Test {
     {
         vm.assume(stdMath.delta(a, b) <= maxDelta);
 
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT);
+        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testFuzz_AssertApproxEqAbsDecimal_IntErr_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
@@ -462,7 +464,7 @@ contract StdAssertionsTest is Test {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT);
+        t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertApproxEqRel_Uint(uint256 a, uint256 b, uint256 maxPercentDelta) external {
@@ -478,7 +480,7 @@ contract StdAssertionsTest is Test {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT);
+        t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertApproxEqRel_UintErr(uint256 a, uint256 b, uint256 maxPercentDelta) external {
@@ -500,7 +502,7 @@ contract StdAssertionsTest is Test {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT);
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertApproxEqRelDecimal_Uint(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
@@ -520,12 +522,15 @@ contract StdAssertionsTest is Test {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT);
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
     }
 
-    function testFailFuzz_AssertApproxEqRelDecimal_UintErr(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals)
-        external
-    {
+    function testFailFuzz_AssertApproxEqRelDecimal_UintErr(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta,
+        uint256 decimals
+    ) external {
         vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
         vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
 
@@ -542,7 +547,7 @@ contract StdAssertionsTest is Test {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT);
+        t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertApproxEqRel_Int(int128 a, int128 b, uint128 maxPercentDelta) external {
@@ -558,7 +563,7 @@ contract StdAssertionsTest is Test {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT);
+        t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertApproxEqRel_IntErr(int128 a, int128 b, uint128 maxPercentDelta) external {
@@ -580,7 +585,7 @@ contract StdAssertionsTest is Test {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT);
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertApproxEqRelDecimal_Int(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
@@ -600,7 +605,7 @@ contract StdAssertionsTest is Test {
         vm.assume(b != 0);
         vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
 
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT);
+        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertApproxEqRelDecimal_IntErr(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
@@ -627,7 +632,7 @@ contract StdAssertionsTest is Test {
         address targetA = address(new TestMockCall(returnData, SHOULD_RETURN));
         address targetB = address(new TestMockCall(returnData, SHOULD_RETURN));
 
-        t._assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData, EXPECT);
+        t._assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertEqCall_Return(
@@ -656,7 +661,7 @@ contract StdAssertionsTest is Test {
         address targetA = address(new TestMockCall(revertDataA, SHOULD_REVERT));
         address targetB = address(new TestMockCall(revertDataB, SHOULD_REVERT));
 
-        t._assertEqCall(targetA, callDataA, targetB, callDataB, NON_STRICT_REVERT_DATA, EXPECT);
+        t._assertEqCall(targetA, callDataA, targetB, callDataB, NON_STRICT_REVERT_DATA, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertEqCall_Revert(
@@ -704,7 +709,7 @@ contract StdAssertionsTest is Test {
 
     function testFuzz_AssertNotEq_Bytes(bytes32 a, bytes32 b) external {
         vm.assume(a != b);
-        t._assertNotEq(a, b, EXPECT);
+        t._assertNotEq(a, b, EXPECT_PASS);
     }
 
     function testFailFuzz_AssertNotEq_Bytes(bytes32 a) external {
@@ -715,7 +720,7 @@ contract StdAssertionsTest is Test {
 
     function testFuzz_AssertNotEq_BytesErr(bytes32 a, bytes32 b) external {
         vm.assume(a != b);
-        t._assertNotEq(a, b, CUSTOM_ERROR, EXPECT);
+        t._assertNotEq(a, b, CUSTOM_ERROR, EXPECT_PASS);
     }
 
     function testFailFuzz_AsserNottEq_BytesErr(bytes32 a) external {

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -22,7 +22,7 @@ contract StdChainsMock is Test {
 }
 
 contract StdChainsTest is Test {
-    function testChainRpcInitialization() public {
+    function test_ChainRpcInitialization() public {
         // RPCs specified in `foundry.toml` should be updated.
         assertEq(getChain(1).rpcUrl, "https://mainnet.infura.io/v3/b1d3925804e74152b316ca7da97060d3");
         assertEq(getChain("optimism_goerli").rpcUrl, "https://goerli.optimism.io/");
@@ -43,7 +43,7 @@ contract StdChainsTest is Test {
         assertEq(getChain("sepolia").rpcUrl, "https://sepolia.infura.io/v3/b9794ad1ddf84dfb8c34d6bb5dca2001");
     }
 
-    function testRpc(string memory rpcAlias) internal {
+    function testFuzz_Rpc(string memory rpcAlias) internal {
         string memory rpcUrl = getChain(rpcAlias).rpcUrl;
         vm.createSelectFork(rpcUrl);
     }
@@ -67,7 +67,7 @@ contract StdChainsTest is Test {
     //     testRpc("gnosis_chain");
     // }
 
-    function testChainNoDefault() public {
+    function test_ChainNoDefault() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
@@ -75,7 +75,7 @@ contract StdChainsTest is Test {
         stdChainsMock.exposed_getChain("does_not_exist");
     }
 
-    function testSetChainFirstFails() public {
+    function test_SetChainFirstFails() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
@@ -83,7 +83,7 @@ contract StdChainsTest is Test {
         stdChainsMock.exposed_setChain("anvil2", ChainData("Anvil", 31337, "URL"));
     }
 
-    function testChainBubbleUp() public {
+    function test_ChainBubbleUp() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
@@ -94,7 +94,7 @@ contract StdChainsTest is Test {
         stdChainsMock.exposed_getChain("needs_undefined_env_var");
     }
 
-    function testCannotSetChain_ChainIdExists() public {
+    function test_CannotSetChain_ChainIdExists() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
@@ -105,7 +105,7 @@ contract StdChainsTest is Test {
         stdChainsMock.exposed_setChain("another_custom_chain", ChainData("", 123456789, ""));
     }
 
-    function testSetChain() public {
+    function test_SetChain() public {
         setChain("custom_chain", ChainData("Custom Chain", 123456789, "https://custom.chain/"));
         Chain memory customChain = getChain("custom_chain");
         assertEq(customChain.name, "Custom Chain");
@@ -131,7 +131,7 @@ contract StdChainsTest is Test {
         assertEq(chainById.chainId, 123456789);
     }
 
-    function testSetNoEmptyAlias() public {
+    function test_SetNoEmptyAlias() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
@@ -139,7 +139,7 @@ contract StdChainsTest is Test {
         stdChainsMock.exposed_setChain("", ChainData("", 123456789, ""));
     }
 
-    function testSetNoChainId0() public {
+    function test_SetNoChainId0() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
@@ -147,7 +147,7 @@ contract StdChainsTest is Test {
         stdChainsMock.exposed_setChain("alias", ChainData("", 0, ""));
     }
 
-    function testGetNoChainId0() public {
+    function test_GetNoChainId0() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
@@ -155,7 +155,7 @@ contract StdChainsTest is Test {
         stdChainsMock.exposed_getChain(0);
     }
 
-    function testGetNoEmptyAlias() public {
+    function test_GetNoEmptyAlias() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
@@ -163,7 +163,7 @@ contract StdChainsTest is Test {
         stdChainsMock.exposed_getChain("");
     }
 
-    function testChainIdNotFound() public {
+    function test_ChainIdNotFound() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
@@ -171,7 +171,7 @@ contract StdChainsTest is Test {
         stdChainsMock.exposed_getChain("no_such_alias");
     }
 
-    function testChainAliasNotFound() public {
+    function test_ChainAliasNotFound() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
@@ -180,7 +180,7 @@ contract StdChainsTest is Test {
         stdChainsMock.exposed_getChain(321);
     }
 
-    function testSetChain_ExistingOne() public {
+    function test_SetChain_ExistingOne() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
@@ -197,7 +197,7 @@ contract StdChainsTest is Test {
         assertEq(modifiedChain.rpcUrl, "https://modified.chain/");
     }
 
-    function testDontUseDefaultRpcUrl() public {
+    function test_DontUseDefaultRpcUrl() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -14,34 +14,34 @@ contract StdCheatsTest is Test {
         test = new Bar();
     }
 
-    function testSkip() public {
+    function test_Skip() public {
         vm.warp(100);
         skip(25);
         assertEq(block.timestamp, 125);
     }
 
-    function testRewind() public {
+    function test_Rewind() public {
         vm.warp(100);
         rewind(25);
         assertEq(block.timestamp, 75);
     }
 
-    function testHoax() public {
+    function test_Hoax() public {
         hoax(address(1337));
         test.bar{value: 100}(address(1337));
     }
 
-    function testHoaxOrigin() public {
+    function test_HoaxOrigin() public {
         hoax(address(1337), address(1337));
         test.origin{value: 100}(address(1337));
     }
 
-    function testHoaxDifferentAddresses() public {
+    function test_HoaxDifferentAddresses() public {
         hoax(address(1337), address(7331));
         test.origin{value: 100}(address(1337), address(7331));
     }
 
-    function testStartHoax() public {
+    function test_StartHoax() public {
         startHoax(address(1337));
         test.bar{value: 100}(address(1337));
         test.bar{value: 100}(address(1337));
@@ -49,7 +49,7 @@ contract StdCheatsTest is Test {
         test.bar(address(this));
     }
 
-    function testStartHoaxOrigin() public {
+    function test_StartHoaxOrigin() public {
         startHoax(address(1337), address(1337));
         test.origin{value: 100}(address(1337));
         test.origin{value: 100}(address(1337));
@@ -57,7 +57,7 @@ contract StdCheatsTest is Test {
         test.bar(address(this));
     }
 
-    function testChangePrankMsgSender() public {
+    function test_ChangePrankMsgSender() public {
         vm.startPrank(address(1337));
         test.bar(address(1337));
         changePrank(address(0xdead));
@@ -67,7 +67,7 @@ contract StdCheatsTest is Test {
         vm.stopPrank();
     }
 
-    function testChangePrankMsgSenderAndTxOrigin() public {
+    function test_ChangePrankMsgSenderAndTxOrigin() public {
         vm.startPrank(address(1337), address(1338));
         test.origin(address(1337), address(1338));
         changePrank(address(0xdead), address(0xbeef));
@@ -77,19 +77,19 @@ contract StdCheatsTest is Test {
         vm.stopPrank();
     }
 
-    function testMakeAccountEquivalence() public {
+    function test_MakeAccountEquivalence() public {
         Account memory account = makeAccount("1337");
         (address addr, uint256 key) = makeAddrAndKey("1337");
         assertEq(account.addr, addr);
         assertEq(account.key, key);
     }
 
-    function testMakeAddrEquivalence() public {
+    function test_MakeAddrEquivalence() public {
         (address addr,) = makeAddrAndKey("1337");
         assertEq(makeAddr("1337"), addr);
     }
 
-    function testMakeAddrSigning() public {
+    function test_MakeAddrSigning() public {
         (address addr, uint256 key) = makeAddrAndKey("1337");
         bytes32 hash = keccak256("some_message");
 
@@ -97,19 +97,19 @@ contract StdCheatsTest is Test {
         assertEq(ecrecover(hash, v, r, s), addr);
     }
 
-    function testDeal() public {
+    function test_Deal() public {
         deal(address(this), 1 ether);
         assertEq(address(this).balance, 1 ether);
     }
 
-    function testDealToken() public {
+    function tes_tDealToken() public {
         Bar barToken = new Bar();
         address bar = address(barToken);
         deal(bar, address(this), 10000e18);
         assertEq(barToken.balanceOf(address(this)), 10000e18);
     }
 
-    function testDealTokenAdjustTotalSupply() public {
+    function test_DealTokenAdjustTotalSupply() public {
         Bar barToken = new Bar();
         address bar = address(barToken);
         deal(bar, address(this), 10000e18, true);
@@ -120,14 +120,14 @@ contract StdCheatsTest is Test {
         assertEq(barToken.totalSupply(), 10000e18);
     }
 
-    function testDealERC1155Token() public {
+    function test_DealERC1155Token() public {
         BarERC1155 barToken = new BarERC1155();
         address bar = address(barToken);
         dealERC1155(bar, address(this), 0, 10000e18, false);
         assertEq(barToken.balanceOf(address(this), 0), 10000e18);
     }
 
-    function testDealERC1155TokenAdjustTotalSupply() public {
+    function test_DealERC1155TokenAdjustTotalSupply() public {
         BarERC1155 barToken = new BarERC1155();
         address bar = address(barToken);
         dealERC1155(bar, address(this), 0, 10000e18, true);
@@ -138,7 +138,7 @@ contract StdCheatsTest is Test {
         assertEq(barToken.totalSupply(0), 10000e18);
     }
 
-    function testDealERC721Token() public {
+    function test_DealERC721Token() public {
         BarERC721 barToken = new BarERC721();
         address bar = address(barToken);
         dealERC721(bar, address(2), 1);
@@ -149,12 +149,12 @@ contract StdCheatsTest is Test {
         assertEq(barToken.balanceOf(bar), 1);
     }
 
-    function testDeployCode() public {
+    function test_DeployCode() public {
         address deployed = deployCode("StdCheats.t.sol:Bar", bytes(""));
         assertEq(string(getCode(deployed)), string(getCode(address(test))));
     }
 
-    function testDestroyAccount() public {
+    function test_DestroyAccount() public {
         // deploy something to destroy it
         BarERC721 barToken = new BarERC721();
         address bar = address(barToken);
@@ -181,18 +181,18 @@ contract StdCheatsTest is Test {
         assertEq(bar.balance, 0);
     }
 
-    function testDeployCodeNoArgs() public {
+    function test_DeployCodeNoArgs() public {
         address deployed = deployCode("StdCheats.t.sol:Bar");
         assertEq(string(getCode(deployed)), string(getCode(address(test))));
     }
 
-    function testDeployCodeVal() public {
+    function test_DeployCodeVal() public {
         address deployed = deployCode("StdCheats.t.sol:Bar", bytes(""), 1 ether);
         assertEq(string(getCode(deployed)), string(getCode(address(test))));
         assertEq(deployed.balance, 1 ether);
     }
 
-    function testDeployCodeValNoArgs() public {
+    function test_DeployCodeValNoArgs() public {
         address deployed = deployCode("StdCheats.t.sol:Bar", 1 ether);
         assertEq(string(getCode(deployed)), string(getCode(address(test))));
         assertEq(deployed.balance, 1 ether);
@@ -203,7 +203,7 @@ contract StdCheatsTest is Test {
         deployCode(what);
     }
 
-    function testDeployCodeFail() public {
+    function test_DeployCodeFail() public {
         vm.expectRevert(bytes("StdCheats deployCode(string): Deployment failed."));
         this.deployCodeHelper("StdCheats.t.sol:RevertingContract");
     }
@@ -225,7 +225,7 @@ contract StdCheatsTest is Test {
         }
     }
 
-    function testDeriveRememberKey() public {
+    function test_DeriveRememberKey() public {
         string memory mnemonic = "test test test test test test test test test test test junk";
 
         (address deployer, uint256 privateKey) = deriveRememberKey(mnemonic, 0);
@@ -233,14 +233,14 @@ contract StdCheatsTest is Test {
         assertEq(privateKey, 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80);
     }
 
-    function testBytesToUint() public {
+    function test_BytesToUint() public {
         assertEq(3, bytesToUint_test(hex"03"));
         assertEq(2, bytesToUint_test(hex"02"));
         assertEq(255, bytesToUint_test(hex"ff"));
         assertEq(29625, bytesToUint_test(hex"73b9"));
     }
 
-    function testParseJsonTxDetail() public {
+    function test_ParseJsonTxDetail() public {
         string memory root = vm.projectRoot();
         string memory path = string.concat(root, "/test/fixtures/broadcast.log.json");
         string memory json = vm.readFile(path);
@@ -259,7 +259,7 @@ contract StdCheatsTest is Test {
         assertEq(txDetail.value, 0);
     }
 
-    function testReadEIP1559Transaction() public view {
+    function test_ReadEIP1559Transaction() public view {
         string memory root = vm.projectRoot();
         string memory path = string.concat(root, "/test/fixtures/broadcast.log.json");
         uint256 index = 0;
@@ -267,14 +267,14 @@ contract StdCheatsTest is Test {
         transaction;
     }
 
-    function testReadEIP1559Transactions() public view {
+    function test_ReadEIP1559Transactions() public view {
         string memory root = vm.projectRoot();
         string memory path = string.concat(root, "/test/fixtures/broadcast.log.json");
         Tx1559[] memory transactions = readTx1559s(path);
         transactions;
     }
 
-    function testReadReceipt() public {
+    function test_ReadReceipt() public {
         string memory root = vm.projectRoot();
         string memory path = string.concat(root, "/test/fixtures/broadcast.log.json");
         uint256 index = 5;
@@ -285,14 +285,14 @@ contract StdCheatsTest is Test {
         );
     }
 
-    function testReadReceipts() public view {
+    function test_ReadReceipts() public view {
         string memory root = vm.projectRoot();
         string memory path = string.concat(root, "/test/fixtures/broadcast.log.json");
         Receipt[] memory receipts = readReceipts(path);
         receipts;
     }
 
-    function testGasMeteringModifier() public {
+    function test_GasMeteringModifier() public {
         uint256 gas_start_normal = gasleft();
         addInLoop();
         uint256 gas_used_normal = gas_start_normal - gasleft();
@@ -335,7 +335,7 @@ contract StdCheatsTest is Test {
         return number;
     }
 
-    function testAssumeAddressIsNot(address addr) external {
+    function testFuzz_AssumeAddressIsNot(address addr) external {
         // skip over Payable and NonPayable enums
         for (uint8 i = 2; i < uint8(type(AddressType).max); i++) {
             assumeAddressIsNot(addr, AddressType(i));
@@ -345,7 +345,7 @@ contract StdCheatsTest is Test {
         assertTrue(addr != address(vm) || addr != 0x000000000000000000636F6e736F6c652e6c6f67);
     }
 
-    function testAssumePayable() external {
+    function test_AssumePayable() external {
         // We deploy a mock version so we can properly test the revert.
         StdCheatsMock stdCheatsMock = new StdCheatsMock();
 
@@ -373,7 +373,7 @@ contract StdCheatsTest is Test {
         stdCheatsMock.exposed_assumePayable(address(cp));
     }
 
-    function testAssumeNotPayable() external {
+    function test_AssumeNotPayable() external {
         // We deploy a mock version so we can properly test the revert.
         StdCheatsMock stdCheatsMock = new StdCheatsMock();
 
@@ -400,7 +400,7 @@ contract StdCheatsTest is Test {
         stdCheatsMock.exposed_assumeNotPayable(address(cp));
     }
 
-    function testAssumeNotPrecompile(address addr) external {
+    function testFuzz_AssumeNotPrecompile(address addr) external {
         assumeNotPrecompile(addr, getChain("optimism_goerli").chainId);
         assertTrue(
             addr < address(1) || (addr > address(9) && addr < address(0x4200000000000000000000000000000000000000))
@@ -408,7 +408,7 @@ contract StdCheatsTest is Test {
         );
     }
 
-    function testCannotDeployCodeTo() external {
+    function test_CannotDeployCodeTo() external {
         vm.expectRevert("StdCheats deployCodeTo(string,bytes,uint256,address): Failed to create runtime bytecode.");
         this._revertDeployCodeTo();
     }
@@ -417,7 +417,7 @@ contract StdCheatsTest is Test {
         deployCodeTo("StdCheats.t.sol:RevertingContract", address(0));
     }
 
-    function testDeployCodeTo() external {
+    function test_DeployCodeTo() external {
         address arbitraryAddress = makeAddr("arbitraryAddress");
 
         deployCodeTo(
@@ -463,7 +463,7 @@ contract StdCheatsForkTest is Test {
         vm.createSelectFork({urlOrAlias: "mainnet", blockNumber: 16_428_900});
     }
 
-    function testCannotAssumeNoBlacklisted_EOA() external {
+    function test_CannotAssumeNoBlacklisted_EOA() external {
         // We deploy a mock version so we can properly test the revert.
         StdCheatsMock stdCheatsMock = new StdCheatsMock();
         address eoa = vm.addr({privateKey: 1});
@@ -471,31 +471,31 @@ contract StdCheatsForkTest is Test {
         stdCheatsMock.exposed_assumeNotBlacklisted(eoa, address(0));
     }
 
-    function testAssumeNotBlacklisted_TokenWithoutBlacklist(address addr) external {
+    function testFuzz_AssumeNotBlacklisted_TokenWithoutBlacklist(address addr) external {
         assumeNotBlacklisted(SHIB, addr);
         assertTrue(true);
     }
 
-    function testAssumeNoBlacklisted_USDC() external {
+    function test_AssumeNoBlacklisted_USDC() external {
         // We deploy a mock version so we can properly test the revert.
         StdCheatsMock stdCheatsMock = new StdCheatsMock();
         vm.expectRevert();
         stdCheatsMock.exposed_assumeNotBlacklisted(USDC, USDC_BLACKLISTED_USER);
     }
 
-    function testAssumeNotBlacklisted_USDC(address addr) external {
+    function testFuzz_AssumeNotBlacklisted_USDC(address addr) external {
         assumeNotBlacklisted(USDC, addr);
         assertFalse(USDCLike(USDC).isBlacklisted(addr));
     }
 
-    function testAssumeNoBlacklisted_USDT() external {
+    function test_AssumeNoBlacklisted_USDT() external {
         // We deploy a mock version so we can properly test the revert.
         StdCheatsMock stdCheatsMock = new StdCheatsMock();
         vm.expectRevert();
         stdCheatsMock.exposed_assumeNotBlacklisted(USDT, USDT_BLACKLISTED_USER);
     }
 
-    function testAssumeNotBlacklisted_USDT(address addr) external {
+    function testFuzz_AssumeNotBlacklisted_USDT(address addr) external {
         assumeNotBlacklisted(USDT, addr);
         assertFalse(USDTLike(USDT).isBlackListed(addr));
     }

--- a/test/StdError.t.sol
+++ b/test/StdError.t.sol
@@ -11,52 +11,52 @@ contract StdErrorsTest is Test {
         test = new ErrorsTest();
     }
 
-    function testExpectAssertion() public {
+    function test_ExpectAssertion() public {
         vm.expectRevert(stdError.assertionError);
         test.assertionError();
     }
 
-    function testExpectArithmetic() public {
+    function test_ExpectArithmetic() public {
         vm.expectRevert(stdError.arithmeticError);
         test.arithmeticError(10);
     }
 
-    function testExpectDiv() public {
+    function test_ExpectDiv() public {
         vm.expectRevert(stdError.divisionError);
         test.divError(0);
     }
 
-    function testExpectMod() public {
+    function test_ExpectMod() public {
         vm.expectRevert(stdError.divisionError);
         test.modError(0);
     }
 
-    function testExpectEnum() public {
+    function test_ExpectEnum() public {
         vm.expectRevert(stdError.enumConversionError);
         test.enumConversion(1);
     }
 
-    function testExpectEncodeStg() public {
+    function test_ExpectEncodeStg() public {
         vm.expectRevert(stdError.encodeStorageError);
         test.encodeStgError();
     }
 
-    function testExpectPop() public {
+    function test_ExpectPop() public {
         vm.expectRevert(stdError.popError);
         test.pop();
     }
 
-    function testExpectOOB() public {
+    function test_ExpectOOB() public {
         vm.expectRevert(stdError.indexOOBError);
         test.indexOOBError(1);
     }
 
-    function testExpectMem() public {
+    function test_ExpectMem() public {
         vm.expectRevert(stdError.memOverflowError);
         test.mem();
     }
 
-    function testExpectIntern() public {
+    function test_ExpectIntern() public {
         vm.expectRevert(stdError.zeroVarError);
         test.intern();
     }

--- a/test/StdMath.t.sol
+++ b/test/StdMath.t.sol
@@ -15,7 +15,7 @@ contract StdMathMock is Test {
 }
 
 contract StdMathTest is Test {
-    function testGetAbs() external {
+    function test_GetAbs() external {
         assertEq(stdMath.abs(-50), 50);
         assertEq(stdMath.abs(50), 50);
         assertEq(stdMath.abs(-1337), 1337);
@@ -25,7 +25,7 @@ contract StdMathTest is Test {
         assertEq(stdMath.abs(type(int256).max), (type(uint256).max >> 1));
     }
 
-    function testGetAbs_Fuzz(int256 a) external {
+    function testFuzz_GetAbs(int256 a) external {
         uint256 manualAbs = getAbs(a);
 
         uint256 abs = stdMath.abs(a);
@@ -33,7 +33,7 @@ contract StdMathTest is Test {
         assertEq(abs, manualAbs);
     }
 
-    function testGetDelta_Uint() external {
+    function test_GetDelta_Uint() external {
         assertEq(stdMath.delta(uint256(0), uint256(0)), 0);
         assertEq(stdMath.delta(uint256(0), uint256(1337)), 1337);
         assertEq(stdMath.delta(uint256(0), type(uint64).max), type(uint64).max);
@@ -51,7 +51,7 @@ contract StdMathTest is Test {
         assertEq(stdMath.delta(5000, uint256(1250)), 3750);
     }
 
-    function testGetDelta_Uint_Fuzz(uint256 a, uint256 b) external {
+    function testFuzz_GetDelta_Uint(uint256 a, uint256 b) external {
         uint256 manualDelta;
         if (a > b) {
             manualDelta = a - b;
@@ -64,7 +64,7 @@ contract StdMathTest is Test {
         assertEq(delta, manualDelta);
     }
 
-    function testGetDelta_Int() external {
+    function test_GetDelta_Int() external {
         assertEq(stdMath.delta(int256(0), int256(0)), 0);
         assertEq(stdMath.delta(int256(0), int256(1337)), 1337);
         assertEq(stdMath.delta(int256(0), type(int64).max), type(uint64).max >> 1);
@@ -96,7 +96,7 @@ contract StdMathTest is Test {
         assertEq(stdMath.delta(5000, int256(1250)), 3750);
     }
 
-    function testGetDelta_Int_Fuzz(int256 a, int256 b) external {
+    function testFuzz_GetDelta_Int(int256 a, int256 b) external {
         uint256 absA = getAbs(a);
         uint256 absB = getAbs(b);
         uint256 absDelta = absA > absB ? absA - absB : absB - absA;
@@ -115,7 +115,7 @@ contract StdMathTest is Test {
         assertEq(delta, manualDelta);
     }
 
-    function testGetPercentDelta_Uint() external {
+    function test_GetPercentDelta_Uint() external {
         StdMathMock stdMathMock = new StdMathMock();
 
         assertEq(stdMath.percentDelta(uint256(0), uint256(1337)), 1e18);
@@ -134,7 +134,7 @@ contract StdMathTest is Test {
         stdMathMock.exposed_percentDelta(uint256(1), 0);
     }
 
-    function testGetPercentDelta_Uint_Fuzz(uint192 a, uint192 b) external {
+    function testFuzz_GetPercentDelta_Uint(uint192 a, uint192 b) external {
         vm.assume(b != 0);
         uint256 manualDelta;
         if (a > b) {
@@ -149,7 +149,7 @@ contract StdMathTest is Test {
         assertEq(percentDelta, manualPercentDelta);
     }
 
-    function testGetPercentDelta_Int() external {
+    function test_GetPercentDelta_Int() external {
         // We deploy a mock version so we can properly test the revert.
         StdMathMock stdMathMock = new StdMathMock();
 
@@ -177,7 +177,7 @@ contract StdMathTest is Test {
         stdMathMock.exposed_percentDelta(int256(1), 0);
     }
 
-    function testGetPercentDelta_Int_Fuzz(int192 a, int192 b) external {
+    function testFuzz_GetPercentDelta_Int(int192 a, int192 b) external {
         vm.assume(b != 0);
         uint256 absA = getAbs(a);
         uint256 absB = getAbs(b);

--- a/test/StdStorage.t.sol
+++ b/test/StdStorage.t.sol
@@ -13,60 +13,60 @@ contract StdStorageTest is Test {
         test = new StorageTest();
     }
 
-    function testStorageHidden() public {
+    function test_StorageHidden() public {
         assertEq(uint256(keccak256("my.random.var")), stdstore.target(address(test)).sig("hidden()").find());
     }
 
-    function testStorageObvious() public {
+    function test_StorageObvious() public {
         assertEq(uint256(0), stdstore.target(address(test)).sig("exists()").find());
     }
 
-    function testStorageCheckedWriteHidden() public {
+    function test_StorageCheckedWriteHidden() public {
         stdstore.target(address(test)).sig(test.hidden.selector).checked_write(100);
         assertEq(uint256(test.hidden()), 100);
     }
 
-    function testStorageCheckedWriteObvious() public {
+    function test_StorageCheckedWriteObvious() public {
         stdstore.target(address(test)).sig(test.exists.selector).checked_write(100);
         assertEq(test.exists(), 100);
     }
 
-    function testStorageCheckedWriteSignedIntegerHidden() public {
+    function test_StorageCheckedWriteSignedIntegerHidden() public {
         stdstore.target(address(test)).sig(test.hidden.selector).checked_write_int(-100);
         assertEq(int256(uint256(test.hidden())), -100);
     }
 
-    function testStorageCheckedWriteSignedIntegerObvious() public {
+    function test_StorageCheckedWriteSignedIntegerObvious() public {
         stdstore.target(address(test)).sig(test.tG.selector).checked_write_int(-100);
         assertEq(test.tG(), -100);
     }
 
-    function testStorageMapStructA() public {
+    function test_StorageMapStructA() public {
         uint256 slot =
             stdstore.target(address(test)).sig(test.map_struct.selector).with_key(address(this)).depth(0).find();
         assertEq(uint256(keccak256(abi.encode(address(this), 4))), slot);
     }
 
-    function testStorageMapStructB() public {
+    function test_StorageMapStructB() public {
         uint256 slot =
             stdstore.target(address(test)).sig(test.map_struct.selector).with_key(address(this)).depth(1).find();
         assertEq(uint256(keccak256(abi.encode(address(this), 4))) + 1, slot);
     }
 
-    function testStorageDeepMap() public {
+    function test_StorageDeepMap() public {
         uint256 slot = stdstore.target(address(test)).sig(test.deep_map.selector).with_key(address(this)).with_key(
             address(this)
         ).find();
         assertEq(uint256(keccak256(abi.encode(address(this), keccak256(abi.encode(address(this), uint256(5)))))), slot);
     }
 
-    function testStorageCheckedWriteDeepMap() public {
+    function test_StorageCheckedWriteDeepMap() public {
         stdstore.target(address(test)).sig(test.deep_map.selector).with_key(address(this)).with_key(address(this))
             .checked_write(100);
         assertEq(100, test.deep_map(address(this), address(this)));
     }
 
-    function testStorageDeepMapStructA() public {
+    function test_StorageDeepMapStructA() public {
         uint256 slot = stdstore.target(address(test)).sig(test.deep_map_struct.selector).with_key(address(this))
             .with_key(address(this)).depth(0).find();
         assertEq(
@@ -75,7 +75,7 @@ contract StdStorageTest is Test {
         );
     }
 
-    function testStorageDeepMapStructB() public {
+    function test_StorageDeepMapStructB() public {
         uint256 slot = stdstore.target(address(test)).sig(test.deep_map_struct.selector).with_key(address(this))
             .with_key(address(this)).depth(1).find();
         assertEq(
@@ -84,7 +84,7 @@ contract StdStorageTest is Test {
         );
     }
 
-    function testStorageCheckedWriteDeepMapStructA() public {
+    function test_StorageCheckedWriteDeepMapStructA() public {
         stdstore.target(address(test)).sig(test.deep_map_struct.selector).with_key(address(this)).with_key(
             address(this)
         ).depth(0).checked_write(100);
@@ -93,7 +93,7 @@ contract StdStorageTest is Test {
         assertEq(0, b);
     }
 
-    function testStorageCheckedWriteDeepMapStructB() public {
+    function test_StorageCheckedWriteDeepMapStructB() public {
         stdstore.target(address(test)).sig(test.deep_map_struct.selector).with_key(address(this)).with_key(
             address(this)
         ).depth(1).checked_write(100);
@@ -102,76 +102,76 @@ contract StdStorageTest is Test {
         assertEq(100, b);
     }
 
-    function testStorageCheckedWriteMapStructA() public {
+    function test_StorageCheckedWriteMapStructA() public {
         stdstore.target(address(test)).sig(test.map_struct.selector).with_key(address(this)).depth(0).checked_write(100);
         (uint256 a, uint256 b) = test.map_struct(address(this));
         assertEq(a, 100);
         assertEq(b, 0);
     }
 
-    function testStorageCheckedWriteMapStructB() public {
+    function test_StorageCheckedWriteMapStructB() public {
         stdstore.target(address(test)).sig(test.map_struct.selector).with_key(address(this)).depth(1).checked_write(100);
         (uint256 a, uint256 b) = test.map_struct(address(this));
         assertEq(a, 0);
         assertEq(b, 100);
     }
 
-    function testStorageStructA() public {
+    function test_StorageStructA() public {
         uint256 slot = stdstore.target(address(test)).sig(test.basic.selector).depth(0).find();
         assertEq(uint256(7), slot);
     }
 
-    function testStorageStructB() public {
+    function test_StorageStructB() public {
         uint256 slot = stdstore.target(address(test)).sig(test.basic.selector).depth(1).find();
         assertEq(uint256(7) + 1, slot);
     }
 
-    function testStorageCheckedWriteStructA() public {
+    function test_StorageCheckedWriteStructA() public {
         stdstore.target(address(test)).sig(test.basic.selector).depth(0).checked_write(100);
         (uint256 a, uint256 b) = test.basic();
         assertEq(a, 100);
         assertEq(b, 1337);
     }
 
-    function testStorageCheckedWriteStructB() public {
+    function test_StorageCheckedWriteStructB() public {
         stdstore.target(address(test)).sig(test.basic.selector).depth(1).checked_write(100);
         (uint256 a, uint256 b) = test.basic();
         assertEq(a, 1337);
         assertEq(b, 100);
     }
 
-    function testStorageMapAddrFound() public {
+    function test_StorageMapAddrFound() public {
         uint256 slot = stdstore.target(address(test)).sig(test.map_addr.selector).with_key(address(this)).find();
         assertEq(uint256(keccak256(abi.encode(address(this), uint256(1)))), slot);
     }
 
-    function testStorageMapUintFound() public {
+    function test_StorageMapUintFound() public {
         uint256 slot = stdstore.target(address(test)).sig(test.map_uint.selector).with_key(100).find();
         assertEq(uint256(keccak256(abi.encode(100, uint256(2)))), slot);
     }
 
-    function testStorageCheckedWriteMapUint() public {
+    function test_StorageCheckedWriteMapUint() public {
         stdstore.target(address(test)).sig(test.map_uint.selector).with_key(100).checked_write(100);
         assertEq(100, test.map_uint(100));
     }
 
-    function testStorageCheckedWriteMapAddr() public {
+    function test_StorageCheckedWriteMapAddr() public {
         stdstore.target(address(test)).sig(test.map_addr.selector).with_key(address(this)).checked_write(100);
         assertEq(100, test.map_addr(address(this)));
     }
 
-    function testStorageCheckedWriteMapBool() public {
+    function test_StorageCheckedWriteMapBool() public {
         stdstore.target(address(test)).sig(test.map_bool.selector).with_key(address(this)).checked_write(true);
         assertTrue(test.map_bool(address(this)));
     }
 
-    function testFailStorageCheckedWriteMapPacked() public {
+    function testFail_StorageCheckedWriteMapPacked() public {
         // expect PackedSlot error but not external call so cant expectRevert
         stdstore.target(address(test)).sig(test.read_struct_lower.selector).with_key(address(uint160(1337)))
             .checked_write(100);
     }
 
-    function testStorageCheckedWriteMapPackedSuccess() public {
+    function test_StorageCheckedWriteMapPackedSuccess() public {
         uint256 full = test.map_packed(address(1337));
         // keep upper 128, set lower 128 to 1337
         full = (full & (uint256((1 << 128) - 1) << 128)) | 1337;
@@ -181,12 +181,12 @@ contract StdStorageTest is Test {
         assertEq(1337, test.read_struct_lower(address(1337)));
     }
 
-    function testFailStorageConst() public {
+    function testFail_StorageConst() public {
         // vm.expectRevert(abi.encodeWithSignature("NotStorage(bytes4)", bytes4(keccak256("const()"))));
         stdstore.target(address(test)).sig("const()").find();
     }
 
-    function testFailStorageNativePack() public {
+    function testFail_StorageNativePack() public {
         stdstore.target(address(test)).sig(test.tA.selector).find();
         stdstore.target(address(test)).sig(test.tB.selector).find();
 
@@ -195,22 +195,22 @@ contract StdStorageTest is Test {
         stdstore.target(address(test)).sig(test.tD.selector).find();
     }
 
-    function testStorageReadBytes32() public {
+    function test_StorageReadBytes32() public {
         bytes32 val = stdstore.target(address(test)).sig(test.tE.selector).read_bytes32();
         assertEq(val, hex"1337");
     }
 
-    function testStorageReadBool_False() public {
+    function test_StorageReadBool_False() public {
         bool val = stdstore.target(address(test)).sig(test.tB.selector).read_bool();
         assertEq(val, false);
     }
 
-    function testStorageReadBool_True() public {
+    function test_StorageReadBool_True() public {
         bool val = stdstore.target(address(test)).sig(test.tH.selector).read_bool();
         assertEq(val, true);
     }
 
-    function testStorageReadBool_Revert() public {
+    function test_StorageReadBool_Revert() public {
         vm.expectRevert("stdStorage read_bool(StdStorage): Cannot decode. Make sure you are reading a bool.");
         this.readNonBoolValue();
     }
@@ -219,17 +219,17 @@ contract StdStorageTest is Test {
         stdstore.target(address(test)).sig(test.tE.selector).read_bool();
     }
 
-    function testStorageReadAddress() public {
+    function test_StorageReadAddress() public {
         address val = stdstore.target(address(test)).sig(test.tF.selector).read_address();
         assertEq(val, address(1337));
     }
 
-    function testStorageReadUint() public {
+    function test_StorageReadUint() public {
         uint256 val = stdstore.target(address(test)).sig(test.exists.selector).read_uint();
         assertEq(val, 1);
     }
 
-    function testStorageReadInt() public {
+    function test_StorageReadInt() public {
         int256 val = stdstore.target(address(test)).sig(test.tG.selector).read_int();
         assertEq(val, type(int256).min);
     }

--- a/test/StdStyle.t.sol
+++ b/test/StdStyle.t.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "../src/Test.sol";
 
 contract StdStyleTest is Test {
-    function testStyleColor() public pure {
+    function test_StyleColor() public pure {
         console2.log(StdStyle.red("StdStyle.red String Test"));
         console2.log(StdStyle.red(uint256(10e18)));
         console2.log(StdStyle.red(int256(-10e18)));
@@ -49,7 +49,7 @@ contract StdStyleTest is Test {
         console2.log(StdStyle.cyanBytes32("StdStyle.cyanBytes32"));
     }
 
-    function testStyleFontWeight() public pure {
+    function test_StyleFontWeight() public pure {
         console2.log(StdStyle.bold("StdStyle.bold String Test"));
         console2.log(StdStyle.bold(uint256(10e18)));
         console2.log(StdStyle.bold(int256(-10e18)));
@@ -87,7 +87,7 @@ contract StdStyleTest is Test {
         console2.log(StdStyle.inverseBytes32("StdStyle.inverseBytes32"));
     }
 
-    function testStyleCombined() public pure {
+    function test_StyleCombined() public pure {
         console2.log(StdStyle.red(StdStyle.bold("Red Bold String Test")));
         console2.log(StdStyle.green(StdStyle.dim(uint256(10e18))));
         console2.log(StdStyle.yellow(StdStyle.italic(int256(-10e18))));
@@ -95,7 +95,7 @@ contract StdStyleTest is Test {
         console2.log(StdStyle.magenta(StdStyle.inverse(true)));
     }
 
-    function testStyleCustom() public pure {
+    function test_StyleCustom() public pure {
         console2.log(h1("Custom Style 1"));
         console2.log(h2("Custom Style 2"));
     }

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -30,7 +30,7 @@ contract StdUtilsTest is Test {
                                      BOUND UINT
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testBound() public {
+    function test_Bound() public {
         assertEq(bound(uint256(5), 0, 4), 0);
         assertEq(bound(uint256(0), 69, 69), 69);
         assertEq(bound(uint256(0), 68, 69), 68);
@@ -39,14 +39,14 @@ contract StdUtilsTest is Test {
         assertEq(bound(uint256(9999), 1337, 6666), 4669);
     }
 
-    function testBound_WithinRange() public {
+    function test_Bound_WithinRange() public {
         assertEq(bound(uint256(51), 50, 150), 51);
         assertEq(bound(uint256(51), 50, 150), bound(bound(uint256(51), 50, 150), 50, 150));
         assertEq(bound(uint256(149), 50, 150), 149);
         assertEq(bound(uint256(149), 50, 150), bound(bound(uint256(149), 50, 150), 50, 150));
     }
 
-    function testBound_EdgeCoverage() public {
+    function test_Bound_EdgeCoverage() public {
         assertEq(bound(uint256(0), 50, 150), 50);
         assertEq(bound(uint256(1), 50, 150), 51);
         assertEq(bound(uint256(2), 50, 150), 52);
@@ -57,7 +57,7 @@ contract StdUtilsTest is Test {
         assertEq(bound(type(uint256).max - 3, 50, 150), 147);
     }
 
-    function testBound_DistributionIsEven(uint256 min, uint256 size) public {
+    function test_Bound_DistributionIsEven(uint256 min, uint256 size) public {
         size = size % 100 + 1;
         min = bound(min, UINT256_MAX / 2, UINT256_MAX / 2 + size);
         uint256 max = min + size - 1;
@@ -73,7 +73,7 @@ contract StdUtilsTest is Test {
         }
     }
 
-    function testBound(uint256 num, uint256 min, uint256 max) public {
+    function test_Bound(uint256 num, uint256 min, uint256 max) public {
         if (min > max) (min, max) = (max, min);
 
         uint256 result = bound(num, min, max);
@@ -84,12 +84,12 @@ contract StdUtilsTest is Test {
         if (num >= min && num <= max) assertEq(result, num);
     }
 
-    function testBoundUint256Max() public {
+    function test_BoundUint256Max() public {
         assertEq(bound(0, type(uint256).max - 1, type(uint256).max), type(uint256).max - 1);
         assertEq(bound(1, type(uint256).max - 1, type(uint256).max), type(uint256).max);
     }
 
-    function testCannotBoundMaxLessThanMin() public {
+    function test_CannotBoundMaxLessThanMin() public {
         // We deploy a mock version so we can properly test the revert.
         StdUtilsMock stdUtils = new StdUtilsMock();
 
@@ -97,7 +97,7 @@ contract StdUtilsTest is Test {
         stdUtils.exposed_bound(uint256(5), 100, 10);
     }
 
-    function testCannotBoundMaxLessThanMin(uint256 num, uint256 min, uint256 max) public {
+    function test_CannotBoundMaxLessThanMin(uint256 num, uint256 min, uint256 max) public {
         // We deploy a mock version so we can properly test the revert.
         StdUtilsMock stdUtils = new StdUtilsMock();
 
@@ -110,7 +110,7 @@ contract StdUtilsTest is Test {
                                      BOUND INT
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testBoundInt() public {
+    function test_BoundInt() public {
         assertEq(bound(-3, 0, 4), 2);
         assertEq(bound(0, -69, -69), -69);
         assertEq(bound(0, -69, -68), -68);
@@ -119,14 +119,14 @@ contract StdUtilsTest is Test {
         assertEq(bound(9999, -1337, 6666), 1995);
     }
 
-    function testBoundInt_WithinRange() public {
+    function test_BoundInt_WithinRange() public {
         assertEq(bound(51, -50, 150), 51);
         assertEq(bound(51, -50, 150), bound(bound(51, -50, 150), -50, 150));
         assertEq(bound(149, -50, 150), 149);
         assertEq(bound(149, -50, 150), bound(bound(149, -50, 150), -50, 150));
     }
 
-    function testBoundInt_EdgeCoverage() public {
+    function test_BoundInt_EdgeCoverage() public {
         assertEq(bound(type(int256).min, -50, 150), -50);
         assertEq(bound(type(int256).min + 1, -50, 150), -49);
         assertEq(bound(type(int256).min + 2, -50, 150), -48);
@@ -146,7 +146,7 @@ contract StdUtilsTest is Test {
         assertEq(bound(type(int256).max - 3, -50, -10), -13);
     }
 
-    function testBoundInt_DistributionIsEven(int256 min, uint256 size) public {
+    function test_BoundInt_DistributionIsEven(int256 min, uint256 size) public {
         size = size % 100 + 1;
         min = bound(min, -int256(size / 2), int256(size - size / 2));
         int256 max = min + int256(size) - 1;
@@ -162,7 +162,7 @@ contract StdUtilsTest is Test {
         }
     }
 
-    function testBoundInt(int256 num, int256 min, int256 max) public {
+    function test_BoundInt(int256 num, int256 min, int256 max) public {
         if (min > max) (min, max) = (max, min);
 
         int256 result = bound(num, min, max);
@@ -173,17 +173,17 @@ contract StdUtilsTest is Test {
         if (num >= min && num <= max) assertEq(result, num);
     }
 
-    function testBoundIntInt256Max() public {
+    function test_BoundIntInt256Max() public {
         assertEq(bound(0, type(int256).max - 1, type(int256).max), type(int256).max - 1);
         assertEq(bound(1, type(int256).max - 1, type(int256).max), type(int256).max);
     }
 
-    function testBoundIntInt256Min() public {
+    function test_BoundIntInt256Min() public {
         assertEq(bound(0, type(int256).min, type(int256).min + 1), type(int256).min);
         assertEq(bound(1, type(int256).min, type(int256).min + 1), type(int256).min + 1);
     }
 
-    function testCannotBoundIntMaxLessThanMin() public {
+    function test_CannotBoundIntMaxLessThanMin() public {
         // We deploy a mock version so we can properly test the revert.
         StdUtilsMock stdUtils = new StdUtilsMock();
 
@@ -191,7 +191,7 @@ contract StdUtilsTest is Test {
         stdUtils.exposed_bound(-5, 100, 10);
     }
 
-    function testCannotBoundIntMaxLessThanMin(int256 num, int256 min, int256 max) public {
+    function test_CannotBoundIntMaxLessThanMin(int256 num, int256 min, int256 max) public {
         // We deploy a mock version so we can properly test the revert.
         StdUtilsMock stdUtils = new StdUtilsMock();
 
@@ -204,7 +204,7 @@ contract StdUtilsTest is Test {
                                 BOUND PRIVATE KEY
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testBoundPrivateKey() public {
+    function test_BoundPrivateKey() public {
         assertEq(boundPrivateKey(0), 1);
         assertEq(boundPrivateKey(1), 1);
         assertEq(boundPrivateKey(300), 300);
@@ -219,7 +219,7 @@ contract StdUtilsTest is Test {
                                    BYTES TO UINT
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testBytesToUint() external {
+    function test_BytesToUint() external {
         bytes memory maxUint = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
         bytes memory two = hex"02";
         bytes memory millionEther = hex"d3c21bcecceda1000000";
@@ -229,7 +229,7 @@ contract StdUtilsTest is Test {
         assertEq(bytesToUint(millionEther), 1_000_000 ether);
     }
 
-    function testCannotConvertGT32Bytes() external {
+    function test_CannotConvertGT32Bytes() external {
         // We deploy a mock version so we can properly test the revert.
         StdUtilsMock stdUtils = new StdUtilsMock();
 
@@ -242,7 +242,7 @@ contract StdUtilsTest is Test {
                                COMPUTE CREATE ADDRESS
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testComputeCreateAddress() external {
+    function test_ComputeCreateAddress() external {
         address deployer = 0x6C9FC64A53c1b71FB3f9Af64d1ae3A4931A5f4E9;
         uint256 nonce = 14;
         address createAddress = computeCreateAddress(deployer, nonce);
@@ -253,7 +253,7 @@ contract StdUtilsTest is Test {
                               COMPUTE CREATE2 ADDRESS
     //////////////////////////////////////////////////////////////////////////*/
 
-    function testComputeCreate2Address() external {
+    function test_ComputeCreate2Address() external {
         bytes32 salt = bytes32(uint256(31415));
         bytes32 initcodeHash = keccak256(abi.encode(0x6080));
         address deployer = 0x6C9FC64A53c1b71FB3f9Af64d1ae3A4931A5f4E9;
@@ -261,7 +261,7 @@ contract StdUtilsTest is Test {
         assertEq(create2Address, 0xB147a5d25748fda14b463EB04B111027C290f4d3);
     }
 
-    function testComputeCreate2AddressWithDefaultDeployer() external {
+    function test_ComputeCreate2AddressWithDefaultDeployer() external {
         bytes32 salt = 0xc290c670fde54e5ef686f9132cbc8711e76a98f0333a438a92daa442c71403c0;
         bytes32 initcodeHash = hashInitCode(hex"6080", "");
         assertEq(initcodeHash, 0x1a578b7a4b0b5755db6d121b4118d4bc68fe170dca840c59bc922f14175a76b0);
@@ -289,7 +289,7 @@ contract StdUtilsForkTest is Test {
         vm.createSelectFork({urlOrAlias: "mainnet", blockNumber: 16_428_900});
     }
 
-    function testCannotGetTokenBalances_NonTokenContract() external {
+    function test_CannotGetTokenBalances_NonTokenContract() external {
         // We deploy a mock version so we can properly test the revert.
         StdUtilsMock stdUtils = new StdUtilsMock();
 
@@ -303,7 +303,7 @@ contract StdUtilsForkTest is Test {
         stdUtils.exposed_getTokenBalances(token, addresses);
     }
 
-    function testCannotGetTokenBalances_EOA() external {
+    function test_CannotGetTokenBalances_EOA() external {
         // We deploy a mock version so we can properly test the revert.
         StdUtilsMock stdUtils = new StdUtilsMock();
 
@@ -314,13 +314,13 @@ contract StdUtilsForkTest is Test {
         stdUtils.exposed_getTokenBalances(eoa, addresses);
     }
 
-    function testGetTokenBalances_Empty() external {
+    function test_GetTokenBalances_Empty() external {
         address[] memory addresses = new address[](0);
         uint256[] memory balances = getTokenBalances(USDC, addresses);
         assertEq(balances.length, 0);
     }
 
-    function testGetTokenBalances_USDC() external {
+    function test_GetTokenBalances_USDC() external {
         address[] memory addresses = new address[](2);
         addresses[0] = USDC_HOLDER_0;
         addresses[1] = USDC_HOLDER_1;
@@ -329,7 +329,7 @@ contract StdUtilsForkTest is Test {
         assertEq(balances[1], 131_350_000_000_000);
     }
 
-    function testGetTokenBalances_SHIB() external {
+    function test_GetTokenBalances_SHIB() external {
         address[] memory addresses = new address[](3);
         addresses[0] = SHIB_HOLDER_0;
         addresses[1] = SHIB_HOLDER_1;


### PR DESCRIPTION
This PR puts the `forge-std` test naming conventions in line with the [style guide](https://book.getfoundry.sh/tutorials/best-practices#tests)

Some liberties have been taken with respect to the names in `StdAssertions.t.sol` but open to any feedback.

I did not add any test names with the `Revert[If|When]` modifier since none of the tests appear to pass or fail conditionally. Correct me if this is erroneous. 

Closes #273 