### PR TITLE
fix: handle USDT blacklisting address(0) and address(1) edge case

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -206,7 +206,10 @@ abstract contract StdCheatsSafe {
     }
 
     // Checks that `addr` is not blacklisted by token contracts that have a blacklist.
-    function assumeNotBlacklisted(address token, address addr) internal view virtual {
+    function assumeNotBlacklisted(address token, address addr) internal virtual {
+        // `USDT` blacklists `address(0)` and `address(1)` for unknown reasons.
+        assumeAddressIsNot(addr, AddressType.ZeroAddress, AddressType.Precompile, AddressType.ForgeAddress);
+
         // Nothing to check if `token` is not a contract.
         uint256 tokenCodeSize;
         assembly {
@@ -230,7 +233,7 @@ abstract contract StdCheatsSafe {
     // This is identical to `assumeNotBlacklisted(address,address)` but with a different name, for
     // backwards compatibility, since this name was used in the original PR which has already has
     // a release. This function can be removed in a future release once we want a breaking change.
-    function assumeNoBlacklisted(address token, address addr) internal view virtual {
+    function assumeNoBlacklisted(address token, address addr) internal virtual {
         assumeNotBlacklisted(token, addr);
     }
 

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -208,7 +208,7 @@ abstract contract StdCheatsSafe {
     // Checks that `addr` is not blacklisted by token contracts that have a blacklist.
     function assumeNotBlacklisted(address token, address addr) internal virtual {
         // `USDT` blacklists `address(0)` and `address(1)` for unknown reasons.
-        assumeAddressIsNot(addr, AddressType.ZeroAddress, AddressType.Precompile, AddressType.ForgeAddress);
+        assumeAddressIsNot(addr, AddressType.ZeroAddress, AddressType.Precompile);
 
         // Nothing to check if `token` is not a contract.
         uint256 tokenCodeSize;

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -454,7 +454,7 @@ contract StdCheatsMock is StdCheats {
     }
 
     // We deploy a mock version so we can properly test expected reverts.
-    function exposed_assumeNotBlacklisted(address token, address addr) external view {
+    function exposed_assumeNotBlacklisted(address token, address addr) external {
         return assumeNotBlacklisted(token, addr);
     }
 }
@@ -476,7 +476,7 @@ contract StdCheatsForkTest is Test {
         StdCheatsMock stdCheatsMock = new StdCheatsMock();
         address eoa = vm.addr({privateKey: 1});
         vm.expectRevert("StdCheats assumeNotBlacklisted(address,address): Token address is not a contract.");
-        stdCheatsMock.exposed_assumeNotBlacklisted(eoa, address(0));
+        stdCheatsMock.exposed_assumeNotBlacklisted(eoa, eoa);
     }
 
     function testFuzz_AssumeNotBlacklisted_TokenWithoutBlacklist(address addr) external {


### PR DESCRIPTION
After a [failing test](https://github.com/foundry-rs/foundry/actions/runs/7547585011/job/20547871860#step:12:883) in Foundry I noticed USDT has blacklisted [address(0)](https://phalcon.blocksec.com/explorer/tx/eth/0x26e2265c66d7de39bdf0570a74118bbeec782ea11b10b9b075f3ef3866d70722) and [address(1)](https://phalcon.blocksec.com/explorer/tx/eth/0xd8ea4a26e5354f8660df8dd24bc46b7f260865cbc5f9e5069665934a0265d6d8) (unclear why), causing fuzz tests with edge bias to revert.

To reduce the likelihood of failing tests I suggest skipping `address(0)` and the precompiles.