### PR TITLE
chore: camelCase for exitCode

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -55,7 +55,7 @@ interface VmSafe {
     }
 
     struct FfiResult {
-        int32 exit_code;
+        int32 exitCode;
         bytes stdout;
         bytes stderr;
     }


### PR DESCRIPTION
Pardon my OCD but I am getting a Solhint warning in my copy of `Vm` (in PRBTest) because of `exit_code`:

> warning  Variable name must be in mixedCase  var-name-mixedcase

