### PR TITLE
chore(`StdCheats`): deprecate changePrank

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.6.2 <0.9.0;
 pragma experimental ABIEncoderV2;
 
 import {StdStorage, stdStorage} from "./StdStorage.sol";
+import {console2} from "./console2.sol";
 import {Vm} from "./Vm.sol";
 
 abstract contract StdCheatsSafe {
@@ -692,6 +693,7 @@ abstract contract StdCheats is StdCheatsSafe {
     }
 
     function changePrank(address msgSender) internal virtual {
+        console2.log("changePrank is deprecated. Please use vm.startPrank instead.");
         vm.stopPrank();
         vm.startPrank(msgSender);
     }

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -638,6 +638,7 @@ abstract contract StdCheats is StdCheatsSafe {
 
     StdStorage private stdstore;
     Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+    address private constant CONSOLE2_ADDRESS = 0x000000000000000000636F6e736F6c652e6c6f67;
 
     // Skip forward or rewind time by the specified number of seconds
     function skip(uint256 time) internal virtual {
@@ -693,7 +694,7 @@ abstract contract StdCheats is StdCheatsSafe {
     }
 
     function changePrank(address msgSender) internal virtual {
-        console2.log("changePrank is deprecated. Please use vm.startPrank instead.");
+        console2_log("changePrank is deprecated. Please use vm.startPrank instead.");
         vm.stopPrank();
         vm.startPrank(msgSender);
     }
@@ -803,5 +804,11 @@ abstract contract StdCheats is StdCheatsSafe {
         (bool success, bytes memory runtimeBytecode) = where.call{value: value}("");
         require(success, "StdCheats deployCodeTo(string,bytes,uint256,address): Failed to create runtime bytecode.");
         vm.etch(where, runtimeBytecode);
+    }
+
+    // Used to prevent the compilation of console, which shortens the compilation time when console is not used elsewhere.
+    function console2_log(string memory p0) private view {
+        (bool status,) = address(CONSOLE2_ADDRESS).staticcall(abi.encodeWithSignature("log(string)", p0));
+        status;
     }
 }


### PR DESCRIPTION
Leftover work from https://github.com/foundry-rs/foundry/pull/4826#issuecomment-1543962477 — deprecates `changePrank` before we delete it completely.