### PR TITLE
chore: make json parse cheatcodes pure

### DIFF
--- a/src/StdJson.sol
+++ b/src/StdJson.sol
@@ -33,59 +33,59 @@ library stdJson {
         return vm.parseJson(json, key);
     }
 
-    function readUint(string memory json, string memory key) internal returns (uint256) {
+    function readUint(string memory json, string memory key) internal pure returns (uint256) {
         return vm.parseJsonUint(json, key);
     }
 
-    function readUintArray(string memory json, string memory key) internal returns (uint256[] memory) {
+    function readUintArray(string memory json, string memory key) internal pure returns (uint256[] memory) {
         return vm.parseJsonUintArray(json, key);
     }
 
-    function readInt(string memory json, string memory key) internal returns (int256) {
+    function readInt(string memory json, string memory key) internal pure returns (int256) {
         return vm.parseJsonInt(json, key);
     }
 
-    function readIntArray(string memory json, string memory key) internal returns (int256[] memory) {
+    function readIntArray(string memory json, string memory key) internal pure returns (int256[] memory) {
         return vm.parseJsonIntArray(json, key);
     }
 
-    function readBytes32(string memory json, string memory key) internal returns (bytes32) {
+    function readBytes32(string memory json, string memory key) internal pure returns (bytes32) {
         return vm.parseJsonBytes32(json, key);
     }
 
-    function readBytes32Array(string memory json, string memory key) internal returns (bytes32[] memory) {
+    function readBytes32Array(string memory json, string memory key) internal pure returns (bytes32[] memory) {
         return vm.parseJsonBytes32Array(json, key);
     }
 
-    function readString(string memory json, string memory key) internal returns (string memory) {
+    function readString(string memory json, string memory key) internal pure returns (string memory) {
         return vm.parseJsonString(json, key);
     }
 
-    function readStringArray(string memory json, string memory key) internal returns (string[] memory) {
+    function readStringArray(string memory json, string memory key) internal pure returns (string[] memory) {
         return vm.parseJsonStringArray(json, key);
     }
 
-    function readAddress(string memory json, string memory key) internal returns (address) {
+    function readAddress(string memory json, string memory key) internal pure returns (address) {
         return vm.parseJsonAddress(json, key);
     }
 
-    function readAddressArray(string memory json, string memory key) internal returns (address[] memory) {
+    function readAddressArray(string memory json, string memory key) internal pure returns (address[] memory) {
         return vm.parseJsonAddressArray(json, key);
     }
 
-    function readBool(string memory json, string memory key) internal returns (bool) {
+    function readBool(string memory json, string memory key) internal pure returns (bool) {
         return vm.parseJsonBool(json, key);
     }
 
-    function readBoolArray(string memory json, string memory key) internal returns (bool[] memory) {
+    function readBoolArray(string memory json, string memory key) internal pure returns (bool[] memory) {
         return vm.parseJsonBoolArray(json, key);
     }
 
-    function readBytes(string memory json, string memory key) internal returns (bytes memory) {
+    function readBytes(string memory json, string memory key) internal pure returns (bytes memory) {
         return vm.parseJsonBytes(json, key);
     }
 
-    function readBytesArray(string memory json, string memory key) internal returns (bytes[] memory) {
+    function readBytesArray(string memory json, string memory key) internal pure returns (bytes[] memory) {
         return vm.parseJsonBytesArray(json, key);
     }
 

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -280,20 +280,26 @@ interface VmSafe {
     // and hex numbers '0xEF'.
     // Type coercion works ONLY for discrete values or arrays. That means that the key must return a value or array, not
     // a JSON object.
-    function parseJsonUint(string calldata json, string calldata key) external returns (uint256);
-    function parseJsonUintArray(string calldata json, string calldata key) external returns (uint256[] memory);
-    function parseJsonInt(string calldata json, string calldata key) external returns (int256);
-    function parseJsonIntArray(string calldata json, string calldata key) external returns (int256[] memory);
-    function parseJsonBool(string calldata json, string calldata key) external returns (bool);
-    function parseJsonBoolArray(string calldata json, string calldata key) external returns (bool[] memory);
-    function parseJsonAddress(string calldata json, string calldata key) external returns (address);
-    function parseJsonAddressArray(string calldata json, string calldata key) external returns (address[] memory);
-    function parseJsonString(string calldata json, string calldata key) external returns (string memory);
-    function parseJsonStringArray(string calldata json, string calldata key) external returns (string[] memory);
-    function parseJsonBytes(string calldata json, string calldata key) external returns (bytes memory);
-    function parseJsonBytesArray(string calldata json, string calldata key) external returns (bytes[] memory);
-    function parseJsonBytes32(string calldata json, string calldata key) external returns (bytes32);
-    function parseJsonBytes32Array(string calldata json, string calldata key) external returns (bytes32[] memory);
+    function parseJsonUint(string calldata json, string calldata key) external pure returns (uint256);
+    function parseJsonUintArray(string calldata json, string calldata key) external pure returns (uint256[] memory);
+    function parseJsonInt(string calldata json, string calldata key) external pure returns (int256);
+    function parseJsonIntArray(string calldata json, string calldata key) external pure returns (int256[] memory);
+    function parseJsonBool(string calldata json, string calldata key) external pure returns (bool);
+    function parseJsonBoolArray(string calldata json, string calldata key) external pure returns (bool[] memory);
+    function parseJsonAddress(string calldata json, string calldata key) external pure returns (address);
+    function parseJsonAddressArray(string calldata json, string calldata key)
+        external
+        pure
+        returns (address[] memory);
+    function parseJsonString(string calldata json, string calldata key) external pure returns (string memory);
+    function parseJsonStringArray(string calldata json, string calldata key) external pure returns (string[] memory);
+    function parseJsonBytes(string calldata json, string calldata key) external pure returns (bytes memory);
+    function parseJsonBytesArray(string calldata json, string calldata key) external pure returns (bytes[] memory);
+    function parseJsonBytes32(string calldata json, string calldata key) external pure returns (bytes32);
+    function parseJsonBytes32Array(string calldata json, string calldata key)
+        external
+        pure
+        returns (bytes32[] memory);
 
     // Checks if a key exists in a JSON or TOML object.
     function keyExists(string calldata json, string calldata key) external view returns (bool);


### PR DESCRIPTION
Hi folks, I believe the json parsing cheatcodes classify as pure as they are not affected by other calls and don't read the state. Please let me know if I'm missing anything.