### PR TITLE
vm: add `loadAllocs(string)` cheatcode

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -552,6 +552,9 @@ interface Vm is VmSafe {
     // Stores a value to an address' storage slot.
     function store(address target, bytes32 slot, bytes32 value) external;
 
+    // Load a genesis JSON file's `allocs` into the in-memory state.
+    function loadAllocs(string calldata pathToAllocsJson) external;
+
     // -------- Call Manipulation --------
     // --- Mocks ---
 

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -540,6 +540,9 @@ interface Vm is VmSafe {
     // Sets an address' code
     function etch(address target, bytes calldata newRuntimeBytecode) external;
 
+    // Load a genesis JSON file's `allocs` into the in-memory state.
+    function loadAllocs(string calldata pathToAllocsJson) external;
+
     // Resets the nonce of an account to 0 for EOAs and 1 for contract accounts
     function resetNonce(address account) external;
 
@@ -551,9 +554,6 @@ interface Vm is VmSafe {
 
     // Stores a value to an address' storage slot.
     function store(address target, bytes32 slot, bytes32 value) external;
-
-    // Load a genesis JSON file's `allocs` into the in-memory state.
-    function loadAllocs(string calldata pathToAllocsJson) external;
 
     // -------- Call Manipulation --------
     // --- Mocks ---

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -10,6 +10,6 @@ contract VmTest is Test {
     // added to or removed from Vm or VmSafe.
     function test_interfaceId() public {
         assertEq(type(VmSafe).interfaceId, bytes4(0x329f5e71), "VmSafe");
-        assertEq(type(Vm).interfaceId, bytes4(0x82ccbb14), "Vm");
+        assertEq(type(Vm).interfaceId, bytes4(0x316cedc3), "Vm");
     }
 }


### PR DESCRIPTION
Adds the `loadAllocs(string)` cheatcode to be usable as part of the
`Vm` interface. This was added to foundry in https://github.com/foundry-rs/foundry/pull/6207.
The cheatcode can be used to read a JSON file from disk that sets EVM
state directly.
