### PR TITLE
fix(stdStorage): wrong slot id may returned by `find()` when slot value == 1337

### DIFF
--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -71,9 +71,9 @@ library stdStorageSafe {
                 if (prev != fdat) {
                     continue;
                 }
-                bytes32 newVal = ~prev;
+                bytes32 new_val = ~prev;
                 // store
-                vm.store(who, reads[i], newVal);
+                vm.store(who, reads[i], new_val);
                 bool success;
                 {
                     bytes memory rdat;
@@ -81,7 +81,7 @@ library stdStorageSafe {
                     fdat = bytesToBytes32(rdat, 32 * field_depth);
                 }
 
-                if (success && fdat == newVal) {
+                if (success && fdat == new_val) {
                     // we found which of the slots is the actual one
                     emit SlotFound(who, fsig, keccak256(abi.encodePacked(ins, field_depth)), uint256(reads[i]));
                     self.slots[who][fsig][keccak256(abi.encodePacked(ins, field_depth))] = uint256(reads[i]);

--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -68,16 +68,21 @@ library stdStorageSafe {
                 if (prev == bytes32(0)) {
                     emit WARNING_UninitedSlot(who, uint256(reads[i]));
                 }
+                if (prev != fdat) {
+                    continue;
+                }
+                bytes32 newVal = bytes32(~uint256(prev));
                 // store
-                vm.store(who, reads[i], bytes32(hex"1337"));
+                vm.store(who, reads[i], newVal);
                 bool success;
-                bytes memory rdat;
+                bytes32 dat;
                 {
+                    bytes memory rdat;
                     (success, rdat) = who.staticcall(cald);
-                    fdat = bytesToBytes32(rdat, 32 * field_depth);
+                    dat = bytesToBytes32(rdat, 32 * field_depth);
                 }
 
-                if (success && fdat == bytes32(hex"1337")) {
+                if (success && dat == newVal) {
                     // we found which of the slots is the actual one
                     emit SlotFound(who, fsig, keccak256(abi.encodePacked(ins, field_depth)), uint256(reads[i]));
                     self.slots[who][fsig][keccak256(abi.encodePacked(ins, field_depth))] = uint256(reads[i]);

--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -71,18 +71,17 @@ library stdStorageSafe {
                 if (prev != fdat) {
                     continue;
                 }
-                bytes32 newVal = bytes32(~uint256(prev));
+                bytes32 newVal = ~prev;
                 // store
                 vm.store(who, reads[i], newVal);
                 bool success;
-                bytes32 dat;
                 {
                     bytes memory rdat;
                     (success, rdat) = who.staticcall(cald);
-                    dat = bytesToBytes32(rdat, 32 * field_depth);
+                    fdat = bytesToBytes32(rdat, 32 * field_depth);
                 }
 
-                if (success && dat == newVal) {
+                if (success && fdat == newVal) {
                     // we found which of the slots is the actual one
                     emit SlotFound(who, fsig, keccak256(abi.encodePacked(ins, field_depth)), uint256(reads[i]));
                     self.slots[who][fsig][keccak256(abi.encodePacked(ins, field_depth))] = uint256(reads[i]);

--- a/test/StdStorage.t.sol
+++ b/test/StdStorage.t.sol
@@ -21,6 +21,10 @@ contract StdStorageTest is Test {
         assertEq(uint256(0), stdstore.target(address(test)).sig("exists()").find());
     }
 
+    function test_StorageExtraSload() public {
+        assertEq(16, stdstore.target(address(test)).sig(test.extra_sload.selector).find());
+    }
+
     function test_StorageCheckedWriteHidden() public {
         stdstore.target(address(test)).sig(test.hidden.selector).checked_write(100);
         assertEq(uint256(test.hidden()), 100);
@@ -262,6 +266,7 @@ contract StorageTest {
     address public tF = address(1337);
     int256 public tG = type(int256).min;
     bool public tH = true;
+    bytes32 private tI = bytes32(~uint256(bytes32(hex"1337")));
 
     constructor() {
         basic = UnpackedStruct({a: 1337, b: 1337});
@@ -289,5 +294,13 @@ contract StorageTest {
 
     function const() public pure returns (bytes32 t) {
         t = bytes32(hex"1337");
+    }
+
+    function extra_sload() public view returns (bytes32 t) {
+        // trigger read on slot `tE`, and make a staticcall to make sure compiler doesn't optimize this SLOAD away
+        assembly {
+            pop(staticcall(gas(), sload(tE.slot), 0, 0, 0, 0))
+        }
+        t = tI;
     }
 }

--- a/test/StdStorage.t.sol
+++ b/test/StdStorage.t.sol
@@ -266,7 +266,7 @@ contract StorageTest {
     address public tF = address(1337);
     int256 public tG = type(int256).min;
     bool public tH = true;
-    bytes32 private tI = bytes32(~uint256(bytes32(hex"1337")));
+    bytes32 private tI = ~bytes32(hex"1337");
 
     constructor() {
         basic = UnpackedStruct({a: 1337, b: 1337});


### PR DESCRIPTION
When finding the target slot ID of a function signature, `find()` would do a staticcall and iterate over all the possible slots, then set the slot to a hardcoded value `hex"1337"` to test if the slot is desired.

But if there are multiple slot reads in the function call and the desired slot value is set to `hex"1337"` coincidentally, a wrong slot id may be returned.

Minimal reproduce contract:

```solidity
import "forge-std/Test.sol";
import "forge-std/StdStorage.sol";

contract StorageTest {
    bytes32 public a = hex"abcd";
    bytes32 public b = hex"1337";

    function extraSload() public view returns (bytes32) {
        // trigger read on slot `a`, and make a staticcall to make sure compiler doesn't optimize this SLOAD away
        assembly {
            pop(staticcall(gas(), sload(a.slot), 0, 0, 0, 0))
        }
        return b;
    }

    function noExtraSload() public view returns (bytes32) {
        return b;
    }
}

contract StdStorageTest is Test {
    using stdStorage for StdStorage;

    function test_ExtraSload() public {
        StorageTest test = new StorageTest();
        // this will fail!
        assertEq(1, stdstore.target(address(test)).sig(test.extraSload.selector).find());
    }

    function test_NoExtraSload() public {
        StorageTest test = new StorageTest();
        assertEq(1, stdstore.target(address(test)).sig(test.noExtraSload.selector).find());
    }
}
```

Test result:
```bash
❯ forge test -vv --mp test/StdStorageTest.sol
[⠆] Compiling...
No files changed, compilation skipped

Running 2 tests for test/StdStorageTest.sol:StdStorageTest
[FAIL. Reason: Assertion failed.] test_ExtraSload() (gas: 201767)
Logs:
  Error: a == b not satisfied [uint]
        Left: 1
       Right: 0

[PASS] test_NoExtraSload() (gas: 192642)
Test result: FAILED. 1 passed; 1 failed; 0 skipped; finished in 3.54ms
Ran 1 test suites: 1 tests passed, 1 failed, 0 skipped (2 total tests)

Failing tests:
Encountered 1 failing test in test/StdStorageTest.sol:StdStorageTest
[FAIL. Reason: Assertion failed.] test_ExtraSload() (gas: 201767)

Encountered a total of 1 failing tests, 1 tests succeeded
```

The `test_ExtraSload()` failed to return the correct slot ID in test.

This patch fixes the issue by replacing the hardcoded new value with bitwise not, prevent from conflicting with the target slot value.