### PR TITLE
fix: rely less on foundry internals

### DIFF
--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -160,9 +160,17 @@ abstract contract StdChains {
                     chain.rpcUrl = vm.envString(envName);
                 }
                 // distinguish 'not found' from 'cannot read'
-                bytes memory notFoundError =
+                bytes memory oldNotFoundError =
                     abi.encodeWithSignature("CheatCodeError", string(abi.encodePacked("invalid rpc url ", chainAlias)));
-                if (keccak256(notFoundError) != keccak256(err) || bytes(chain.rpcUrl).length == 0) {
+                // TODO: use `abi.encodeWithSelector(Vm.CheatcodeError)` on next Vm update
+                bytes memory newNotFoundError = abi.encodeWithSignature(
+                    "CheatcodeError(string)", string(abi.encodePacked("invalid rpc url: ", chainAlias))
+                );
+                bytes32 errHash = keccak256(err);
+                if (
+                    (errHash != keccak256(oldNotFoundError) && errHash != keccak256(newNotFoundError))
+                        || bytes(chain.rpcUrl).length == 0
+                ) {
                     /// @solidity memory-safe-assembly
                     assembly {
                         revert(add(32, err), mload(err))

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -159,10 +159,10 @@ abstract contract StdChains {
                 } else {
                     chain.rpcUrl = vm.envString(envName);
                 }
-                // distinguish 'not found' from 'cannot read'
+                // Distinguish 'not found' from 'cannot read'
+                // The upstream error thrown by forge for failing cheats changed so we check both the old and new versions
                 bytes memory oldNotFoundError =
                     abi.encodeWithSignature("CheatCodeError", string(abi.encodePacked("invalid rpc url ", chainAlias)));
-                // TODO: use `abi.encodeWithSelector(Vm.CheatcodeError)` on next Vm update
                 bytes memory newNotFoundError = abi.encodeWithSignature(
                     "CheatcodeError(string)", string(abi.encodePacked("invalid rpc url: ", chainAlias))
                 );

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -208,13 +208,9 @@ contract StdChainsTest is Test {
 
         // Should error if default RPCs flag is set to false.
         stdChainsMock.exposed_setFallbackToDefaultRpcUrls(false);
-        vm.expectRevert(
-            "Failed to get environment variable `ANVIL_RPC_URL` as type `string`: environment variable not found"
-        );
+        vm.expectRevert();
         stdChainsMock.exposed_getChain(31337);
-        vm.expectRevert(
-            "Failed to get environment variable `SEPOLIA_RPC_URL` as type `string`: environment variable not found"
-        );
+        vm.expectRevert();
         stdChainsMock.exposed_getChain("sepolia");
     }
 }


### PR DESCRIPTION
Rely less on internal Foundry error messages for our own testing.
Unfortunately it looks like we still rely on the "RPC URL not found" error message to when defaulting to environment variables in `StdChains.getChainWithUpdatedRpcUrl`.

Unblocks https://github.com/foundry-rs/foundry/pull/6131

cc @mattsse @mds1 