### PR TITLE
Exclude internal cheats from Vm

### DIFF
--- a/scripts/vm.py
+++ b/scripts/vm.py
@@ -30,7 +30,7 @@ def main():
     contract = Cheatcodes.from_json(json_str)
 
     ccs = contract.cheatcodes
-    ccs = list(filter(lambda cc: cc.status != "experimental", ccs))
+    ccs = list(filter(lambda cc: cc.status not in ["experimental", "internal"], ccs))
     ccs.sort(key=lambda cc: cc.func.id)
 
     safe = list(filter(lambda cc: cc.safety == "safe", ccs))


### PR DESCRIPTION
https://github.com/foundry-rs/foundry/pull/6841 introduced `internal` cheatcodes type for cheats only used internally for foundry testing. Such cheatcodes shouldn't end up in forge-std. 

This PR updates `vm.py` script to exclude them along with `experimental` cheats