### PR TITLE
Add .sleep(uint) to VmSafe interface

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -539,4 +539,6 @@ interface Vm is VmSafe {
     function transact(bytes32 txHash) external;
     // Fetches the given transaction from the given fork and executes it on the current state
     function transact(uint256 forkId, bytes32 txHash) external;
+    // Suspends execution of the main thread for `duration` milliseconds
+    function sleep(uint256 duration) external;
 }


### PR DESCRIPTION
Fixes #436 

Added `.sleep(uint)` to `VmSafe` following the addition of the feature in Foundry:
https://github.com/foundry-rs/foundry/pull/5519 

I manually tested that it works by using `vm.sleep` in a test (`StdUtilsTest`) and measured the running time:
![image](https://github.com/foundry-rs/forge-std/assets/506487/bd96a8e4-b505-46b6-b628-26ab112de0f9)
![image](https://github.com/foundry-rs/forge-std/assets/506487/f88e8573-fe71-4215-a118-29053a127a3d)
(notice the "finished in 10.00s" part)

Let me know if there's anything more needed here :slightly_smiling_face: 