### PR TITLE
[WIP] Use native assertions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "lib/ds-test"]
-	path = lib/ds-test
-	url = https://github.com/dapphub/ds-test

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ contract Bar {
 
 ### Std Assertions
 
-Expand upon the assertion functions from the `DSTest` library.
+Contains various assertions.
 
 ### `console.log`
 

--- a/src/StdAssertions.sol
+++ b/src/StdAssertions.sol
@@ -1,326 +1,531 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.6.2 <0.9.0;
 
-import {DSTest} from "ds-test/test.sol";
 import {stdMath} from "./StdMath.sol";
+import {Vm} from "./Vm.sol";
+import {console2} from "./console2.sol";
 
-abstract contract StdAssertions is DSTest {
-    event log_array(uint256[] val);
-    event log_array(int256[] val);
-    event log_array(address[] val);
-    event log_named_array(string key, uint256[] val);
-    event log_named_array(string key, int256[] val);
-    event log_named_array(string key, address[] val);
+abstract contract StdAssertions {
+    Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    function fail(string memory err) internal virtual {
-        emit log_named_string("Error", err);
-        fail();
+    event log(string);
+    event log_named_bytes(string key, bytes val);
+
+    function assertTrue(bool data) internal virtual {
+        vm.assertTrue(data);
+    }
+
+    function assertTrue(bool data, string memory err) internal virtual {
+        vm.assertTrue(data, err);
     }
 
     function assertFalse(bool data) internal virtual {
-        assertTrue(!data);
+        vm.assertFalse(data);
     }
 
     function assertFalse(bool data, string memory err) internal virtual {
-        assertTrue(!data, err);
+        vm.assertFalse(data, err);
     }
 
-    function assertEq(bool a, bool b) internal virtual {
-        if (a != b) {
-            emit log("Error: a == b not satisfied [bool]");
-            emit log_named_string("      Left", a ? "true" : "false");
-            emit log_named_string("     Right", b ? "true" : "false");
-            fail();
-        }
+    function assertEq(bool left, bool right) internal virtual {
+        vm.assertEq(left, right);
     }
 
-    function assertEq(bool a, bool b, string memory err) internal virtual {
-        if (a != b) {
-            emit log_named_string("Error", err);
-            assertEq(a, b);
-        }
+    function assertEq(bool left, bool right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
     }
 
-    function assertEq(bytes memory a, bytes memory b) internal virtual {
-        assertEq0(a, b);
+    function assertEq(uint256 left, uint256 right) internal virtual {
+        vm.assertEq(left, right);
     }
 
-    function assertEq(bytes memory a, bytes memory b, string memory err) internal virtual {
-        assertEq0(a, b, err);
+    function assertEq(uint256 left, uint256 right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
     }
 
-    function assertEq(uint256[] memory a, uint256[] memory b) internal virtual {
-        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
-            emit log("Error: a == b not satisfied [uint[]]");
-            emit log_named_array("      Left", a);
-            emit log_named_array("     Right", b);
-            fail();
-        }
+    function assertEqDecimal(uint256 left, uint256 right, uint256 decimals) internal virtual {
+        vm.assertEqDecimal(left, right, decimals);
     }
 
-    function assertEq(int256[] memory a, int256[] memory b) internal virtual {
-        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
-            emit log("Error: a == b not satisfied [int[]]");
-            emit log_named_array("      Left", a);
-            emit log_named_array("     Right", b);
-            fail();
-        }
+    function assertEqDecimal(uint256 left, uint256 right, uint256 decimals, string memory err) internal virtual {
+        vm.assertEqDecimal(left, right, decimals, err);
     }
 
-    function assertEq(address[] memory a, address[] memory b) internal virtual {
-        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
-            emit log("Error: a == b not satisfied [address[]]");
-            emit log_named_array("      Left", a);
-            emit log_named_array("     Right", b);
-            fail();
-        }
+    function assertEq(int256 left, int256 right) internal virtual {
+        vm.assertEq(left, right);
     }
 
-    function assertEq(uint256[] memory a, uint256[] memory b, string memory err) internal virtual {
-        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
-            emit log_named_string("Error", err);
-            assertEq(a, b);
-        }
+    function assertEq(int256 left, int256 right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
     }
 
-    function assertEq(int256[] memory a, int256[] memory b, string memory err) internal virtual {
-        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
-            emit log_named_string("Error", err);
-            assertEq(a, b);
-        }
+    function assertEqDecimal(int256 left, int256 right, uint256 decimals) internal virtual {
+        vm.assertEqDecimal(left, right, decimals);
     }
 
-    function assertEq(address[] memory a, address[] memory b, string memory err) internal virtual {
-        if (keccak256(abi.encode(a)) != keccak256(abi.encode(b))) {
-            emit log_named_string("Error", err);
-            assertEq(a, b);
-        }
+    function assertEqDecimal(int256 left, int256 right, uint256 decimals, string memory err) internal virtual {
+        vm.assertEqDecimal(left, right, decimals, err);
+    }
+
+    function assertEq(address left, address right) internal virtual {
+        vm.assertEq(left, right);
+    }
+
+    function assertEq(address left, address right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
+    }
+
+    function assertEq(bytes32 left, bytes32 right) internal virtual {
+        vm.assertEq(left, right);
+    }
+
+    function assertEq(bytes32 left, bytes32 right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
+    }
+
+    function assertEq(string memory left, string memory right) internal virtual {
+        vm.assertEq(left, right);
+    }
+
+    function assertEq(string memory left, string memory right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
+    }
+
+    function assertEq(bytes memory left, bytes memory right) internal virtual {
+        vm.assertEq(left, right);
+    }
+
+    function assertEq(bytes memory left, bytes memory right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
+    }
+
+    function assertEq(bool[] memory left, bool[] memory right) internal virtual {
+        vm.assertEq(left, right);
+    }
+
+    function assertEq(bool[] memory left, bool[] memory right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
+    }
+
+    function assertEq(uint256[] memory left, uint256[] memory right) internal virtual {
+        vm.assertEq(left, right);
+    }
+
+    function assertEq(uint256[] memory left, uint256[] memory right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
+    }
+
+    function assertEq(int256[] memory left, int256[] memory right) internal virtual {
+        vm.assertEq(left, right);
+    }
+
+    function assertEq(int256[] memory left, int256[] memory right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
+    }
+
+    function assertEq(address[] memory left, address[] memory right) internal virtual {
+        vm.assertEq(left, right);
+    }
+
+    function assertEq(address[] memory left, address[] memory right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
+    }
+
+    function assertEq(bytes32[] memory left, bytes32[] memory right) internal virtual {
+        vm.assertEq(left, right);
+    }
+
+    function assertEq(bytes32[] memory left, bytes32[] memory right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
+    }
+
+    function assertEq(string[] memory left, string[] memory right) internal virtual {
+        vm.assertEq(left, right);
+    }
+
+    function assertEq(string[] memory left, string[] memory right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
+    }
+
+    function assertEq(bytes[] memory left, bytes[] memory right) internal virtual {
+        vm.assertEq(left, right);
+    }
+
+    function assertEq(bytes[] memory left, bytes[] memory right, string memory err) internal virtual {
+        vm.assertEq(left, right, err);
     }
 
     // Legacy helper
     function assertEqUint(uint256 a, uint256 b) internal virtual {
-        assertEq(uint256(a), uint256(b));
+        assertEq(a, b);
     }
 
-    function assertApproxEqAbs(uint256 a, uint256 b, uint256 maxDelta) internal virtual {
-        uint256 delta = stdMath.delta(a, b);
-
-        if (delta > maxDelta) {
-            emit log("Error: a ~= b not satisfied [uint]");
-            emit log_named_uint("      Left", a);
-            emit log_named_uint("     Right", b);
-            emit log_named_uint(" Max Delta", maxDelta);
-            emit log_named_uint("     Delta", delta);
-            fail();
-        }
+    function assertNotEq(bool left, bool right) internal virtual {
+        vm.assertNotEq(left, right);
     }
 
-    function assertApproxEqAbs(uint256 a, uint256 b, uint256 maxDelta, string memory err) internal virtual {
-        uint256 delta = stdMath.delta(a, b);
-
-        if (delta > maxDelta) {
-            emit log_named_string("Error", err);
-            assertApproxEqAbs(a, b, maxDelta);
-        }
+    function assertNotEq(bool left, bool right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
     }
 
-    function assertApproxEqAbsDecimal(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals) internal virtual {
-        uint256 delta = stdMath.delta(a, b);
-
-        if (delta > maxDelta) {
-            emit log("Error: a ~= b not satisfied [uint]");
-            emit log_named_decimal_uint("      Left", a, decimals);
-            emit log_named_decimal_uint("     Right", b, decimals);
-            emit log_named_decimal_uint(" Max Delta", maxDelta, decimals);
-            emit log_named_decimal_uint("     Delta", delta, decimals);
-            fail();
-        }
+    function assertNotEq(uint256 left, uint256 right) internal virtual {
+        vm.assertNotEq(left, right);
     }
 
-    function assertApproxEqAbsDecimal(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals, string memory err)
+    function assertNotEq(uint256 left, uint256 right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertNotEqDecimal(uint256 left, uint256 right, uint256 decimals) internal virtual {
+        vm.assertNotEqDecimal(left, right, decimals);
+    }
+
+    function assertNotEqDecimal(uint256 left, uint256 right, uint256 decimals, string memory err) internal virtual {
+        vm.assertNotEqDecimal(left, right, decimals, err);
+    }
+
+    function assertNotEq(int256 left, int256 right) internal virtual {
+        vm.assertNotEq(left, right);
+    }
+
+    function assertNotEq(int256 left, int256 right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertNotEqDecimal(int256 left, int256 right, uint256 decimals) internal virtual {
+        vm.assertNotEqDecimal(left, right, decimals);
+    }
+
+    function assertNotEqDecimal(int256 left, int256 right, uint256 decimals, string memory err) internal virtual {
+        vm.assertNotEqDecimal(left, right, decimals, err);
+    }
+
+    function assertNotEq(address left, address right) internal virtual {
+        vm.assertNotEq(left, right);
+    }
+
+    function assertNotEq(address left, address right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertNotEq(bytes32 left, bytes32 right) internal virtual {
+        vm.assertNotEq(left, right);
+    }
+
+    function assertNotEq(bytes32 left, bytes32 right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertNotEq(string memory left, string memory right) internal virtual {
+        vm.assertNotEq(left, right);
+    }
+
+    function assertNotEq(string memory left, string memory right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertNotEq(bytes memory left, bytes memory right) internal virtual {
+        vm.assertNotEq(left, right);
+    }
+
+    function assertNotEq(bytes memory left, bytes memory right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertNotEq(bool[] memory left, bool[] memory right) internal virtual {
+        vm.assertNotEq(left, right);
+    }
+
+    function assertNotEq(bool[] memory left, bool[] memory right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertNotEq(uint256[] memory left, uint256[] memory right) internal virtual {
+        vm.assertNotEq(left, right);
+    }
+
+    function assertNotEq(uint256[] memory left, uint256[] memory right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertNotEq(int256[] memory left, int256[] memory right) internal virtual {
+        vm.assertNotEq(left, right);
+    }
+
+    function assertNotEq(int256[] memory left, int256[] memory right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertNotEq(address[] memory left, address[] memory right) internal virtual {
+        vm.assertNotEq(left, right);
+    }
+
+    function assertNotEq(address[] memory left, address[] memory right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertNotEq(bytes32[] memory left, bytes32[] memory right) internal virtual {
+        vm.assertNotEq(left, right);
+    }
+
+    function assertNotEq(bytes32[] memory left, bytes32[] memory right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertNotEq(string[] memory left, string[] memory right) internal virtual {
+        vm.assertNotEq(left, right);
+    }
+
+    function assertNotEq(string[] memory left, string[] memory right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertNotEq(bytes[] memory left, bytes[] memory right) internal virtual {
+        vm.assertNotEq(left, right);
+    }
+
+    function assertNotEq(bytes[] memory left, bytes[] memory right, string memory err) internal virtual {
+        vm.assertNotEq(left, right, err);
+    }
+
+    function assertLt(uint256 left, uint256 right) internal virtual {
+        vm.assertLt(left, right);
+    }
+
+    function assertLt(uint256 left, uint256 right, string memory err) internal virtual {
+        vm.assertLt(left, right, err);
+    }
+
+    function assertLtDecimal(uint256 left, uint256 right, uint256 decimals) internal virtual {
+        vm.assertLtDecimal(left, right, decimals);
+    }
+
+    function assertLtDecimal(uint256 left, uint256 right, uint256 decimals, string memory err) internal virtual {
+        vm.assertLtDecimal(left, right, decimals, err);
+    }
+
+    function assertLt(int256 left, int256 right) internal virtual {
+        vm.assertLt(left, right);
+    }
+
+    function assertLt(int256 left, int256 right, string memory err) internal virtual {
+        vm.assertLt(left, right, err);
+    }
+
+    function assertLtDecimal(int256 left, int256 right, uint256 decimals) internal virtual {
+        vm.assertLtDecimal(left, right, decimals);
+    }
+
+    function assertLtDecimal(int256 left, int256 right, uint256 decimals, string memory err) internal virtual {
+        vm.assertLtDecimal(left, right, decimals, err);
+    }
+
+    function assertGt(uint256 left, uint256 right) internal virtual {
+        vm.assertGt(left, right);
+    }
+
+    function assertGt(uint256 left, uint256 right, string memory err) internal virtual {
+        vm.assertGt(left, right, err);
+    }
+
+    function assertGtDecimal(uint256 left, uint256 right, uint256 decimals) internal virtual {
+        vm.assertGtDecimal(left, right, decimals);
+    }
+
+    function assertGtDecimal(uint256 left, uint256 right, uint256 decimals, string memory err) internal virtual {
+        vm.assertGtDecimal(left, right, decimals, err);
+    }
+
+    function assertGt(int256 left, int256 right) internal virtual {
+        vm.assertGt(left, right);
+    }
+
+    function assertGt(int256 left, int256 right, string memory err) internal virtual {
+        vm.assertGt(left, right, err);
+    }
+
+    function assertGtDecimal(int256 left, int256 right, uint256 decimals) internal virtual {
+        vm.assertGtDecimal(left, right, decimals);
+    }
+
+    function assertGtDecimal(int256 left, int256 right, uint256 decimals, string memory err) internal virtual {
+        vm.assertGtDecimal(left, right, decimals, err);
+    }
+
+    function assertLe(uint256 left, uint256 right) internal virtual {
+        vm.assertLe(left, right);
+    }
+
+    function assertLe(uint256 left, uint256 right, string memory err) internal virtual {
+        vm.assertLe(left, right, err);
+    }
+
+    function assertLeDecimal(uint256 left, uint256 right, uint256 decimals) internal virtual {
+        vm.assertLeDecimal(left, right, decimals);
+    }
+
+    function assertLeDecimal(uint256 left, uint256 right, uint256 decimals, string memory err) internal virtual {
+        vm.assertLeDecimal(left, right, decimals, err);
+    }
+
+    function assertLe(int256 left, int256 right) internal virtual {
+        vm.assertLe(left, right);
+    }
+
+    function assertLe(int256 left, int256 right, string memory err) internal virtual {
+        vm.assertLe(left, right, err);
+    }
+
+    function assertLeDecimal(int256 left, int256 right, uint256 decimals) internal virtual {
+        vm.assertLeDecimal(left, right, decimals);
+    }
+
+    function assertLeDecimal(int256 left, int256 right, uint256 decimals, string memory err) internal virtual {
+        vm.assertLeDecimal(left, right, decimals, err);
+    }
+
+    function assertGe(uint256 left, uint256 right) internal virtual {
+        vm.assertGe(left, right);
+    }
+
+    function assertGe(uint256 left, uint256 right, string memory err) internal virtual {
+        vm.assertGe(left, right, err);
+    }
+
+    function assertGeDecimal(uint256 left, uint256 right, uint256 decimals) internal virtual {
+        vm.assertGeDecimal(left, right, decimals);
+    }
+
+    function assertGeDecimal(uint256 left, uint256 right, uint256 decimals, string memory err) internal virtual {
+        vm.assertGeDecimal(left, right, decimals, err);
+    }
+
+    function assertGe(int256 left, int256 right) internal virtual {
+        vm.assertGe(left, right);
+    }
+
+    function assertGe(int256 left, int256 right, string memory err) internal virtual {
+        vm.assertGe(left, right, err);
+    }
+
+    function assertGeDecimal(int256 left, int256 right, uint256 decimals) internal virtual {
+        vm.assertGeDecimal(left, right, decimals);
+    }
+
+    function assertGeDecimal(int256 left, int256 right, uint256 decimals, string memory err) internal virtual {
+        vm.assertGeDecimal(left, right, decimals, err);
+    }
+
+    function assertApproxEqAbs(uint256 left, uint256 right, uint256 maxDelta) internal virtual {
+        vm.assertApproxEqAbs(left, right, maxDelta);
+    }
+
+    function assertApproxEqAbs(uint256 left, uint256 right, uint256 maxDelta, string memory err) internal virtual {
+        vm.assertApproxEqAbs(left, right, maxDelta, err);
+    }
+
+    function assertApproxEqAbsDecimal(uint256 left, uint256 right, uint256 maxDelta, uint256 decimals)
         internal
         virtual
     {
-        uint256 delta = stdMath.delta(a, b);
-
-        if (delta > maxDelta) {
-            emit log_named_string("Error", err);
-            assertApproxEqAbsDecimal(a, b, maxDelta, decimals);
-        }
+        vm.assertApproxEqAbsDecimal(left, right, maxDelta, decimals);
     }
 
-    function assertApproxEqAbs(int256 a, int256 b, uint256 maxDelta) internal virtual {
-        uint256 delta = stdMath.delta(a, b);
-
-        if (delta > maxDelta) {
-            emit log("Error: a ~= b not satisfied [int]");
-            emit log_named_int("       Left", a);
-            emit log_named_int("      Right", b);
-            emit log_named_uint(" Max Delta", maxDelta);
-            emit log_named_uint("     Delta", delta);
-            fail();
-        }
+    function assertApproxEqAbsDecimal(
+        uint256 left,
+        uint256 right,
+        uint256 maxDelta,
+        uint256 decimals,
+        string memory err
+    ) internal virtual {
+        vm.assertApproxEqAbsDecimal(left, right, maxDelta, decimals, err);
     }
 
-    function assertApproxEqAbs(int256 a, int256 b, uint256 maxDelta, string memory err) internal virtual {
-        uint256 delta = stdMath.delta(a, b);
-
-        if (delta > maxDelta) {
-            emit log_named_string("Error", err);
-            assertApproxEqAbs(a, b, maxDelta);
-        }
+    function assertApproxEqAbs(int256 left, int256 right, uint256 maxDelta) internal virtual {
+        vm.assertApproxEqAbs(left, right, maxDelta);
     }
 
-    function assertApproxEqAbsDecimal(int256 a, int256 b, uint256 maxDelta, uint256 decimals) internal virtual {
-        uint256 delta = stdMath.delta(a, b);
-
-        if (delta > maxDelta) {
-            emit log("Error: a ~= b not satisfied [int]");
-            emit log_named_decimal_int("      Left", a, decimals);
-            emit log_named_decimal_int("     Right", b, decimals);
-            emit log_named_decimal_uint(" Max Delta", maxDelta, decimals);
-            emit log_named_decimal_uint("     Delta", delta, decimals);
-            fail();
-        }
+    function assertApproxEqAbs(int256 left, int256 right, uint256 maxDelta, string memory err) internal virtual {
+        vm.assertApproxEqAbs(left, right, maxDelta, err);
     }
 
-    function assertApproxEqAbsDecimal(int256 a, int256 b, uint256 maxDelta, uint256 decimals, string memory err)
+    function assertApproxEqAbsDecimal(int256 left, int256 right, uint256 maxDelta, uint256 decimals) internal virtual {
+        vm.assertApproxEqAbsDecimal(left, right, maxDelta, decimals);
+    }
+
+    function assertApproxEqAbsDecimal(int256 left, int256 right, uint256 maxDelta, uint256 decimals, string memory err)
         internal
         virtual
     {
-        uint256 delta = stdMath.delta(a, b);
-
-        if (delta > maxDelta) {
-            emit log_named_string("Error", err);
-            assertApproxEqAbsDecimal(a, b, maxDelta, decimals);
-        }
+        vm.assertApproxEqAbsDecimal(left, right, maxDelta, decimals, err);
     }
 
     function assertApproxEqRel(
-        uint256 a,
-        uint256 b,
+        uint256 left,
+        uint256 right,
         uint256 maxPercentDelta // An 18 decimal fixed point number, where 1e18 == 100%
     ) internal virtual {
-        if (b == 0) return assertEq(a, b); // If the left is 0, right must be too.
-
-        uint256 percentDelta = stdMath.percentDelta(a, b);
-
-        if (percentDelta > maxPercentDelta) {
-            emit log("Error: a ~= b not satisfied [uint]");
-            emit log_named_uint("        Left", a);
-            emit log_named_uint("       Right", b);
-            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta * 100, 18);
-            emit log_named_decimal_uint("     % Delta", percentDelta * 100, 18);
-            fail();
-        }
+        vm.assertApproxEqRel(left, right, maxPercentDelta);
     }
 
     function assertApproxEqRel(
-        uint256 a,
-        uint256 b,
+        uint256 left,
+        uint256 right,
         uint256 maxPercentDelta, // An 18 decimal fixed point number, where 1e18 == 100%
         string memory err
     ) internal virtual {
-        if (b == 0) return assertEq(a, b, err); // If the left is 0, right must be too.
-
-        uint256 percentDelta = stdMath.percentDelta(a, b);
-
-        if (percentDelta > maxPercentDelta) {
-            emit log_named_string("Error", err);
-            assertApproxEqRel(a, b, maxPercentDelta);
-        }
+        vm.assertApproxEqRel(left, right, maxPercentDelta, err);
     }
 
     function assertApproxEqRelDecimal(
-        uint256 a,
-        uint256 b,
+        uint256 left,
+        uint256 right,
         uint256 maxPercentDelta, // An 18 decimal fixed point number, where 1e18 == 100%
         uint256 decimals
     ) internal virtual {
-        if (b == 0) return assertEq(a, b); // If the left is 0, right must be too.
-
-        uint256 percentDelta = stdMath.percentDelta(a, b);
-
-        if (percentDelta > maxPercentDelta) {
-            emit log("Error: a ~= b not satisfied [uint]");
-            emit log_named_decimal_uint("        Left", a, decimals);
-            emit log_named_decimal_uint("       Right", b, decimals);
-            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta * 100, 18);
-            emit log_named_decimal_uint("     % Delta", percentDelta * 100, 18);
-            fail();
-        }
+        vm.assertApproxEqRelDecimal(left, right, maxPercentDelta, decimals);
     }
 
     function assertApproxEqRelDecimal(
-        uint256 a,
-        uint256 b,
+        uint256 left,
+        uint256 right,
         uint256 maxPercentDelta, // An 18 decimal fixed point number, where 1e18 == 100%
         uint256 decimals,
         string memory err
     ) internal virtual {
-        if (b == 0) return assertEq(a, b, err); // If the left is 0, right must be too.
-
-        uint256 percentDelta = stdMath.percentDelta(a, b);
-
-        if (percentDelta > maxPercentDelta) {
-            emit log_named_string("Error", err);
-            assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals);
-        }
+        vm.assertApproxEqRelDecimal(left, right, maxPercentDelta, decimals, err);
     }
 
-    function assertApproxEqRel(int256 a, int256 b, uint256 maxPercentDelta) internal virtual {
-        if (b == 0) return assertEq(a, b); // If the left is 0, right must be too.
-
-        uint256 percentDelta = stdMath.percentDelta(a, b);
-
-        if (percentDelta > maxPercentDelta) {
-            emit log("Error: a ~= b not satisfied [int]");
-            emit log_named_int("        Left", a);
-            emit log_named_int("       Right", b);
-            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta * 100, 18);
-            emit log_named_decimal_uint("     % Delta", percentDelta * 100, 18);
-            fail();
-        }
+    function assertApproxEqRel(int256 left, int256 right, uint256 maxPercentDelta) internal virtual {
+        vm.assertApproxEqRel(left, right, maxPercentDelta);
     }
 
-    function assertApproxEqRel(int256 a, int256 b, uint256 maxPercentDelta, string memory err) internal virtual {
-        if (b == 0) return assertEq(a, b, err); // If the left is 0, right must be too.
-
-        uint256 percentDelta = stdMath.percentDelta(a, b);
-
-        if (percentDelta > maxPercentDelta) {
-            emit log_named_string("Error", err);
-            assertApproxEqRel(a, b, maxPercentDelta);
-        }
+    function assertApproxEqRel(
+        int256 left,
+        int256 right,
+        uint256 maxPercentDelta, // An 18 decimal fixed point number, where 1e18 == 100%
+        string memory err
+    ) internal virtual {
+        vm.assertApproxEqRel(left, right, maxPercentDelta, err);
     }
 
-    function assertApproxEqRelDecimal(int256 a, int256 b, uint256 maxPercentDelta, uint256 decimals) internal virtual {
-        if (b == 0) return assertEq(a, b); // If the left is 0, right must be too.
-
-        uint256 percentDelta = stdMath.percentDelta(a, b);
-
-        if (percentDelta > maxPercentDelta) {
-            emit log("Error: a ~= b not satisfied [int]");
-            emit log_named_decimal_int("        Left", a, decimals);
-            emit log_named_decimal_int("       Right", b, decimals);
-            emit log_named_decimal_uint(" Max % Delta", maxPercentDelta * 100, 18);
-            emit log_named_decimal_uint("     % Delta", percentDelta * 100, 18);
-            fail();
-        }
+    function assertApproxEqRelDecimal(
+        int256 left,
+        int256 right,
+        uint256 maxPercentDelta, // An 18 decimal fixed point number, where 1e18 == 100%
+        uint256 decimals
+    ) internal virtual {
+        vm.assertApproxEqRelDecimal(left, right, maxPercentDelta, decimals);
     }
 
-    function assertApproxEqRelDecimal(int256 a, int256 b, uint256 maxPercentDelta, uint256 decimals, string memory err)
-        internal
-        virtual
-    {
-        if (b == 0) return assertEq(a, b, err); // If the left is 0, right must be too.
-
-        uint256 percentDelta = stdMath.percentDelta(a, b);
-
-        if (percentDelta > maxPercentDelta) {
-            emit log_named_string("Error", err);
-            assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals);
-        }
+    function assertApproxEqRelDecimal(
+        int256 left,
+        int256 right,
+        uint256 maxPercentDelta, // An 18 decimal fixed point number, where 1e18 == 100%
+        uint256 decimals,
+        string memory err
+    ) internal virtual {
+        vm.assertApproxEqRelDecimal(left, right, maxPercentDelta, decimals, err);
     }
 
     function assertEqCall(address target, bytes memory callDataA, bytes memory callDataB) internal virtual {
@@ -351,6 +556,8 @@ abstract contract StdAssertions is DSTest {
         (bool successA, bytes memory returnDataA) = address(targetA).call(callDataA);
         (bool successB, bytes memory returnDataB) = address(targetB).call(callDataB);
 
+        console2.log(successA, successB);
+
         if (successA && successB) {
             assertEq(returnDataA, returnDataB, "Call return data does not match");
         }
@@ -363,14 +570,14 @@ abstract contract StdAssertions is DSTest {
             emit log("Error: Calls were not equal");
             emit log_named_bytes("  Left call revert data", returnDataA);
             emit log_named_bytes(" Right call return data", returnDataB);
-            fail();
+            revert("assertion failed");
         }
 
         if (successA && !successB) {
             emit log("Error: Calls were not equal");
             emit log_named_bytes("  Left call return data", returnDataA);
             emit log_named_bytes(" Right call revert data", returnDataB);
-            fail();
+            revert("assertion failed");
         }
     }
 }

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -24,10 +24,6 @@ import {Vm} from "./Vm.sol";
 
 // 📦 BOILERPLATE
 import {TestBase} from "./Base.sol";
-import {DSTest} from "ds-test/test.sol";
 
 // ⭐️ TEST
-abstract contract Test is TestBase, DSTest, StdAssertions, StdChains, StdCheats, StdInvariant, StdUtils {
-// Note: IS_TEST() must return true.
-// Note: Must have failure system, https://github.com/dapphub/ds-test/blob/cd98eff28324bfac652e63a239a60632a761790b/src/test.sol#L39-L76.
-}
+abstract contract Test is TestBase, StdAssertions, StdChains, StdCheats, StdInvariant, StdUtils {}

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -736,6 +736,18 @@ interface VmSafe {
     /// Parses the given `string` into a `uint256`.
     function parseUint(string calldata stringifiedValue) external pure returns (uint256 parsedValue);
 
+    /// Replaces occurrences of `from` in the given `string` with `to`.
+    function replace(string calldata input, string calldata from, string calldata to)
+        external
+        pure
+        returns (string memory output);
+
+    /// Splits the given `string` into an array of strings divided by the `delimiter`.
+    function split(string calldata input, string calldata delimiter) external pure returns (string[] memory outputs);
+
+    /// Converts the given `string` value to Lowercase.
+    function toLowercase(string calldata input) external pure returns (string memory output);
+
     /// Converts the given value to a `string`.
     function toString(address value) external pure returns (string memory stringifiedValue);
 
@@ -754,7 +766,441 @@ interface VmSafe {
     /// Converts the given value to a `string`.
     function toString(int256 value) external pure returns (string memory stringifiedValue);
 
+    /// Converts the given `string` value to Uppercase.
+    function toUppercase(string calldata input) external pure returns (string memory output);
+
+    /// Trims leading and trailing whitespace from the given `string` value.
+    function trim(string calldata input) external pure returns (string memory output);
+
     // ======== Testing ========
+
+    /// Compares two `uint256` values. Expects difference to be less than or equal to `maxDelta`.
+    /// Formats values with decimals in failure message.
+    function assertApproxEqAbsDecimal(uint256 left, uint256 right, uint256 maxDelta, uint256 decimals) external pure;
+
+    /// Compares two `uint256` values. Expects difference to be less than or equal to `maxDelta`.
+    /// Formats values with decimals in failure message. Includes error message into revert string on failure.
+    function assertApproxEqAbsDecimal(
+        uint256 left,
+        uint256 right,
+        uint256 maxDelta,
+        uint256 decimals,
+        string calldata error
+    ) external pure;
+
+    /// Compares two `int256` values. Expects difference to be less than or equal to `maxDelta`.
+    /// Formats values with decimals in failure message.
+    function assertApproxEqAbsDecimal(int256 left, int256 right, uint256 maxDelta, uint256 decimals) external pure;
+
+    /// Compares two `int256` values. Expects difference to be less than or equal to `maxDelta`.
+    /// Formats values with decimals in failure message. Includes error message into revert string on failure.
+    function assertApproxEqAbsDecimal(
+        int256 left,
+        int256 right,
+        uint256 maxDelta,
+        uint256 decimals,
+        string calldata error
+    ) external pure;
+
+    /// Compares two `uint256` values. Expects difference to be less than or equal to `maxDelta`.
+    function assertApproxEqAbs(uint256 left, uint256 right, uint256 maxDelta) external pure;
+
+    /// Compares two `uint256` values. Expects difference to be less than or equal to `maxDelta`.
+    /// Includes error message into revert string on failure.
+    function assertApproxEqAbs(uint256 left, uint256 right, uint256 maxDelta, string calldata error) external pure;
+
+    /// Compares two `int256` values. Expects difference to be less than or equal to `maxDelta`.
+    function assertApproxEqAbs(int256 left, int256 right, uint256 maxDelta) external pure;
+
+    /// Compares two `int256` values. Expects difference to be less than or equal to `maxDelta`.
+    /// Includes error message into revert string on failure.
+    function assertApproxEqAbs(int256 left, int256 right, uint256 maxDelta, string calldata error) external pure;
+
+    /// Compares two `uint256` values. Expects relative difference in percents to be less than or equal to `maxPercentDelta`.
+    /// `maxPercentDelta` is an 18 decimal fixed point number, where 1e18 == 100%
+    /// Formats values with decimals in failure message.
+    function assertApproxEqRelDecimal(uint256 left, uint256 right, uint256 maxPercentDelta, uint256 decimals)
+        external
+        pure;
+
+    /// Compares two `uint256` values. Expects relative difference in percents to be less than or equal to `maxPercentDelta`.
+    /// `maxPercentDelta` is an 18 decimal fixed point number, where 1e18 == 100%
+    /// Formats values with decimals in failure message. Includes error message into revert string on failure.
+    function assertApproxEqRelDecimal(
+        uint256 left,
+        uint256 right,
+        uint256 maxPercentDelta,
+        uint256 decimals,
+        string calldata error
+    ) external pure;
+
+    /// Compares two `int256` values. Expects relative difference in percents to be less than or equal to `maxPercentDelta`.
+    /// `maxPercentDelta` is an 18 decimal fixed point number, where 1e18 == 100%
+    /// Formats values with decimals in failure message.
+    function assertApproxEqRelDecimal(int256 left, int256 right, uint256 maxPercentDelta, uint256 decimals)
+        external
+        pure;
+
+    /// Compares two `int256` values. Expects relative difference in percents to be less than or equal to `maxPercentDelta`.
+    /// `maxPercentDelta` is an 18 decimal fixed point number, where 1e18 == 100%
+    /// Formats values with decimals in failure message. Includes error message into revert string on failure.
+    function assertApproxEqRelDecimal(
+        int256 left,
+        int256 right,
+        uint256 maxPercentDelta,
+        uint256 decimals,
+        string calldata error
+    ) external pure;
+
+    /// Compares two `uint256` values. Expects relative difference in percents to be less than or equal to `maxPercentDelta`.
+    /// `maxPercentDelta` is an 18 decimal fixed point number, where 1e18 == 100%
+    function assertApproxEqRel(uint256 left, uint256 right, uint256 maxPercentDelta) external pure;
+
+    /// Compares two `uint256` values. Expects relative difference in percents to be less than or equal to `maxPercentDelta`.
+    /// `maxPercentDelta` is an 18 decimal fixed point number, where 1e18 == 100%
+    /// Includes error message into revert string on failure.
+    function assertApproxEqRel(uint256 left, uint256 right, uint256 maxPercentDelta, string calldata error)
+        external
+        pure;
+
+    /// Compares two `int256` values. Expects relative difference in percents to be less than or equal to `maxPercentDelta`.
+    /// `maxPercentDelta` is an 18 decimal fixed point number, where 1e18 == 100%
+    function assertApproxEqRel(int256 left, int256 right, uint256 maxPercentDelta) external pure;
+
+    /// Compares two `int256` values. Expects relative difference in percents to be less than or equal to `maxPercentDelta`.
+    /// `maxPercentDelta` is an 18 decimal fixed point number, where 1e18 == 100%
+    /// Includes error message into revert string on failure.
+    function assertApproxEqRel(int256 left, int256 right, uint256 maxPercentDelta, string calldata error)
+        external
+        pure;
+
+    /// Asserts that two `uint256` values are equal, formatting them with decimals in failure message.
+    function assertEqDecimal(uint256 left, uint256 right, uint256 decimals) external pure;
+
+    /// Asserts that two `uint256` values are equal, formatting them with decimals in failure message.
+    /// Includes error message into revert string on failure.
+    function assertEqDecimal(uint256 left, uint256 right, uint256 decimals, string calldata error) external pure;
+
+    /// Asserts that two `int256` values are equal, formatting them with decimals in failure message.
+    function assertEqDecimal(int256 left, int256 right, uint256 decimals) external pure;
+
+    /// Asserts that two `int256` values are equal, formatting them with decimals in failure message.
+    /// Includes error message into revert string on failure.
+    function assertEqDecimal(int256 left, int256 right, uint256 decimals, string calldata error) external pure;
+
+    /// Asserts that two `bool` values are equal.
+    function assertEq(bool left, bool right) external pure;
+
+    /// Asserts that two `bool` values are equal and includes error message into revert string on failure.
+    function assertEq(bool left, bool right, string calldata error) external pure;
+
+    /// Asserts that two `string` values are equal.
+    function assertEq(string calldata left, string calldata right) external pure;
+
+    /// Asserts that two `string` values are equal and includes error message into revert string on failure.
+    function assertEq(string calldata left, string calldata right, string calldata error) external pure;
+
+    /// Asserts that two `bytes` values are equal.
+    function assertEq(bytes calldata left, bytes calldata right) external pure;
+
+    /// Asserts that two `bytes` values are equal and includes error message into revert string on failure.
+    function assertEq(bytes calldata left, bytes calldata right, string calldata error) external pure;
+
+    /// Asserts that two arrays of `bool` values are equal.
+    function assertEq(bool[] calldata left, bool[] calldata right) external pure;
+
+    /// Asserts that two arrays of `bool` values are equal and includes error message into revert string on failure.
+    function assertEq(bool[] calldata left, bool[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two arrays of `uint256 values are equal.
+    function assertEq(uint256[] calldata left, uint256[] calldata right) external pure;
+
+    /// Asserts that two arrays of `uint256` values are equal and includes error message into revert string on failure.
+    function assertEq(uint256[] calldata left, uint256[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two arrays of `int256` values are equal.
+    function assertEq(int256[] calldata left, int256[] calldata right) external pure;
+
+    /// Asserts that two arrays of `int256` values are equal and includes error message into revert string on failure.
+    function assertEq(int256[] calldata left, int256[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two `uint256` values are equal.
+    function assertEq(uint256 left, uint256 right) external pure;
+
+    /// Asserts that two arrays of `address` values are equal.
+    function assertEq(address[] calldata left, address[] calldata right) external pure;
+
+    /// Asserts that two arrays of `address` values are equal and includes error message into revert string on failure.
+    function assertEq(address[] calldata left, address[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two arrays of `bytes32` values are equal.
+    function assertEq(bytes32[] calldata left, bytes32[] calldata right) external pure;
+
+    /// Asserts that two arrays of `bytes32` values are equal and includes error message into revert string on failure.
+    function assertEq(bytes32[] calldata left, bytes32[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two arrays of `string` values are equal.
+    function assertEq(string[] calldata left, string[] calldata right) external pure;
+
+    /// Asserts that two arrays of `string` values are equal and includes error message into revert string on failure.
+    function assertEq(string[] calldata left, string[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two arrays of `bytes` values are equal.
+    function assertEq(bytes[] calldata left, bytes[] calldata right) external pure;
+
+    /// Asserts that two arrays of `bytes` values are equal and includes error message into revert string on failure.
+    function assertEq(bytes[] calldata left, bytes[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two `uint256` values are equal and includes error message into revert string on failure.
+    function assertEq(uint256 left, uint256 right, string calldata error) external pure;
+
+    /// Asserts that two `int256` values are equal.
+    function assertEq(int256 left, int256 right) external pure;
+
+    /// Asserts that two `int256` values are equal and includes error message into revert string on failure.
+    function assertEq(int256 left, int256 right, string calldata error) external pure;
+
+    /// Asserts that two `address` values are equal.
+    function assertEq(address left, address right) external pure;
+
+    /// Asserts that two `address` values are equal and includes error message into revert string on failure.
+    function assertEq(address left, address right, string calldata error) external pure;
+
+    /// Asserts that two `bytes32` values are equal.
+    function assertEq(bytes32 left, bytes32 right) external pure;
+
+    /// Asserts that two `bytes32` values are equal and includes error message into revert string on failure.
+    function assertEq(bytes32 left, bytes32 right, string calldata error) external pure;
+
+    /// Asserts that the given condition is false.
+    function assertFalse(bool condition) external pure;
+
+    /// Asserts that the given condition is false and includes error message into revert string on failure.
+    function assertFalse(bool condition, string calldata error) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be greater than or equal to second.
+    /// Formats values with decimals in failure message.
+    function assertGeDecimal(uint256 left, uint256 right, uint256 decimals) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be greater than or equal to second.
+    /// Formats values with decimals in failure message. Includes error message into revert string on failure.
+    function assertGeDecimal(uint256 left, uint256 right, uint256 decimals, string calldata error) external pure;
+
+    /// Compares two `int256` values. Expects first value to be greater than or equal to second.
+    /// Formats values with decimals in failure message.
+    function assertGeDecimal(int256 left, int256 right, uint256 decimals) external pure;
+
+    /// Compares two `int256` values. Expects first value to be greater than or equal to second.
+    /// Formats values with decimals in failure message. Includes error message into revert string on failure.
+    function assertGeDecimal(int256 left, int256 right, uint256 decimals, string calldata error) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be greater than or equal to second.
+    function assertGe(uint256 left, uint256 right) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be greater than or equal to second.
+    /// Includes error message into revert string on failure.
+    function assertGe(uint256 left, uint256 right, string calldata error) external pure;
+
+    /// Compares two `int256` values. Expects first value to be greater than or equal to second.
+    function assertGe(int256 left, int256 right) external pure;
+
+    /// Compares two `int256` values. Expects first value to be greater than or equal to second.
+    /// Includes error message into revert string on failure.
+    function assertGe(int256 left, int256 right, string calldata error) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be greater than second.
+    /// Formats values with decimals in failure message.
+    function assertGtDecimal(uint256 left, uint256 right, uint256 decimals) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be greater than second.
+    /// Formats values with decimals in failure message. Includes error message into revert string on failure.
+    function assertGtDecimal(uint256 left, uint256 right, uint256 decimals, string calldata error) external pure;
+
+    /// Compares two `int256` values. Expects first value to be greater than second.
+    /// Formats values with decimals in failure message.
+    function assertGtDecimal(int256 left, int256 right, uint256 decimals) external pure;
+
+    /// Compares two `int256` values. Expects first value to be greater than second.
+    /// Formats values with decimals in failure message. Includes error message into revert string on failure.
+    function assertGtDecimal(int256 left, int256 right, uint256 decimals, string calldata error) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be greater than second.
+    function assertGt(uint256 left, uint256 right) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be greater than second.
+    /// Includes error message into revert string on failure.
+    function assertGt(uint256 left, uint256 right, string calldata error) external pure;
+
+    /// Compares two `int256` values. Expects first value to be greater than second.
+    function assertGt(int256 left, int256 right) external pure;
+
+    /// Compares two `int256` values. Expects first value to be greater than second.
+    /// Includes error message into revert string on failure.
+    function assertGt(int256 left, int256 right, string calldata error) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be less than or equal to second.
+    /// Formats values with decimals in failure message.
+    function assertLeDecimal(uint256 left, uint256 right, uint256 decimals) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be less than or equal to second.
+    /// Formats values with decimals in failure message. Includes error message into revert string on failure.
+    function assertLeDecimal(uint256 left, uint256 right, uint256 decimals, string calldata error) external pure;
+
+    /// Compares two `int256` values. Expects first value to be less than or equal to second.
+    /// Formats values with decimals in failure message.
+    function assertLeDecimal(int256 left, int256 right, uint256 decimals) external pure;
+
+    /// Compares two `int256` values. Expects first value to be less than or equal to second.
+    /// Formats values with decimals in failure message. Includes error message into revert string on failure.
+    function assertLeDecimal(int256 left, int256 right, uint256 decimals, string calldata error) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be less than or equal to second.
+    function assertLe(uint256 left, uint256 right) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be less than or equal to second.
+    /// Includes error message into revert string on failure.
+    function assertLe(uint256 left, uint256 right, string calldata error) external pure;
+
+    /// Compares two `int256` values. Expects first value to be less than or equal to second.
+    function assertLe(int256 left, int256 right) external pure;
+
+    /// Compares two `int256` values. Expects first value to be less than or equal to second.
+    /// Includes error message into revert string on failure.
+    function assertLe(int256 left, int256 right, string calldata error) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be less than second.
+    /// Formats values with decimals in failure message.
+    function assertLtDecimal(uint256 left, uint256 right, uint256 decimals) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be less than second.
+    /// Formats values with decimals in failure message. Includes error message into revert string on failure.
+    function assertLtDecimal(uint256 left, uint256 right, uint256 decimals, string calldata error) external pure;
+
+    /// Compares two `int256` values. Expects first value to be less than second.
+    /// Formats values with decimals in failure message.
+    function assertLtDecimal(int256 left, int256 right, uint256 decimals) external pure;
+
+    /// Compares two `int256` values. Expects first value to be less than second.
+    /// Formats values with decimals in failure message. Includes error message into revert string on failure.
+    function assertLtDecimal(int256 left, int256 right, uint256 decimals, string calldata error) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be less than second.
+    function assertLt(uint256 left, uint256 right) external pure;
+
+    /// Compares two `uint256` values. Expects first value to be less than second.
+    /// Includes error message into revert string on failure.
+    function assertLt(uint256 left, uint256 right, string calldata error) external pure;
+
+    /// Compares two `int256` values. Expects first value to be less than second.
+    function assertLt(int256 left, int256 right) external pure;
+
+    /// Compares two `int256` values. Expects first value to be less than second.
+    /// Includes error message into revert string on failure.
+    function assertLt(int256 left, int256 right, string calldata error) external pure;
+
+    /// Asserts that two `uint256` values are not equal, formatting them with decimals in failure message.
+    function assertNotEqDecimal(uint256 left, uint256 right, uint256 decimals) external pure;
+
+    /// Asserts that two `uint256` values are not equal, formatting them with decimals in failure message.
+    /// Includes error message into revert string on failure.
+    function assertNotEqDecimal(uint256 left, uint256 right, uint256 decimals, string calldata error) external pure;
+
+    /// Asserts that two `int256` values are not equal, formatting them with decimals in failure message.
+    function assertNotEqDecimal(int256 left, int256 right, uint256 decimals) external pure;
+
+    /// Asserts that two `int256` values are not equal, formatting them with decimals in failure message.
+    /// Includes error message into revert string on failure.
+    function assertNotEqDecimal(int256 left, int256 right, uint256 decimals, string calldata error) external pure;
+
+    /// Asserts that two `bool` values are not equal.
+    function assertNotEq(bool left, bool right) external pure;
+
+    /// Asserts that two `bool` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(bool left, bool right, string calldata error) external pure;
+
+    /// Asserts that two `string` values are not equal.
+    function assertNotEq(string calldata left, string calldata right) external pure;
+
+    /// Asserts that two `string` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(string calldata left, string calldata right, string calldata error) external pure;
+
+    /// Asserts that two `bytes` values are not equal.
+    function assertNotEq(bytes calldata left, bytes calldata right) external pure;
+
+    /// Asserts that two `bytes` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(bytes calldata left, bytes calldata right, string calldata error) external pure;
+
+    /// Asserts that two arrays of `bool` values are not equal.
+    function assertNotEq(bool[] calldata left, bool[] calldata right) external pure;
+
+    /// Asserts that two arrays of `bool` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(bool[] calldata left, bool[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two arrays of `uint256` values are not equal.
+    function assertNotEq(uint256[] calldata left, uint256[] calldata right) external pure;
+
+    /// Asserts that two arrays of `uint256` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(uint256[] calldata left, uint256[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two arrays of `int256` values are not equal.
+    function assertNotEq(int256[] calldata left, int256[] calldata right) external pure;
+
+    /// Asserts that two arrays of `int256` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(int256[] calldata left, int256[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two `uint256` values are not equal.
+    function assertNotEq(uint256 left, uint256 right) external pure;
+
+    /// Asserts that two arrays of `address` values are not equal.
+    function assertNotEq(address[] calldata left, address[] calldata right) external pure;
+
+    /// Asserts that two arrays of `address` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(address[] calldata left, address[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two arrays of `bytes32` values are not equal.
+    function assertNotEq(bytes32[] calldata left, bytes32[] calldata right) external pure;
+
+    /// Asserts that two arrays of `bytes32` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(bytes32[] calldata left, bytes32[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two arrays of `string` values are not equal.
+    function assertNotEq(string[] calldata left, string[] calldata right) external pure;
+
+    /// Asserts that two arrays of `string` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(string[] calldata left, string[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two arrays of `bytes` values are not equal.
+    function assertNotEq(bytes[] calldata left, bytes[] calldata right) external pure;
+
+    /// Asserts that two arrays of `bytes` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(bytes[] calldata left, bytes[] calldata right, string calldata error) external pure;
+
+    /// Asserts that two `uint256` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(uint256 left, uint256 right, string calldata error) external pure;
+
+    /// Asserts that two `int256` values are not equal.
+    function assertNotEq(int256 left, int256 right) external pure;
+
+    /// Asserts that two `int256` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(int256 left, int256 right, string calldata error) external pure;
+
+    /// Asserts that two `address` values are not equal.
+    function assertNotEq(address left, address right) external pure;
+
+    /// Asserts that two `address` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(address left, address right, string calldata error) external pure;
+
+    /// Asserts that two `bytes32` values are not equal.
+    function assertNotEq(bytes32 left, bytes32 right) external pure;
+
+    /// Asserts that two `bytes32` values are not equal and includes error message into revert string on failure.
+    function assertNotEq(bytes32 left, bytes32 right, string calldata error) external pure;
+
+    /// Asserts that the given condition is true.
+    function assertTrue(bool condition) external pure;
+
+    /// Asserts that the given condition is true and includes error message into revert string on failure.
+    function assertTrue(bool condition, string calldata error) external pure;
 
     /// If the condition is false, discard this run's fuzz inputs and generate new ones.
     function assume(bool condition) external pure;

--- a/test/StdAssertions.t.sol
+++ b/test/StdAssertions.t.sol
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.7.0 <0.9.0;
 
-import "../src/Test.sol";
+import "../src/StdAssertions.sol";
+import {Vm} from "../src/Vm.sol";
 
-contract StdAssertionsTest is Test {
-    string constant CUSTOM_ERROR = "guh!";
+interface VmInternal is Vm {
+    function _expectCheatcodeRevert(bytes memory message) external;
+}
 
-    bool constant EXPECT_PASS = false;
-    bool constant EXPECT_FAIL = true;
+contract StdAssertionsTest is StdAssertions {
+    string constant errorMessage = "User provided message";
+    uint256 constant maxDecimals = 77;
 
     bool constant SHOULD_REVERT = true;
     bool constant SHOULD_RETURN = false;
@@ -15,624 +18,819 @@ contract StdAssertionsTest is Test {
     bool constant STRICT_REVERT_DATA = true;
     bool constant NON_STRICT_REVERT_DATA = false;
 
-    TestTest t = new TestTest();
+    VmInternal constant vm = VmInternal(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    /*//////////////////////////////////////////////////////////////////////////
-                                    FAIL(STRING)
-    //////////////////////////////////////////////////////////////////////////*/
+    function _abs(int256 a) internal pure returns (uint256) {
+        // Required or it will fail when `a = type(int256).min`
+        if (a == type(int256).min) {
+            return uint256(type(int256).max) + 1;
+        }
 
-    function test_ShouldFail() external {
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._fail(CUSTOM_ERROR);
+        return uint256(a > 0 ? a : -a);
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-                                    ASSERT_FALSE
-    //////////////////////////////////////////////////////////////////////////*/
-
-    function test_AssertFalse_Pass() external {
-        t._assertFalse(false, EXPECT_PASS);
+    function _getDelta(uint256 a, uint256 b) internal pure returns (uint256) {
+        return a > b ? a - b : b - a;
     }
 
-    function test_AssertFalse_Fail() external {
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: Assertion Failed");
-        t._assertFalse(true, EXPECT_FAIL);
+    function _getDelta(int256 a, int256 b) internal pure returns (uint256) {
+        // a and b are of the same sign
+        // this works thanks to two's complement, the left-most bit is the sign bit
+        if ((a ^ b) > -1) {
+            return _getDelta(_abs(a), _abs(b));
+        }
+
+        // a and b are of opposite signs
+        return _abs(a) + _abs(b);
     }
 
-    function test_AssertFalse_Err_Pass() external {
-        t._assertFalse(false, CUSTOM_ERROR, EXPECT_PASS);
-    }
-
-    function test_AssertFalse_Err_Fail() external {
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._assertFalse(true, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                    ASSERT_EQ(BOOL)
-    //////////////////////////////////////////////////////////////////////////*/
-
-    function testFuzz_AssertEq_Bool_Pass(bool a) external {
-        t._assertEq(a, a, EXPECT_PASS);
-    }
-
-    function testFuzz_AssertEq_Bool_Fail(bool a, bool b) external {
-        vm.assume(a != b);
-
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [bool]");
-        t._assertEq(a, b, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_BoolErr_Pass(bool a) external {
-        t._assertEq(a, a, CUSTOM_ERROR, EXPECT_PASS);
-    }
-
-    function testFuzz_AssertEq_BoolErr_Fail(bool a, bool b) external {
-        vm.assume(a != b);
-
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                    ASSERT_EQ(BYTES)
-    //////////////////////////////////////////////////////////////////////////*/
-
-    function testFuzz_AssertEq_Bytes_Pass(bytes calldata a) external {
-        t._assertEq(a, a, EXPECT_PASS);
-    }
-
-    function testFuzz_AssertEq_Bytes_Fail(bytes calldata a, bytes calldata b) external {
-        vm.assume(keccak256(a) != keccak256(b));
-
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [bytes]");
-        t._assertEq(a, b, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_BytesErr_Pass(bytes calldata a) external {
-        t._assertEq(a, a, CUSTOM_ERROR, EXPECT_PASS);
-    }
-
-    function testFuzz_AssertEq_BytesErr_Fail(bytes calldata a, bytes calldata b) external {
-        vm.assume(keccak256(a) != keccak256(b));
-
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                    ASSERT_EQ(ARRAY)
-    //////////////////////////////////////////////////////////////////////////*/
-
-    function testFuzz_AssertEq_UintArr_Pass(uint256 e0, uint256 e1, uint256 e2) public {
-        uint256[] memory a = new uint256[](3);
-        a[0] = e0;
-        a[1] = e1;
-        a[2] = e2;
-        uint256[] memory b = new uint256[](3);
-        b[0] = e0;
-        b[1] = e1;
-        b[2] = e2;
-
-        t._assertEq(a, b, EXPECT_PASS);
-    }
-
-    function testFuzz_AssertEq_IntArr_Pass(int256 e0, int256 e1, int256 e2) public {
-        int256[] memory a = new int256[](3);
-        a[0] = e0;
-        a[1] = e1;
-        a[2] = e2;
-        int256[] memory b = new int256[](3);
-        b[0] = e0;
-        b[1] = e1;
-        b[2] = e2;
-
-        t._assertEq(a, b, EXPECT_PASS);
-    }
-
-    function testFuzz_AssertEq_AddressArr_Pass(address e0, address e1, address e2) public {
-        address[] memory a = new address[](3);
-        a[0] = e0;
-        a[1] = e1;
-        a[2] = e2;
-        address[] memory b = new address[](3);
-        b[0] = e0;
-        b[1] = e1;
-        b[2] = e2;
-
-        t._assertEq(a, b, EXPECT_PASS);
-    }
-
-    function testFuzz_AssertEq_UintArr_FailEl(uint256 e1) public {
-        vm.assume(e1 != 0);
-        uint256[] memory a = new uint256[](3);
-        uint256[] memory b = new uint256[](3);
-        b[1] = e1;
-
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [uint[]]");
-        t._assertEq(a, b, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_IntArr_FailEl(int256 e1) public {
-        vm.assume(e1 != 0);
-        int256[] memory a = new int256[](3);
-        int256[] memory b = new int256[](3);
-        b[1] = e1;
-
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [int[]]");
-        t._assertEq(a, b, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_AddressArr_FailEl(address e1) public {
-        vm.assume(e1 != address(0));
-        address[] memory a = new address[](3);
-        address[] memory b = new address[](3);
-        b[1] = e1;
-
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [address[]]");
-        t._assertEq(a, b, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_UintArrErr_FailEl(uint256 e1) public {
-        vm.assume(e1 != 0);
-        uint256[] memory a = new uint256[](3);
-        uint256[] memory b = new uint256[](3);
-        b[1] = e1;
-
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [uint[]]");
-        t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_IntArrErr_FailEl(int256 e1) public {
-        vm.assume(e1 != 0);
-        int256[] memory a = new int256[](3);
-        int256[] memory b = new int256[](3);
-        b[1] = e1;
-
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [int[]]");
-        t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_AddressArrErr_FailEl(address e1) public {
-        vm.assume(e1 != address(0));
-        address[] memory a = new address[](3);
-        address[] memory b = new address[](3);
-        b[1] = e1;
-
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [address[]]");
-        t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_UintArr_FailLen(uint256 lenA, uint256 lenB) public {
-        vm.assume(lenA != lenB);
-        vm.assume(lenA <= 10000);
-        vm.assume(lenB <= 10000);
-        uint256[] memory a = new uint256[](lenA);
-        uint256[] memory b = new uint256[](lenB);
-
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [uint[]]");
-        t._assertEq(a, b, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_IntArr_FailLen(uint256 lenA, uint256 lenB) public {
-        vm.assume(lenA != lenB);
-        vm.assume(lenA <= 10000);
-        vm.assume(lenB <= 10000);
-        int256[] memory a = new int256[](lenA);
-        int256[] memory b = new int256[](lenB);
-
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [int[]]");
-        t._assertEq(a, b, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_AddressArr_FailLen(uint256 lenA, uint256 lenB) public {
-        vm.assume(lenA != lenB);
-        vm.assume(lenA <= 10000);
-        vm.assume(lenB <= 10000);
-        address[] memory a = new address[](lenA);
-        address[] memory b = new address[](lenB);
-
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [address[]]");
-        t._assertEq(a, b, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_UintArrErr_FailLen(uint256 lenA, uint256 lenB) public {
-        vm.assume(lenA != lenB);
-        vm.assume(lenA <= 10000);
-        vm.assume(lenB <= 10000);
-        uint256[] memory a = new uint256[](lenA);
-        uint256[] memory b = new uint256[](lenB);
-
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [uint[]]");
-        t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_IntArrErr_FailLen(uint256 lenA, uint256 lenB) public {
-        vm.assume(lenA != lenB);
-        vm.assume(lenA <= 10000);
-        vm.assume(lenB <= 10000);
-        int256[] memory a = new int256[](lenA);
-        int256[] memory b = new int256[](lenB);
-
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [int[]]");
-        t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertEq_AddressArrErr_FailLen(uint256 lenA, uint256 lenB) public {
-        vm.assume(lenA != lenB);
-        vm.assume(lenA <= 10000);
-        vm.assume(lenB <= 10000);
-        address[] memory a = new address[](lenA);
-        address[] memory b = new address[](lenB);
-
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a == b not satisfied [address[]]");
-        t._assertEq(a, b, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                    ASSERT_EQ(UINT)
-    //////////////////////////////////////////////////////////////////////////*/
-
-    function test_AssertEqUint() public {
-        assertEqUint(uint8(1), uint128(1));
-        assertEqUint(uint64(2), uint64(2));
-    }
-
-    function testFail_AssertEqUint() public {
-        assertEqUint(uint64(1), uint96(2));
-        assertEqUint(uint160(3), uint160(4));
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                    APPROX_EQ_ABS(UINT)
-    //////////////////////////////////////////////////////////////////////////*/
-
-    function testFuzz_AssertApproxEqAbs_Uint_Pass(uint256 a, uint256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) <= maxDelta);
-
-        t._assertApproxEqAbs(a, b, maxDelta, EXPECT_PASS);
-    }
-
-    function testFuzz_AssertApproxEqAbs_Uint_Fail(uint256 a, uint256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) > maxDelta);
-
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a ~= b not satisfied [uint]");
-        t._assertApproxEqAbs(a, b, maxDelta, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertApproxEqAbs_UintErr_Pass(uint256 a, uint256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) <= maxDelta);
-
-        t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_PASS);
-    }
-
-    function testFuzz_AssertApproxEqAbs_UintErr_Fail(uint256 a, uint256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) > maxDelta);
-
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                    APPROX_EQ_ABS_DECIMAL(UINT)
-    //////////////////////////////////////////////////////////////////////////*/
-
-    function testFuzz_AssertApproxEqAbsDecimal_Uint_Pass(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
-        external
+    function _prefixDecWithZeroes(string memory intPart, string memory decimalPart, uint256 decimals)
+        internal
+        pure
+        returns (string memory)
     {
-        vm.assume(stdMath.delta(a, b) <= maxDelta);
+        while (bytes(decimalPart).length < decimals) {
+            decimalPart = string.concat("0", decimalPart);
+        }
 
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_PASS);
+        return string.concat(intPart, ".", decimalPart);
     }
 
-    function testFuzz_AssertApproxEqAbsDecimal_Uint_Fail(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
-        external
-    {
-        vm.assume(stdMath.delta(a, b) > maxDelta);
+    function _formatWithDecimals(uint256 value, uint256 decimals) internal returns (string memory) {
+        string memory intPart = vm.toString(value / (10 ** decimals));
+        string memory decimalPart = vm.toString(value % (10 ** decimals));
 
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a ~= b not satisfied [uint]");
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_FAIL);
+        return _prefixDecWithZeroes(intPart, decimalPart, decimals);
     }
 
-    function testFuzz_AssertApproxEqAbsDecimal_UintErr_Pass(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
-        external
-    {
-        vm.assume(stdMath.delta(a, b) <= maxDelta);
+    function _formatWithDecimals(int256 value, uint256 decimals) internal returns (string memory) {
+        string memory intPart = vm.toString(value / int256(10 ** decimals));
+        int256 mod = value % int256(10 ** decimals);
+        string memory decimalPart = vm.toString(mod > 0 ? mod : -mod);
 
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
+        // Add - if we have something like 0.123
+        if ((value < 0) && keccak256(abi.encode(intPart)) == keccak256(abi.encode("0"))) {
+            intPart = string.concat("-", intPart);
+        }
+
+        return _prefixDecWithZeroes(intPart, decimalPart, decimals);
     }
 
-    function testFuzz_AssertApproxEqAbsDecimal_UintErr_Fail(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals)
-        external
-    {
-        vm.assume(stdMath.delta(a, b) > maxDelta);
+    function testFuzzAssertEqNotEq(uint256 left, uint256 right, uint256 decimals) public {
+        vm.assume(left != right);
+        vm.assume(decimals <= maxDecimals);
 
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT_FAIL);
+        assertEq(left, left);
+        assertEq(right, right);
+        assertNotEq(left, right);
+        assertNotEq(right, left);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " != ", vm.toString(right)))
+        );
+        assertEq(left, right, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " == ", vm.toString(left)))
+        );
+        assertNotEq(left, left, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(left, decimals),
+                    " != ",
+                    _formatWithDecimals(right, decimals)
+                )
+            )
+        );
+        assertEqDecimal(left, right, decimals);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(left, decimals),
+                    " == ",
+                    _formatWithDecimals(left, decimals)
+                )
+            )
+        );
+        assertNotEqDecimal(left, left, decimals);
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-                                    APPROX_EQ_ABS(INT)
-    //////////////////////////////////////////////////////////////////////////*/
+    function testFuzzAssertEqNotEq(int256 left, int256 right, uint256 decimals) public {
+        vm.assume(left != right);
+        vm.assume(decimals <= maxDecimals);
 
-    function testFuzz_AssertApproxEqAbs_Int_Pass(int256 a, int256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) <= maxDelta);
+        assertEq(left, left);
+        assertEq(right, right);
+        assertNotEq(left, right);
+        assertNotEq(right, left);
 
-        t._assertApproxEqAbs(a, b, maxDelta, EXPECT_PASS);
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " != ", vm.toString(right)))
+        );
+        assertEq(left, right, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " == ", vm.toString(left)))
+        );
+        assertNotEq(left, left, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    errorMessage,
+                    ": ",
+                    _formatWithDecimals(left, decimals),
+                    " != ",
+                    _formatWithDecimals(right, decimals)
+                )
+            )
+        );
+        assertEqDecimal(left, right, decimals, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    errorMessage, ": ", _formatWithDecimals(left, decimals), " == ", _formatWithDecimals(left, decimals)
+                )
+            )
+        );
+        assertNotEqDecimal(left, left, decimals, errorMessage);
     }
 
-    function testFuzz_AssertApproxEqAbs_Int_Fail(int256 a, int256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) > maxDelta);
+    function testFuzzAssertEqNotEq(bool left, bool right) public {
+        vm.assume(left != right);
 
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a ~= b not satisfied [int]");
-        t._assertApproxEqAbs(a, b, maxDelta, EXPECT_FAIL);
+        assertEq(left, left);
+        assertEq(right, right);
+        assertNotEq(left, right);
+        assertNotEq(right, left);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " != ", vm.toString(right)))
+        );
+        assertEq(left, right, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " == ", vm.toString(left)))
+        );
+        assertNotEq(left, left, errorMessage);
     }
 
-    function testFuzz_AssertApproxEqAbs_IntErr_Pass(int256 a, int256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) <= maxDelta);
+    function testFuzzAssertEqNotEq(address left, address right) public {
+        vm.assume(left != right);
 
-        t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_PASS);
+        assertEq(left, left);
+        assertEq(right, right);
+        assertNotEq(left, right);
+        assertNotEq(right, left);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " != ", vm.toString(right)))
+        );
+        assertEq(left, right, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " == ", vm.toString(left)))
+        );
+        assertNotEq(left, left, errorMessage);
     }
 
-    function testFuzz_AssertApproxEqAbs_IntErr_Fail(int256 a, int256 b, uint256 maxDelta) external {
-        vm.assume(stdMath.delta(a, b) > maxDelta);
+    function testFuzzAssertEqNotEq(bytes32 left, bytes32 right) public {
+        vm.assume(left != right);
 
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._assertApproxEqAbs(a, b, maxDelta, CUSTOM_ERROR, EXPECT_FAIL);
+        assertEq(left, left);
+        assertEq(right, right);
+        assertNotEq(left, right);
+        assertNotEq(right, left);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " != ", vm.toString(right)))
+        );
+        assertEq(left, right, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " == ", vm.toString(left)))
+        );
+        assertNotEq(left, left, errorMessage);
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-                                    APPROX_EQ_ABS_DECIMAL(INT)
-    //////////////////////////////////////////////////////////////////////////*/
+    function testFuzzAssertEqNotEq(string memory left, string memory right) public {
+        vm.assume(keccak256(abi.encodePacked(left)) != keccak256(abi.encodePacked(right)));
 
-    function testFuzz_AssertApproxEqAbsDecimal_Int_Pass(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
-        external
-    {
-        vm.assume(stdMath.delta(a, b) <= maxDelta);
+        assertEq(left, left);
+        assertEq(right, right);
+        assertNotEq(left, right);
+        assertNotEq(right, left);
 
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_PASS);
+        vm._expectCheatcodeRevert(bytes(string.concat(errorMessage, ": ", left, " != ", right)));
+        assertEq(left, right, errorMessage);
+
+        vm._expectCheatcodeRevert(bytes(string.concat(errorMessage, ": ", left, " == ", left)));
+        assertNotEq(left, left, errorMessage);
     }
 
-    function testFuzz_AssertApproxEqAbsDecimal_Int_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
-        external
-    {
-        vm.assume(stdMath.delta(a, b) > maxDelta);
+    function testFuzzAssertEqNotEq(bytes memory left, bytes memory right) public {
+        vm.assume(keccak256(left) != keccak256(right));
 
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a ~= b not satisfied [int]");
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, EXPECT_FAIL);
+        assertEq(left, left);
+        assertEq(right, right);
+        assertNotEq(left, right);
+        assertNotEq(right, left);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " != ", vm.toString(right)))
+        );
+        assertEq(left, right, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " == ", vm.toString(left)))
+        );
+        assertNotEq(left, left, errorMessage);
     }
 
-    function testFuzz_AssertApproxEqAbsDecimal_IntErr_Pass(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
-        external
-    {
-        vm.assume(stdMath.delta(a, b) <= maxDelta);
+    function testFuzzAssertGtLt(uint256 left, uint256 right, uint256 decimals) public {
+        vm.assume(left < right);
+        vm.assume(decimals <= maxDecimals);
 
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
+        assertGt(right, left);
+        assertLt(left, right);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " <= ", vm.toString(right)))
+        );
+        assertGt(left, right, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(right), " <= ", vm.toString(right)))
+        );
+        assertGt(right, right, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " >= ", vm.toString(left)))
+        );
+        assertLt(left, left, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(right), " >= ", vm.toString(left)))
+        );
+        assertLt(right, left, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(left, decimals),
+                    " <= ",
+                    _formatWithDecimals(right, decimals)
+                )
+            )
+        );
+        assertGtDecimal(left, right, decimals);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(right, decimals),
+                    " <= ",
+                    _formatWithDecimals(right, decimals)
+                )
+            )
+        );
+        assertGtDecimal(right, right, decimals);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(left, decimals),
+                    " >= ",
+                    _formatWithDecimals(left, decimals)
+                )
+            )
+        );
+        assertLtDecimal(left, left, decimals);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(right, decimals),
+                    " >= ",
+                    _formatWithDecimals(left, decimals)
+                )
+            )
+        );
+        assertLtDecimal(right, left, decimals);
     }
 
-    function testFuzz_AssertApproxEqAbsDecimal_IntErr_Fail(int256 a, int256 b, uint256 maxDelta, uint256 decimals)
-        external
-    {
-        vm.assume(stdMath.delta(a, b) > maxDelta);
+    function testFuzzAssertGtLt(int256 left, int256 right, uint256 decimals) public {
+        vm.assume(left < right);
+        vm.assume(decimals <= maxDecimals);
 
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._assertApproxEqAbsDecimal(a, b, maxDelta, decimals, CUSTOM_ERROR, EXPECT_FAIL);
+        assertGt(right, left);
+        assertLt(left, right);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " <= ", vm.toString(right)))
+        );
+        assertGt(left, right, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(right), " <= ", vm.toString(right)))
+        );
+        assertGt(right, right, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " >= ", vm.toString(left)))
+        );
+        assertLt(left, left, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(right), " >= ", vm.toString(left)))
+        );
+        assertLt(right, left, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(left, decimals),
+                    " <= ",
+                    _formatWithDecimals(right, decimals)
+                )
+            )
+        );
+        assertGtDecimal(left, right, decimals);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(right, decimals),
+                    " <= ",
+                    _formatWithDecimals(right, decimals)
+                )
+            )
+        );
+        assertGtDecimal(right, right, decimals);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(left, decimals),
+                    " >= ",
+                    _formatWithDecimals(left, decimals)
+                )
+            )
+        );
+        assertLtDecimal(left, left, decimals);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(right, decimals),
+                    " >= ",
+                    _formatWithDecimals(left, decimals)
+                )
+            )
+        );
+        assertLtDecimal(right, left, decimals);
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-                                    APPROX_EQ_REL(UINT)
-    //////////////////////////////////////////////////////////////////////////*/
+    function testFuzzAssertGeLe(uint256 left, uint256 right, uint256 decimals) public {
+        vm.assume(left < right);
+        vm.assume(decimals <= maxDecimals);
 
-    function testFuzz_AssertApproxEqRel_Uint_Pass(uint256 a, uint256 b, uint256 maxPercentDelta) external {
-        vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
-        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+        assertGe(left, left);
+        assertLe(left, left);
+        assertGe(right, right);
+        assertLe(right, right);
+        assertGe(right, left);
+        assertLe(left, right);
 
-        t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_PASS);
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " < ", vm.toString(right)))
+        );
+        assertGe(left, right, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(right), " > ", vm.toString(left)))
+        );
+        assertLe(right, left, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(left, decimals),
+                    " < ",
+                    _formatWithDecimals(right, decimals)
+                )
+            )
+        );
+        assertGeDecimal(left, right, decimals);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(right, decimals),
+                    " > ",
+                    _formatWithDecimals(left, decimals)
+                )
+            )
+        );
+        assertLeDecimal(right, left, decimals);
     }
 
-    function testFuzz_AssertApproxEqRel_Uint_Fail(uint256 a, uint256 b, uint256 maxPercentDelta) external {
-        vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
-        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
+    function testFuzzAssertGeLe(int256 left, int256 right, uint256 decimals) public {
+        vm.assume(left < right);
+        vm.assume(decimals <= maxDecimals);
 
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a ~= b not satisfied [uint]");
-        t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_FAIL);
+        assertGe(left, left);
+        assertLe(left, left);
+        assertGe(right, right);
+        assertLe(right, right);
+        assertGe(right, left);
+        assertLe(left, right);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(left), " < ", vm.toString(right)))
+        );
+        assertGe(left, right, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(string.concat(errorMessage, ": ", vm.toString(right), " > ", vm.toString(left)))
+        );
+        assertLe(right, left, errorMessage);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(left, decimals),
+                    " < ",
+                    _formatWithDecimals(right, decimals)
+                )
+            )
+        );
+        assertGeDecimal(left, right, decimals);
+
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "assertion failed: ",
+                    _formatWithDecimals(right, decimals),
+                    " > ",
+                    _formatWithDecimals(left, decimals)
+                )
+            )
+        );
+        assertLeDecimal(right, left, decimals);
     }
 
-    function testFuzz_AssertApproxEqRel_UintErr_Pass(uint256 a, uint256 b, uint256 maxPercentDelta) external {
-        vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
-        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+    function testFuzzAssertApproxEqAbs(uint256 left, uint256 right, uint256 decimals) public {
+        uint256 delta = _getDelta(right, left);
+        vm.assume(decimals <= maxDecimals);
 
-        t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_PASS);
+        assertApproxEqAbs(left, right, delta);
+
+        if (delta > 0) {
+            vm._expectCheatcodeRevert(
+                bytes(
+                    string.concat(
+                        errorMessage,
+                        ": ",
+                        vm.toString(left),
+                        " !~= ",
+                        vm.toString(right),
+                        " (max delta: ",
+                        vm.toString(delta - 1),
+                        ", real delta: ",
+                        vm.toString(delta),
+                        ")"
+                    )
+                )
+            );
+            assertApproxEqAbs(left, right, delta - 1, errorMessage);
+
+            vm._expectCheatcodeRevert(
+                bytes(
+                    string.concat(
+                        "assertion failed: ",
+                        _formatWithDecimals(left, decimals),
+                        " !~= ",
+                        _formatWithDecimals(right, decimals),
+                        " (max delta: ",
+                        _formatWithDecimals(delta - 1, decimals),
+                        ", real delta: ",
+                        _formatWithDecimals(delta, decimals),
+                        ")"
+                    )
+                )
+            );
+            assertApproxEqAbsDecimal(left, right, delta - 1, decimals);
+        }
     }
 
-    function testFuzz_AssertApproxEqRel_UintErr_Fail(uint256 a, uint256 b, uint256 maxPercentDelta) external {
-        vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
-        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
+    function testFuzzAssertApproxEqAbs(int256 left, int256 right, uint256 decimals) public {
+        uint256 delta = _getDelta(right, left);
+        vm.assume(decimals <= maxDecimals);
 
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_FAIL);
+        assertApproxEqAbs(left, right, delta);
+
+        if (delta > 0) {
+            vm._expectCheatcodeRevert(
+                bytes(
+                    string.concat(
+                        errorMessage,
+                        ": ",
+                        vm.toString(left),
+                        " !~= ",
+                        vm.toString(right),
+                        " (max delta: ",
+                        vm.toString(delta - 1),
+                        ", real delta: ",
+                        vm.toString(delta),
+                        ")"
+                    )
+                )
+            );
+            assertApproxEqAbs(left, right, delta - 1, errorMessage);
+
+            vm._expectCheatcodeRevert(
+                bytes(
+                    string.concat(
+                        "assertion failed: ",
+                        _formatWithDecimals(left, decimals),
+                        " !~= ",
+                        _formatWithDecimals(right, decimals),
+                        " (max delta: ",
+                        _formatWithDecimals(delta - 1, decimals),
+                        ", real delta: ",
+                        _formatWithDecimals(delta, decimals),
+                        ")"
+                    )
+                )
+            );
+            assertApproxEqAbsDecimal(left, right, delta - 1, decimals);
+        }
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-                                    APPROX_EQ_REL_DECIMAL(UINT)
-    //////////////////////////////////////////////////////////////////////////*/
+    function testFuzzAssertApproxEqRel(uint256 left, uint256 right, uint256 decimals) public {
+        vm.assume(right != 0);
+        uint256 delta = _getDelta(right, left);
+        vm.assume(delta < type(uint256).max / (10 ** 18));
+        vm.assume(decimals <= maxDecimals);
 
-    function testFuzz_AssertApproxEqRelDecimal_Uint_Pass(
-        uint256 a,
-        uint256 b,
-        uint256 maxPercentDelta,
-        uint256 decimals
-    ) external {
-        vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
-        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+        uint256 percentDelta = delta * (10 ** 18) / right;
 
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_PASS);
+        assertApproxEqRel(left, right, percentDelta);
+
+        if (percentDelta > 0) {
+            vm._expectCheatcodeRevert(
+                bytes(
+                    string.concat(
+                        errorMessage,
+                        ": ",
+                        vm.toString(left),
+                        " !~= ",
+                        vm.toString(right),
+                        " (max delta: ",
+                        _formatWithDecimals(percentDelta - 1, 16),
+                        "%, real delta: ",
+                        _formatWithDecimals(percentDelta, 16),
+                        "%)"
+                    )
+                )
+            );
+            assertApproxEqRel(left, right, percentDelta - 1, errorMessage);
+
+            vm._expectCheatcodeRevert(
+                bytes(
+                    string.concat(
+                        "assertion failed: ",
+                        _formatWithDecimals(left, decimals),
+                        " !~= ",
+                        _formatWithDecimals(right, decimals),
+                        " (max delta: ",
+                        _formatWithDecimals(percentDelta - 1, 16),
+                        "%, real delta: ",
+                        _formatWithDecimals(percentDelta, 16),
+                        "%)"
+                    )
+                )
+            );
+            assertApproxEqRelDecimal(left, right, percentDelta - 1, decimals);
+        }
     }
 
-    function testFuzz_AssertApproxEqRelDecimal_Uint_Fail(
-        uint256 a,
-        uint256 b,
-        uint256 maxPercentDelta,
-        uint256 decimals
-    ) external {
-        vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
-        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
+    function testFuzzAssertApproxEqRel(int256 left, int256 right, uint256 decimals) public {
+        vm.assume(left < right);
+        vm.assume(right != 0);
+        uint256 delta = _getDelta(right, left);
+        vm.assume(delta < type(uint256).max / (10 ** 18));
+        vm.assume(decimals <= maxDecimals);
 
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a ~= b not satisfied [uint]");
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_FAIL);
+        uint256 percentDelta = delta * (10 ** 18) / _abs(right);
+
+        assertApproxEqRel(left, right, percentDelta);
+
+        if (percentDelta > 0) {
+            vm._expectCheatcodeRevert(
+                bytes(
+                    string.concat(
+                        errorMessage,
+                        ": ",
+                        vm.toString(left),
+                        " !~= ",
+                        vm.toString(right),
+                        " (max delta: ",
+                        _formatWithDecimals(percentDelta - 1, 16),
+                        "%, real delta: ",
+                        _formatWithDecimals(percentDelta, 16),
+                        "%)"
+                    )
+                )
+            );
+            assertApproxEqRel(left, right, percentDelta - 1, errorMessage);
+
+            vm._expectCheatcodeRevert(
+                bytes(
+                    string.concat(
+                        "assertion failed: ",
+                        _formatWithDecimals(left, decimals),
+                        " !~= ",
+                        _formatWithDecimals(right, decimals),
+                        " (max delta: ",
+                        _formatWithDecimals(percentDelta - 1, 16),
+                        "%, real delta: ",
+                        _formatWithDecimals(percentDelta, 16),
+                        "%)"
+                    )
+                )
+            );
+            assertApproxEqRelDecimal(left, right, percentDelta - 1, decimals);
+        }
     }
 
-    function testFuzz_AssertApproxEqRelDecimal_UintErr_Pass(
-        uint256 a,
-        uint256 b,
-        uint256 maxPercentDelta,
-        uint256 decimals
-    ) external {
-        vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
-        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+    function testAssertEqNotEqArrays() public {
+        {
+            uint256[] memory arr1 = new uint256[](1);
+            arr1[0] = 1;
+            uint256[] memory arr2 = new uint256[](2);
+            arr2[0] = 1;
+            arr2[1] = 2;
 
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
+            assertEq(arr1, arr1);
+            assertEq(arr2, arr2);
+            assertNotEq(arr1, arr2);
+
+            vm._expectCheatcodeRevert(bytes("assertion failed: [1] != [1, 2]"));
+            assertEq(arr1, arr2);
+
+            vm._expectCheatcodeRevert(bytes(string.concat("assertion failed: [1, 2] == [1, 2]")));
+            assertNotEq(arr2, arr2);
+        }
+        {
+            int256[] memory arr1 = new int256[](2);
+            int256[] memory arr2 = new int256[](1);
+            arr1[0] = 5;
+            arr2[0] = type(int256).max;
+
+            assertEq(arr1, arr1);
+            assertEq(arr2, arr2);
+            assertNotEq(arr1, arr2);
+
+            vm._expectCheatcodeRevert(bytes(string.concat(errorMessage, ": [5, 0] != [", vm.toString(arr2[0]), "]")));
+            assertEq(arr1, arr2, errorMessage);
+
+            vm._expectCheatcodeRevert(bytes(string.concat("assertion failed: [5, 0] == [5, 0]")));
+            assertNotEq(arr1, arr1);
+        }
+        {
+            bool[] memory arr1 = new bool[](2);
+            bool[] memory arr2 = new bool[](2);
+            arr1[0] = true;
+            arr2[1] = true;
+
+            assertEq(arr1, arr1);
+            assertEq(arr2, arr2);
+            assertNotEq(arr1, arr2);
+
+            vm._expectCheatcodeRevert(bytes(string.concat(errorMessage, ": [true, false] != [false, true]")));
+            assertEq(arr1, arr2, errorMessage);
+
+            vm._expectCheatcodeRevert(bytes(string("assertion failed: [true, false] == [true, false]")));
+            assertNotEq(arr1, arr1);
+        }
+        {
+            address[] memory arr1 = new address[](1);
+            address[] memory arr2 = new address[](0);
+
+            assertEq(arr1, arr1);
+            assertEq(arr2, arr2);
+            assertNotEq(arr1, arr2);
+
+            vm._expectCheatcodeRevert(bytes(string.concat(errorMessage, ": [", vm.toString(arr1[0]), "] != []")));
+            assertEq(arr1, arr2, errorMessage);
+
+            vm._expectCheatcodeRevert(bytes(string("assertion failed: [] == []")));
+            assertNotEq(arr2, arr2);
+        }
+        {
+            bytes32[] memory arr1 = new bytes32[](1);
+            bytes32[] memory arr2 = new bytes32[](1);
+            arr1[0] = bytes32(uint256(1));
+
+            assertEq(arr1, arr1);
+            assertEq(arr2, arr2);
+            assertNotEq(arr1, arr2);
+
+            vm._expectCheatcodeRevert(
+                bytes(string.concat(errorMessage, ": [", vm.toString(arr1[0]), "] != [", vm.toString(arr2[0]), "]"))
+            );
+            assertEq(arr1, arr2, errorMessage);
+
+            vm._expectCheatcodeRevert(
+                bytes(string.concat("assertion failed: [", vm.toString(arr2[0]), "] == [", vm.toString(arr2[0]), "]"))
+            );
+            assertNotEq(arr2, arr2);
+        }
+        {
+            string[] memory arr1 = new string[](1);
+            string[] memory arr2 = new string[](3);
+
+            arr1[0] = "foo";
+            arr2[2] = "bar";
+
+            assertEq(arr1, arr1);
+            assertEq(arr2, arr2);
+            assertNotEq(arr1, arr2);
+
+            vm._expectCheatcodeRevert(bytes("assertion failed: [foo] != [, , bar]"));
+            assertEq(arr1, arr2);
+
+            vm._expectCheatcodeRevert(bytes(string.concat(errorMessage, ": [foo] == [foo]")));
+            assertNotEq(arr1, arr1, errorMessage);
+        }
+        {
+            bytes[] memory arr1 = new bytes[](1);
+            bytes[] memory arr2 = new bytes[](2);
+
+            arr1[0] = hex"1111";
+            arr2[1] = hex"1234";
+
+            assertEq(arr1, arr1);
+            assertEq(arr2, arr2);
+            assertNotEq(arr1, arr2);
+
+            vm._expectCheatcodeRevert(bytes("assertion failed: [0x1111] != [0x, 0x1234]"));
+            assertEq(arr1, arr2);
+
+            vm._expectCheatcodeRevert(bytes(string.concat(errorMessage, ": [0x1111] == [0x1111]")));
+            assertNotEq(arr1, arr1, errorMessage);
+        }
     }
 
-    function testFuzz_AssertApproxEqRelDecimal_UintErr_Fail(
-        uint256 a,
-        uint256 b,
-        uint256 maxPercentDelta,
-        uint256 decimals
-    ) external {
-        vm.assume(a < type(uint128).max && b < type(uint128).max && b != 0);
-        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
+    function testAssertBool() public {
+        assertTrue(true);
+        assertFalse(false);
 
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_FAIL);
+        vm._expectCheatcodeRevert(bytes("assertion failed"));
+        assertTrue(false);
+
+        vm._expectCheatcodeRevert(bytes(errorMessage));
+        assertTrue(false, errorMessage);
+
+        vm._expectCheatcodeRevert(bytes("assertion failed"));
+        assertFalse(true);
+
+        vm._expectCheatcodeRevert(bytes(errorMessage));
+        assertFalse(true, errorMessage);
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-                                    APPROX_EQ_REL(INT)
-    //////////////////////////////////////////////////////////////////////////*/
+    function testAssertApproxEqRel() public {
+        vm._expectCheatcodeRevert(bytes("assertion failed: overflow in delta calculation"));
+        assertApproxEqRel(type(int256).min, type(int256).max, 0);
 
-    function testFuzz_AssertApproxEqRel_Int_Pass(int128 a, int128 b, uint128 maxPercentDelta) external {
-        vm.assume(b != 0);
-        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
+        vm._expectCheatcodeRevert(bytes(string.concat(errorMessage, ": overflow in delta calculation")));
+        assertApproxEqRel(int256(1), int256(0), 0, errorMessage);
 
-        t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_PASS);
+        vm._expectCheatcodeRevert(bytes(string.concat(errorMessage, ": overflow in delta calculation")));
+        assertApproxEqRel(uint256(0), type(uint256).max, 0, errorMessage);
+
+        vm._expectCheatcodeRevert(bytes("assertion failed: overflow in delta calculation"));
+        assertApproxEqRel(uint256(1), uint256(0), uint256(0));
     }
-
-    function testFuzz_AssertApproxEqRel_Int_Fail(int128 a, int128 b, uint128 maxPercentDelta) external {
-        vm.assume(b != 0);
-        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
-
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a ~= b not satisfied [int]");
-        t._assertApproxEqRel(a, b, maxPercentDelta, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertApproxEqRel_IntErr_Pass(int128 a, int128 b, uint128 maxPercentDelta) external {
-        vm.assume(b != 0);
-        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
-
-        t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_PASS);
-    }
-
-    function testFuzz_AssertApproxEqRel_IntErr_Fail(int128 a, int128 b, uint128 maxPercentDelta) external {
-        vm.assume(b != 0);
-        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
-
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._assertApproxEqRel(a, b, maxPercentDelta, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                    APPROX_EQ_REL_DECIMAL(INT)
-    //////////////////////////////////////////////////////////////////////////*/
-
-    function testAssertApproxEqRelDecimal_Int_Pass(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
-        external
-    {
-        vm.assume(b != 0);
-        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
-
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_PASS);
-    }
-
-    function testAssertApproxEqRelDecimal_Int_Fail(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
-        external
-    {
-        vm.assume(b != 0);
-        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
-
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a ~= b not satisfied [int]");
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, EXPECT_FAIL);
-    }
-
-    function testAssertApproxEqRelDecimal_IntErr_Pass(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
-        external
-    {
-        vm.assume(b != 0);
-        vm.assume(stdMath.percentDelta(a, b) <= maxPercentDelta);
-
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_PASS);
-    }
-
-    function testAssertApproxEqRelDecimal_IntErr_Fail(int128 a, int128 b, uint128 maxPercentDelta, uint128 decimals)
-        external
-    {
-        vm.assume(b != 0);
-        vm.assume(stdMath.percentDelta(a, b) > maxPercentDelta);
-
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                    ASSERT_EQ_CALL
-    //////////////////////////////////////////////////////////////////////////*/
 
     function testFuzz_AssertEqCall_Return_Pass(
         bytes memory callDataA,
@@ -643,7 +841,7 @@ contract StdAssertionsTest is Test {
         address targetA = address(new TestMockCall(returnData, SHOULD_RETURN));
         address targetB = address(new TestMockCall(returnData, SHOULD_RETURN));
 
-        t._assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData, EXPECT_PASS);
+        assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData);
     }
 
     function testFuzz_RevertWhenCalled_AssertEqCall_Return_Fail(
@@ -658,9 +856,14 @@ contract StdAssertionsTest is Test {
         address targetA = address(new TestMockCall(returnDataA, SHOULD_RETURN));
         address targetB = address(new TestMockCall(returnDataB, SHOULD_RETURN));
 
-        vm.expectEmit(true, true, true, true);
-        emit log_named_string("Error", "Call return data does not match");
-        t._assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData, EXPECT_FAIL);
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "Call return data does not match: ", vm.toString(returnDataA), " != ", vm.toString(returnDataB)
+                )
+            )
+        );
+        assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData);
     }
 
     function testFuzz_AssertEqCall_Revert_Pass(
@@ -672,7 +875,7 @@ contract StdAssertionsTest is Test {
         address targetA = address(new TestMockCall(revertDataA, SHOULD_REVERT));
         address targetB = address(new TestMockCall(revertDataB, SHOULD_REVERT));
 
-        t._assertEqCall(targetA, callDataA, targetB, callDataB, NON_STRICT_REVERT_DATA, EXPECT_PASS);
+        assertEqCall(targetA, callDataA, targetB, callDataB, NON_STRICT_REVERT_DATA);
     }
 
     function testFuzz_RevertWhenCalled_AssertEqCall_Revert_Fail(
@@ -686,9 +889,14 @@ contract StdAssertionsTest is Test {
         address targetA = address(new TestMockCall(revertDataA, SHOULD_REVERT));
         address targetB = address(new TestMockCall(revertDataB, SHOULD_REVERT));
 
-        vm.expectEmit(true, true, true, true);
-        emit log_named_string("Error", "Call revert data does not match");
-        t._assertEqCall(targetA, callDataA, targetB, callDataB, STRICT_REVERT_DATA, EXPECT_FAIL);
+        vm._expectCheatcodeRevert(
+            bytes(
+                string.concat(
+                    "Call revert data does not match: ", vm.toString(revertDataA), " != ", vm.toString(revertDataB)
+                )
+            )
+        );
+        assertEqCall(targetA, callDataA, targetB, callDataB, STRICT_REVERT_DATA);
     }
 
     function testFuzz_RevertWhenCalled_AssertEqCall_Fail(
@@ -696,296 +904,27 @@ contract StdAssertionsTest is Test {
         bytes memory callDataB,
         bytes memory returnDataA,
         bytes memory returnDataB,
-        bool strictRevertData
+        bool strictRevertData,
+        bool shouldARevert
     ) external {
         address targetA = address(new TestMockCall(returnDataA, SHOULD_RETURN));
         address targetB = address(new TestMockCall(returnDataB, SHOULD_REVERT));
 
-        vm.expectEmit(true, true, true, true);
-        emit log_named_bytes("  Left call return data", returnDataA);
-        vm.expectEmit(true, true, true, true);
-        emit log_named_bytes(" Right call revert data", returnDataB);
-        t._assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData, EXPECT_FAIL);
+        vm.expectRevert(bytes("assertion failed"));
+        this.assertEqCallExternal(targetA, callDataA, targetB, callDataB, strictRevertData);
 
-        vm.expectEmit(true, true, true, true);
-        emit log_named_bytes("  Left call revert data", returnDataB);
-        vm.expectEmit(true, true, true, true);
-        emit log_named_bytes(" Right call return data", returnDataA);
-        t._assertEqCall(targetB, callDataB, targetA, callDataA, strictRevertData, EXPECT_FAIL);
+        vm.expectRevert(bytes("assertion failed"));
+        this.assertEqCallExternal(targetB, callDataB, targetA, callDataA, strictRevertData);
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-                                ASSERT_NOT_EQ(BYTES)
-    //////////////////////////////////////////////////////////////////////////*/
-
-    function testFuzz_AssertNotEq_Bytes_Pass(bytes32 a, bytes32 b) external {
-        vm.assume(a != b);
-        t._assertNotEq(a, b, EXPECT_PASS);
-    }
-
-    function testFuzz_AssertNotEq_Bytes_Fail(bytes32 a) external {
-        vm.expectEmit(false, false, false, true);
-        emit log("Error: a != b not satisfied [bytes32]");
-        t._assertNotEq(a, a, EXPECT_FAIL);
-    }
-
-    function testFuzz_AssertNotEq_BytesErr_Pass(bytes32 a, bytes32 b) external {
-        vm.assume(a != b);
-        t._assertNotEq(a, b, CUSTOM_ERROR, EXPECT_PASS);
-    }
-
-    function testFuzz_AsserNottEq_BytesErr_Fail(bytes32 a) external {
-        vm.expectEmit(false, false, false, true);
-        emit log_named_string("Error", CUSTOM_ERROR);
-        t._assertNotEq(a, a, CUSTOM_ERROR, EXPECT_FAIL);
-    }
-
-    /*//////////////////////////////////////////////////////////////////////////
-                                ASSERT_NOT_EQ(UINT)
-    //////////////////////////////////////////////////////////////////////////*/
-
-    function test_AssertNotEqUint() public {
-        assertNotEq(uint8(1), uint128(2));
-        assertNotEq(uint64(3), uint64(4));
-    }
-
-    function testFail_AssertNotEqUint() public {
-        assertNotEq(uint64(1), uint96(1));
-        assertNotEq(uint160(2), uint160(2));
-    }
-}
-
-contract TestTest is Test {
-    modifier expectFailure(bool expectFail) {
-        bool preState = vm.load(HEVM_ADDRESS, bytes32("failed")) != bytes32(0x00);
-        _;
-        bool postState = vm.load(HEVM_ADDRESS, bytes32("failed")) != bytes32(0x00);
-
-        if (preState == true) {
-            return;
-        }
-
-        if (expectFail) {
-            require(postState == true, "expected failure not triggered");
-
-            // unwind the expected failure
-            vm.store(HEVM_ADDRESS, bytes32("failed"), bytes32(uint256(0x00)));
-        } else {
-            require(postState == false, "unexpected failure was triggered");
-        }
-    }
-
-    function _fail(string memory err) external expectFailure(true) {
-        fail(err);
-    }
-
-    function _assertFalse(bool data, bool expectFail) external expectFailure(expectFail) {
-        assertFalse(data);
-    }
-
-    function _assertFalse(bool data, string memory err, bool expectFail) external expectFailure(expectFail) {
-        assertFalse(data, err);
-    }
-
-    function _assertEq(bool a, bool b, bool expectFail) external expectFailure(expectFail) {
-        assertEq(a, b);
-    }
-
-    function _assertEq(bool a, bool b, string memory err, bool expectFail) external expectFailure(expectFail) {
-        assertEq(a, b, err);
-    }
-
-    function _assertEq(bytes memory a, bytes memory b, bool expectFail) external expectFailure(expectFail) {
-        assertEq(a, b);
-    }
-
-    function _assertEq(bytes memory a, bytes memory b, string memory err, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertEq(a, b, err);
-    }
-
-    function _assertEq(uint256[] memory a, uint256[] memory b, bool expectFail) external expectFailure(expectFail) {
-        assertEq(a, b);
-    }
-
-    function _assertEq(int256[] memory a, int256[] memory b, bool expectFail) external expectFailure(expectFail) {
-        assertEq(a, b);
-    }
-
-    function _assertEq(address[] memory a, address[] memory b, bool expectFail) external expectFailure(expectFail) {
-        assertEq(a, b);
-    }
-
-    function _assertEq(uint256[] memory a, uint256[] memory b, string memory err, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertEq(a, b, err);
-    }
-
-    function _assertEq(int256[] memory a, int256[] memory b, string memory err, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertEq(a, b, err);
-    }
-
-    function _assertEq(address[] memory a, address[] memory b, string memory err, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertEq(a, b, err);
-    }
-
-    function _assertNotEq(bytes32 a, bytes32 b, bool expectFail) external expectFailure(expectFail) {
-        assertNotEq32(a, b);
-    }
-
-    function _assertNotEq(bytes32 a, bytes32 b, string memory err, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertNotEq32(a, b, err);
-    }
-
-    function _assertApproxEqAbs(uint256 a, uint256 b, uint256 maxDelta, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertApproxEqAbs(a, b, maxDelta);
-    }
-
-    function _assertApproxEqAbs(uint256 a, uint256 b, uint256 maxDelta, string memory err, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertApproxEqAbs(a, b, maxDelta, err);
-    }
-
-    function _assertApproxEqAbsDecimal(uint256 a, uint256 b, uint256 maxDelta, uint256 decimals, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertApproxEqAbsDecimal(a, b, maxDelta, decimals);
-    }
-
-    function _assertApproxEqAbsDecimal(
-        uint256 a,
-        uint256 b,
-        uint256 maxDelta,
-        uint256 decimals,
-        string memory err,
-        bool expectFail
-    ) external expectFailure(expectFail) {
-        assertApproxEqAbsDecimal(a, b, maxDelta, decimals, err);
-    }
-
-    function _assertApproxEqAbs(int256 a, int256 b, uint256 maxDelta, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertApproxEqAbs(a, b, maxDelta);
-    }
-
-    function _assertApproxEqAbs(int256 a, int256 b, uint256 maxDelta, string memory err, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertApproxEqAbs(a, b, maxDelta, err);
-    }
-
-    function _assertApproxEqAbsDecimal(int256 a, int256 b, uint256 maxDelta, uint256 decimals, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertApproxEqAbsDecimal(a, b, maxDelta, decimals);
-    }
-
-    function _assertApproxEqAbsDecimal(
-        int256 a,
-        int256 b,
-        uint256 maxDelta,
-        uint256 decimals,
-        string memory err,
-        bool expectFail
-    ) external expectFailure(expectFail) {
-        assertApproxEqAbsDecimal(a, b, maxDelta, decimals, err);
-    }
-
-    function _assertApproxEqRel(uint256 a, uint256 b, uint256 maxPercentDelta, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertApproxEqRel(a, b, maxPercentDelta);
-    }
-
-    function _assertApproxEqRel(uint256 a, uint256 b, uint256 maxPercentDelta, string memory err, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertApproxEqRel(a, b, maxPercentDelta, err);
-    }
-
-    function _assertApproxEqRelDecimal(uint256 a, uint256 b, uint256 maxPercentDelta, uint256 decimals, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals);
-    }
-
-    function _assertApproxEqRelDecimal(
-        uint256 a,
-        uint256 b,
-        uint256 maxPercentDelta,
-        uint256 decimals,
-        string memory err,
-        bool expectFail
-    ) external expectFailure(expectFail) {
-        assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, err);
-    }
-
-    function _assertApproxEqRel(int256 a, int256 b, uint256 maxPercentDelta, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertApproxEqRel(a, b, maxPercentDelta);
-    }
-
-    function _assertApproxEqRel(int256 a, int256 b, uint256 maxPercentDelta, string memory err, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertApproxEqRel(a, b, maxPercentDelta, err);
-    }
-
-    function _assertApproxEqRelDecimal(int256 a, int256 b, uint256 maxPercentDelta, uint256 decimals, bool expectFail)
-        external
-        expectFailure(expectFail)
-    {
-        assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals);
-    }
-
-    function _assertApproxEqRelDecimal(
-        int256 a,
-        int256 b,
-        uint256 maxPercentDelta,
-        uint256 decimals,
-        string memory err,
-        bool expectFail
-    ) external expectFailure(expectFail) {
-        assertApproxEqRelDecimal(a, b, maxPercentDelta, decimals, err);
-    }
-
-    function _assertEqCall(
+    // Helper function to test outcome of assertEqCall via `expect` cheatcodes
+    function assertEqCallExternal(
         address targetA,
         bytes memory callDataA,
         address targetB,
         bytes memory callDataB,
-        bool strictRevertData,
-        bool expectFail
-    ) external expectFailure(expectFail) {
+        bool strictRevertData
+    ) public {
         assertEqCall(targetA, callDataA, targetB, callDataB, strictRevertData);
     }
 }

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -305,9 +305,6 @@ contract StdCheatsTest is Test {
         addInLoopNoGasNoGas();
         uint256 gas_used_double = gas_start_double - gasleft();
 
-        emit log_named_uint("Normal gas", gas_used_normal);
-        emit log_named_uint("Single modifier gas", gas_used_single);
-        emit log_named_uint("Double modifier  gas", gas_used_double);
         assertTrue(gas_used_double + gas_used_single < gas_used_normal);
     }
 

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,7 +9,7 @@ contract VmTest is Test {
     // inadvertently moved between Vm and VmSafe. This test must be updated each time a function is
     // added to or removed from Vm or VmSafe.
     function test_interfaceId() public {
-        assertEq(type(VmSafe).interfaceId, bytes4(0x01ec102d), "VmSafe");
+        assertEq(type(VmSafe).interfaceId, bytes4(0x63728340), "VmSafe");
         assertEq(type(Vm).interfaceId, bytes4(0xa63eed6b), "Vm");
     }
 }


### PR DESCRIPTION
Ref https://github.com/foundry-rs/foundry/pull/6803#issuecomment-1908957860

## Changes

1. Updates Vm interface to include native assertions
2. Removes `DSTest` dependency and moves all `assert*` functions to `StdAssertions`
3. Updates all implementations of `assert*` functions in `StdAssertions` with calls to `vm.assert*` cheatcodes
4. Updates tests for `StdAssertions`

## Breaking changes

This PR is marked as a draft because in current version it introduces some breaking changes which I am not sure we want. I think it makes sense to discuss them here first and decide if we are ready to merge them.

1. `DSTest` includes some additional `assert*` functions which duplicate logic of their alternatives. For example `assertEq0(bytes, bytes)` equivalent to `assertEq(bytes, bytes)` or `assertEq32(bytes32,bytes32)` equivalent to `assertEq(bytes32, bytes32)`. Do we want to keep those considering that we don't have native cheatcodes with such selectors or it makes sense to drop them now?
2. `DSTest` includes logic with `failed()` and `fail()` methods. Currently I haven't included this logic to `StdAssertions` because we are migrating to new assertions behavior when they revert immidiately. Removal of those should also not affect custom testing frameworks as they usually implement `failed()` method themselves on base `Test` contract. However, this will affect users or frameworks relying on explicit calls to `fail()` method on `forge-std` base `Test` contract. I am not sure if it is a common usecase and if it makes sense to keep it.
3. I have not migrated `log_*` events to `StdAssertions` except for `log` and `log_named_bytes` which are needed for `assertEqCall` cheats. Are we expecting those to be commonly used or all users should be using `console.log` calls at this point?
4. Some utility functions and modifiers from `DSTest` are not migrated too, not sure if they are used at all: `hasHEVMContext`, `logs_gas`, `mayRevert`, `testopts`, `HEVM_ADDRESS`

All changes are basically just something not being migrated from `DSTest` to `StdAssertions` and fixing it is as simple as copy-pasting it. However, I am not sure if we really want to keep compatibility with some of legacy methods above.