### PR TITLE
feat: base goerli and base chaindata setup to stdchains default rpcs

### DIFF
--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -222,7 +222,7 @@ abstract contract StdChains {
         );
         setChainWithDefaultRpcUrl("moonbase", ChainData("Moonbase", 1287, "https://rpc.testnet.moonbeam.network"));
         setChainWithDefaultRpcUrl("base_goerli", ChainData("Base Goerli", 84531, "https://goerli.base.org"));
-        setChainWithDefaultRpcUrl("base",ChainData("Base", 8453, "https://mainnet.base.org"));
+        setChainWithDefaultRpcUrl("base", ChainData("Base", 8453, "https://mainnet.base.org"));
     }
 
     // set chain info, with priority to chainAlias' rpc url in foundry.toml

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -221,6 +221,8 @@ abstract contract StdChains {
             "moonriver", ChainData("Moonriver", 1285, "https://rpc.api.moonriver.moonbeam.network")
         );
         setChainWithDefaultRpcUrl("moonbase", ChainData("Moonbase", 1287, "https://rpc.testnet.moonbeam.network"));
+        setChainWithDefaultRpcUrl("base_goerli", ChainData("Base Goerli", 84531, "https://goerli.base.org"));
+        setChainWithDefaultRpcUrl("base",ChainData("Base", 8453, "https://mainnet.base.org"));
     }
 
     // set chain info, with priority to chainAlias' rpc url in foundry.toml

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -65,6 +65,8 @@ contract StdChainsTest is Test {
     //     testRpc("bnb_smart_chain");
     //     testRpc("bnb_smart_chain_testnet");
     //     testRpc("gnosis_chain");
+    //     testRpc("base_goerli");
+    //     testRpc("base");
     // }
 
     function test_ChainNoDefault() public {

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -65,6 +65,8 @@ contract StdChainsTest is Test {
     //     testRpc("bnb_smart_chain");
     //     testRpc("bnb_smart_chain_testnet");
     //     testRpc("gnosis_chain");
+    //     testRpc("moonbeam");
+    //     testRpc("moonriver");
     //     testRpc("base_goerli");
     //     testRpc("base");
     // }

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -67,6 +67,7 @@ contract StdChainsTest is Test {
     //     testRpc("gnosis_chain");
     //     testRpc("moonbeam");
     //     testRpc("moonriver");
+    //     testRpc("moonbase");
     //     testRpc("base_goerli");
     //     testRpc("base");
     // }


### PR DESCRIPTION
Updates StdChains to have base and base goerli as default rpcs during initialization