### PR TITLE
Add vm.unixTime to VmSafe interface

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -414,7 +414,7 @@ interface VmSafe {
     // Suspends execution of the main thread for `duration` milliseconds
     function sleep(uint256 duration) external;
     // Returns the time since unix epoch in milliseconds
-    function unixTime() external returns (uint milliseconds);
+    function unixTime() external returns (uint256 milliseconds);
 }
 
 interface Vm is VmSafe {

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -165,6 +165,9 @@ interface VmSafe {
     // Get the path of the current project root.
     function projectRoot() external view returns (string memory path);
 
+    // Returns the time since unix epoch in milliseconds
+    function unixTime() external returns (uint256 milliseconds);
+
     // -------- Reading and writing --------
 
     // Closes file for reading, resetting the offset and allowing to read it from beginning with readLine.
@@ -238,18 +241,13 @@ interface VmSafe {
     // `path` is relative to the project root.
     function writeLine(string calldata path, string calldata data) external;
 
-    // -------- Running executables --------
+    // -------- Foreign Function Interface --------
 
     // Performs a foreign function call via the terminal
     function ffi(string[] calldata commandInput) external returns (bytes memory result);
 
     // Performs a foreign function call via terminal and returns the exit code, stdout, and stderr
     function tryFfi(string[] calldata commandInput) external returns (FfiResult memory result);
-
-    // -------- System information --------
-
-    // Returns the time since unix epoch in milliseconds
-    function unixTime() external returns (uint256 milliseconds);
 
     // ======== Environment Variables ========
 

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -413,6 +413,8 @@ interface VmSafe {
     function breakpoint(string calldata char, bool value) external;
     // Suspends execution of the main thread for `duration` milliseconds
     function sleep(uint256 duration) external;
+    // Returns the time since unix epoch in milliseconds
+    function unixTime() external returns (uint milliseconds);
 }
 
 interface Vm is VmSafe {


### PR DESCRIPTION
Following https://github.com/foundry-rs/foundry/pull/5952.
Adding `vm.unixTime()` cheatcode to `VmSafe` interface.
I tested this change manually on my machine.