### PR TITLE
feat: add new serializeJson cheatcode to the Vm and to StdJson

### DIFF
--- a/src/StdJson.sol
+++ b/src/StdJson.sol
@@ -89,6 +89,10 @@ library stdJson {
         return vm.parseJsonBytesArray(json, key);
     }
 
+    function serialize(string memory jsonKey, string memory rootObject) internal returns (string memory) {
+        return vm.serializeJson(jsonKey, rootObject);
+    }
+
     function serialize(string memory jsonKey, string memory key, bool value) internal returns (string memory) {
         return vm.serializeBool(jsonKey, key, value);
     }

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -309,6 +309,7 @@ interface VmSafe {
 
     // Serialize a key and value to a JSON object stored in-memory that can be later written to a file
     // It returns the stringified version of the specific JSON file up to that moment.
+    function serializeJson(string calldata objectKey, string calldata value) external returns (string memory json);
     function serializeBool(string calldata objectKey, string calldata valueKey, bool value)
         external
         returns (string memory json);


### PR DESCRIPTION
Adds the new serializeJson cheatcode to the Vm and updates StdJson. Foundry's PR: https://github.com/foundry-rs/foundry/pull/5755

I didn't add tests because it just calls the vm and there are no tests for StdJson. Let me know if I should add some.