### PR TITLE
Mark envOr functions as view

### DIFF
--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -148,7 +148,7 @@ abstract contract StdChains {
 
     // lookup rpcUrl, in descending order of priority:
     // current -> config (foundry.toml) -> environment variable -> default
-    function getChainWithUpdatedRpcUrl(string memory chainAlias, Chain memory chain) private returns (Chain memory) {
+    function getChainWithUpdatedRpcUrl(string memory chainAlias, Chain memory chain) private view returns (Chain memory) {
         if (bytes(chain.rpcUrl).length == 0) {
             try vm.rpcUrl(chainAlias) returns (string memory configRpcUrl) {
                 chain.rpcUrl = configRpcUrl;

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -250,85 +250,85 @@ interface VmSafe {
     /// Gets the environment variable `name` and parses it as `bool`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
-    function envOr(string calldata name, bool defaultValue) external returns (bool value);
+    function envOr(string calldata name, bool defaultValue) external view returns (bool value);
 
     /// Gets the environment variable `name` and parses it as `uint256`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
-    function envOr(string calldata name, uint256 defaultValue) external returns (uint256 value);
+    function envOr(string calldata name, uint256 defaultValue) external view returns (uint256 value);
 
     /// Gets the environment variable `name` and parses it as an array of `address`, delimited by `delim`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
     function envOr(string calldata name, string calldata delim, address[] calldata defaultValue)
-        external
+        external view
         returns (address[] memory value);
 
     /// Gets the environment variable `name` and parses it as an array of `bytes32`, delimited by `delim`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
     function envOr(string calldata name, string calldata delim, bytes32[] calldata defaultValue)
-        external
+        external view
         returns (bytes32[] memory value);
 
     /// Gets the environment variable `name` and parses it as an array of `string`, delimited by `delim`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
     function envOr(string calldata name, string calldata delim, string[] calldata defaultValue)
-        external
+        external view
         returns (string[] memory value);
 
     /// Gets the environment variable `name` and parses it as an array of `bytes`, delimited by `delim`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
     function envOr(string calldata name, string calldata delim, bytes[] calldata defaultValue)
-        external
+        external view
         returns (bytes[] memory value);
 
     /// Gets the environment variable `name` and parses it as `int256`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
-    function envOr(string calldata name, int256 defaultValue) external returns (int256 value);
+    function envOr(string calldata name, int256 defaultValue) external view returns (int256 value);
 
     /// Gets the environment variable `name` and parses it as `address`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
-    function envOr(string calldata name, address defaultValue) external returns (address value);
+    function envOr(string calldata name, address defaultValue) external view returns (address value);
 
     /// Gets the environment variable `name` and parses it as `bytes32`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
-    function envOr(string calldata name, bytes32 defaultValue) external returns (bytes32 value);
+    function envOr(string calldata name, bytes32 defaultValue) external view returns (bytes32 value);
 
     /// Gets the environment variable `name` and parses it as `string`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
-    function envOr(string calldata name, string calldata defaultValue) external returns (string memory value);
+    function envOr(string calldata name, string calldata defaultValue) external view returns (string memory value);
 
     /// Gets the environment variable `name` and parses it as `bytes`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
-    function envOr(string calldata name, bytes calldata defaultValue) external returns (bytes memory value);
+    function envOr(string calldata name, bytes calldata defaultValue) external view returns (bytes memory value);
 
     /// Gets the environment variable `name` and parses it as an array of `bool`, delimited by `delim`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
     function envOr(string calldata name, string calldata delim, bool[] calldata defaultValue)
-        external
+        external view
         returns (bool[] memory value);
 
     /// Gets the environment variable `name` and parses it as an array of `uint256`, delimited by `delim`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
     function envOr(string calldata name, string calldata delim, uint256[] calldata defaultValue)
-        external
+        external view
         returns (uint256[] memory value);
 
     /// Gets the environment variable `name` and parses it as an array of `int256`, delimited by `delim`.
     /// Reverts if the variable could not be parsed.
     /// Returns `defaultValue` if the variable was not found.
     function envOr(string calldata name, string calldata delim, int256[] calldata defaultValue)
-        external
+        external view
         returns (int256[] memory value);
 
     /// Gets the environment variable `name` and parses it as `string`.

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -12,11 +12,11 @@ contract StdUtilsMock is StdUtils {
         return getTokenBalances(token, addresses);
     }
 
-    function exposed_bound(int256 num, int256 min, int256 max) external view returns (int256) {
+    function exposed_bound(int256 num, int256 min, int256 max) external pure returns (int256) {
         return bound(num, min, max);
     }
 
-    function exposed_bound(uint256 num, uint256 min, uint256 max) external view returns (uint256) {
+    function exposed_bound(uint256 num, uint256 min, uint256 max) external pure returns (uint256) {
         return bound(num, min, max);
     }
 


### PR DESCRIPTION
I tried using `vm.envOr` in a view function and noticed it wasn't marked as `view`. Checked with foundry devs and looks like this was just an oversight.

Fix a couple compile warnings that came up as a result