### PR TITLE
vm: add dumpState cheatcode

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -906,6 +906,9 @@ interface Vm is VmSafe {
     /// Reverts if used on unsupported EVM versions.
     function difficulty(uint256 newDifficulty) external;
 
+    /// Dump a genesis JSON file's `allocs` to disk.
+    function dumpState(string calldata pathToStateJson) external;
+
     /// Sets an address' code.
     function etch(address target, bytes calldata newRuntimeBytecode) external;
 

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -205,14 +205,6 @@ interface VmSafe {
         bool reverted;
     }
 
-    // ======== Base64 ========
-
-    /// Encodes a `bytes` value to base64 string
-    function toBase64(bytes calldata data) external pure returns (string memory);
-
-    /// Encodes a `bytes` value to base64url string
-    function toBase64URL(bytes calldata data) external pure returns (string memory);
-
     // ======== Environment ========
 
     /// Gets the environment variable `name` and parses it as `address`.
@@ -847,6 +839,18 @@ interface VmSafe {
 
     /// Signs data with a `Wallet`.
     function sign(Wallet calldata wallet, bytes32 digest) external returns (uint8 v, bytes32 r, bytes32 s);
+
+    /// Encodes a `bytes` value to a base64url string.
+    function toBase64URL(bytes calldata data) external pure returns (string memory);
+
+    /// Encodes a `string` value to a base64url string.
+    function toBase64URL(string calldata data) external pure returns (string memory);
+
+    /// Encodes a `bytes` value to a base64 string.
+    function toBase64(bytes calldata data) external pure returns (string memory);
+
+    /// Encodes a `string` value to a base64 string.
+    function toBase64(string calldata data) external pure returns (string memory);
 }
 
 /// The `Vm` interface does allow manipulation of the EVM state. These are all intended to be used

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,7 +9,7 @@ contract VmTest is Test {
     // inadvertently moved between Vm and VmSafe. This test must be updated each time a function is
     // added to or removed from Vm or VmSafe.
     function test_interfaceId() public {
-        assertEq(type(VmSafe).interfaceId, bytes4(0x90569756), "VmSafe");
-        assertEq(type(Vm).interfaceId, bytes4(0xd6a02054), "Vm");
+        assertEq(type(VmSafe).interfaceId, bytes4(0x01ec102d), "VmSafe");
+        assertEq(type(Vm).interfaceId, bytes4(0xa63eed6b), "Vm");
     }
 }


### PR DESCRIPTION
Adds a new cheatcode `dumpState(string)` that was implemented in foundry in https://github.com/foundry-rs/foundry/pull/6827. This cheatcode will write a JSON file to disk that contains the current state of the EVM.