### PR TITLE
ci: foundry multibuild workflow

### DIFF
--- a/.github/workflows/multibuild.yml
+++ b/.github/workflows/multibuild.yml
@@ -1,0 +1,20 @@
+name: "Multibuild"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * 0" # at 3:00am UTC every Sunday
+
+jobs:
+  multibuild:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Check out the repo"
+        uses: "actions/checkout@v3"
+
+      - name: "Check that forge-std can be built with multiple Solidity versions"
+        uses: "PaulRBerg/foundry-multibuild@v1"
+        with:
+          min: "0.6.2"
+          max: "0.8.23"
+          skip-test: "true"


### PR DESCRIPTION
This PR adds a CI workflow that runs once weekly to use my [Foundry Multibuild](https://github.com/marketplace/actions/foundry-multibuild) action for checking that Forge Std remains compatible with all compiler versions allowed by the pragma (from v0.6.2 up to v0.8.23).

Notes:

- Some files like`console.sol` use `>=0.4.22`, but Foundry Multibuild does not work with a pragma so low because the other files wouldn't compile.
- Tests are excluded because they are not meant to be used by consumers of Forge Std (and they wouldn't work anyway for the same reason as above)
- For more details on Foundry Multibuild, see my [announcement](https://twitter.com/PaulRBerg/status/1741761895390982386) on Twitter, and the [GitHub repo](https://github.com/PaulRBerg/foundry-multibuild).