### PR TITLE
feat(`vm`): add rpc and eth_getLogs cheats

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -135,6 +135,16 @@ interface VmSafe {
     // Resumes gas metering (i.e. gas usage is counted again). Noop if already on.
     function resumeGasMetering() external;
 
+    // -------- RPC Methods --------
+
+    /// Gets all the logs according to specified filter.
+    function eth_getLogs(uint256 fromBlock, uint256 toBlock, address target, bytes32[] calldata topics)
+        external
+        returns (EthGetLogs[] memory logs);
+
+    // Performs an Ethereum JSON-RPC request to the current fork URL.
+    function rpc(string calldata method, string calldata params) external returns (bytes memory data);
+
     // ======== Test Configuration ========
 
     // If the condition is false, discard this run's fuzz inputs and generate new ones.
@@ -145,14 +155,6 @@ interface VmSafe {
 
     // Writes a conditional breakpoint to jump to in the debugger
     function breakpoint(string calldata char, bool value) external;
-
-    /// Gets all the logs according to specified filter.
-    function eth_getLogs(uint256 fromBlock, uint256 toBlock, address target, bytes32[] calldata topics)
-        external
-        returns (EthGetLogs[] memory logs);
-
-    // Performs an Ethereum JSON-RPC request to the current fork URL.
-    function rpc(string calldata method, string calldata params) external returns (bytes memory data);
 
     // Returns the RPC url for the given alias
     function rpcUrl(string calldata rpcAlias) external view returns (string memory json);

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -33,6 +33,18 @@ interface VmSafe {
         string url;
     }
 
+    struct EthGetLogs {
+        address emitter;
+        bytes32[] topics;
+        bytes data;
+        bytes32 blockHash;
+        uint64 blockNumber;
+        bytes32 transactionHash;
+        uint64 transactionIndex;
+        uint256 logIndex;
+        bool removed;
+    }
+
     struct DirEntry {
         string errorMessage;
         string path;
@@ -133,6 +145,12 @@ interface VmSafe {
 
     // Writes a conditional breakpoint to jump to in the debugger
     function breakpoint(string calldata char, bool value) external;
+
+    /// Gets all the logs according to specified filter.
+    function eth_getLogs(uint256 fromBlock, uint256 toBlock, address addr, bytes32[] memory topics) external returns (EthGetLogs[] memory logs);
+
+    // Performs an Ethereum JSON-RPC request to the current fork URL.
+    function rpc(string calldata method, string calldata params) external returns (bytes memory data);
 
     // Returns the RPC url for the given alias
     function rpcUrl(string calldata rpcAlias) external view returns (string memory json);

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -147,7 +147,9 @@ interface VmSafe {
     function breakpoint(string calldata char, bool value) external;
 
     /// Gets all the logs according to specified filter.
-    function eth_getLogs(uint256 fromBlock, uint256 toBlock, address addr, bytes32[] memory topics) external returns (EthGetLogs[] memory logs);
+    function eth_getLogs(uint256 fromBlock, uint256 toBlock, address addr, bytes32[] calldata topics)
+        external
+        returns (EthGetLogs[] memory logs);
 
     // Performs an Ethereum JSON-RPC request to the current fork URL.
     function rpc(string calldata method, string calldata params) external returns (bytes memory data);

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -147,7 +147,7 @@ interface VmSafe {
     function breakpoint(string calldata char, bool value) external;
 
     /// Gets all the logs according to specified filter.
-    function eth_getLogs(uint256 fromBlock, uint256 toBlock, address addr, bytes32[] calldata topics)
+    function eth_getLogs(uint256 fromBlock, uint256 toBlock, address target, bytes32[] calldata topics)
         external
         returns (EthGetLogs[] memory logs);
 

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,7 +9,7 @@ contract VmTest is Test {
     // inadvertently moved between Vm and VmSafe. This test must be updated each time a function is
     // added to or removed from Vm or VmSafe.
     function test_interfaceId() public {
-        assertEq(type(VmSafe).interfaceId, bytes4(0x329f5e71), "VmSafe");
+        assertEq(type(VmSafe).interfaceId, bytes4(0x1578a242), "VmSafe");
         assertEq(type(Vm).interfaceId, bytes4(0x316cedc3), "Vm");
     }
 }


### PR DESCRIPTION
These were the last missing cheats added in the past month to Foundry.