### PR TITLE
stdStorage: support packed variables

### DIFF
--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -82,6 +82,10 @@ library stdStorageSafe {
         return (foundLeft && foundRight, offsetLeft, offsetRight);
     }
 
+    function find(StdStorage storage self) internal returns (FindData storage) {
+        return find(self, true);
+    }
+
     /// @notice find an arbitrary storage slot given a function sig, input data, address of the contract and a value to check against
     // slot complexity:
     //  if flat, will be bytes32(uint256(uint));

--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -75,7 +75,7 @@ library stdStorageSafe {
         (bool foundLeft, uint256 offsetLeft) = findOffset(self, slot, cald, true);
         (bool foundRight, uint256 offsetRight) = findOffset(self, slot, cald, false);
 
-        // `findOffset` may mutate slot value, so we are setting in to initial value
+        // `findOffset` may mutate slot value, so we are setting it to initial value
         vm.store(self._target, slot, prevSlotValue);
         return (foundLeft && foundRight, offsetLeft, offsetRight);
     }
@@ -352,9 +352,9 @@ library stdStorage {
             );
         }
         uint256 curVal = uint256(vm.load(who, bytes32(data.slot)));
-        // <value> followed by `offserRight` zeroes
+        // <value> followed by `offsetRight` zeroes
         uint256 mask = uint256(set) << data.offsetRight;
-        // `offsetLeft` ones + `256 - offsetLeft - offsetRight` zeroes + `offsetRight`
+        // `offsetLeft` ones + `256 - offsetLeft - offsetRight` zeroes + `offsetRight` ones
         uint256 helperMask = ~(
             (type(uint256).max - ((1 << data.offsetRight) - 1))
                 - (((1 << data.offsetLeft) - 1) << (256 - data.offsetLeft))

--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -38,8 +38,8 @@ library stdStorageSafe {
         bytes32 fdat;
     }
 
-    /// @notice tries to find values of `offsetLeft` and `offsetRight` such 
-    /// that return value of the given call exactly matches value of 
+    /// @notice tries to find values of `offsetLeft` and `offsetRight` such
+    /// that return value of the given call exactly matches value of
     /// given_slot[offsetLeft:-offsetRight]
     function findOffset(StdStorage storage self, bytes32 slot, bytes memory cald)
         public
@@ -73,8 +73,8 @@ library stdStorageSafe {
                 uint256 new_val;
                 {
                     // `offsetLeft` zeroes + (256 - offsetRight - offsetLeft) ones + `offsetRight` zeroes
-                    uint256 mask = (type(uint256).max - ((1 << offsetRight) - 1))
-                        & ~((2 ** offsetLeft - 1) << (256 - offsetLeft));
+                    uint256 mask =
+                        (type(uint256).max - ((1 << offsetRight) - 1)) & ~((2 ** offsetLeft - 1) << (256 - offsetLeft));
 
                     if (((uint256(vars.prev) & mask) >> offsetRight) != uint256(vars.prevData)) {
                         continue;

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.7.0 <0.9.0;
 import "../src/StdCheats.sol";
 import "../src/Test.sol";
 import "../src/StdJson.sol";
+import "../src/interfaces/IERC20.sol";
 
 contract StdCheatsTest is Test {
     Bar test;
@@ -506,6 +507,15 @@ contract StdCheatsForkTest is Test {
     function testFuzz_AssumeNotBlacklisted_USDT(address addr) external {
         assumeNotBlacklisted(USDT, addr);
         assertFalse(USDTLike(USDT).isBlackListed(addr));
+    }
+
+    function test_dealUSDC() external {
+        // roll fork to the point when USDC contract updated to store balance in packed slots
+        vm.rollFork(19279215);
+
+        uint256 balance = 100e6;
+        deal(USDC, address(this), balance);
+        assertEq(IERC20(USDC).balanceOf(address(this)), balance);
     }
 }
 

--- a/test/StdStorage.t.sol
+++ b/test/StdStorage.t.sol
@@ -179,10 +179,12 @@ contract StdStorageTest is Test {
     }
 
     function testFuzz_StorageCheckedWriteMapPacked(address addr, uint128 value) public {
-        stdstore.target(address(test)).sig(test.read_struct_lower.selector).with_key(addr).checked_write(value);
+        stdstore.enable_packed_slots().target(address(test)).sig(test.read_struct_lower.selector).with_key(addr)
+            .checked_write(value);
         assertEq(test.read_struct_lower(addr), value);
 
-        stdstore.target(address(test)).sig(test.read_struct_upper.selector).with_key(addr).checked_write(value);
+        stdstore.enable_packed_slots().target(address(test)).sig(test.read_struct_upper.selector).with_key(addr)
+            .checked_write(value);
         assertEq(test.read_struct_upper(addr), value);
     }
 
@@ -202,10 +204,10 @@ contract StdStorageTest is Test {
     }
 
     function testFuzz_StorageNativePack(uint248 val1, uint248 val2, bool boolVal1, bool boolVal2) public {
-        stdstore.target(address(test)).sig(test.tA.selector).checked_write(val1);
-        stdstore.target(address(test)).sig(test.tB.selector).checked_write(boolVal1);
-        stdstore.target(address(test)).sig(test.tC.selector).checked_write(boolVal2);
-        stdstore.target(address(test)).sig(test.tD.selector).checked_write(val2);
+        stdstore.enable_packed_slots().target(address(test)).sig(test.tA.selector).checked_write(val1);
+        stdstore.enable_packed_slots().target(address(test)).sig(test.tB.selector).checked_write(boolVal1);
+        stdstore.enable_packed_slots().target(address(test)).sig(test.tC.selector).checked_write(boolVal2);
+        stdstore.enable_packed_slots().target(address(test)).sig(test.tD.selector).checked_write(val2);
 
         assertEq(test.tA(), val1);
         assertEq(test.tB(), boolVal1);
@@ -284,15 +286,16 @@ contract StdStorageTest is Test {
 
         // Pack all values into the slot.
         for (uint256 i = 0; i < nvars; i++) {
-            stdstore.target(address(test)).sig("getRandomPacked(uint256,uint256)").with_key(sizes[i]).with_key(
-                offsets[i]
-            ).checked_write(vals[i]);
+            stdstore.enable_packed_slots().target(address(test)).sig("getRandomPacked(uint256,uint256)").with_key(
+                sizes[i]
+            ).with_key(offsets[i]).checked_write(vals[i]);
         }
 
         // Verify the read data matches.
         for (uint256 i = 0; i < nvars; i++) {
-            uint256 readVal = stdstore.target(address(test)).sig("getRandomPacked(uint256,uint256)").with_key(sizes[i])
-                .with_key(offsets[i]).read_uint();
+            uint256 readVal = stdstore.enable_packed_slots().target(address(test)).sig(
+                "getRandomPacked(uint256,uint256)"
+            ).with_key(sizes[i]).with_key(offsets[i]).read_uint();
 
             uint256 retVal = test.getRandomPacked(sizes[i], offsets[i]);
 

--- a/test/StdStorage.t.sol
+++ b/test/StdStorage.t.sol
@@ -251,6 +251,49 @@ contract StdStorageTest is Test {
         int256 val = stdstore.target(address(test)).sig(test.tG.selector).read_int();
         assertEq(val, type(int256).min);
     }
+
+    function testFuzzPacked2(uint256 nvars, uint256 seed) public {
+        // Number of random variables to generate.
+        nvars = bound(nvars, 1, 20);
+
+        // This will decrease as we generate values in the below loop.
+        uint256 bitsRemaining = 256;
+
+        // Generate a random value and size for each variable.
+        uint256[] memory vals = new uint256[](nvars);
+        uint256[] memory sizes = new uint256[](nvars);
+        uint256[] memory offsets = new uint256[](nvars);
+
+        for (uint256 i = 0; i < nvars; i++) {
+            // Generate a random value and size.
+            offsets[i] = i == 0 ? 0 : offsets[i - 1] + sizes[i - 1];
+
+            uint256 nvarsRemaining = nvars - i;
+            uint256 maxVarSize = bitsRemaining - nvarsRemaining + 1;
+            sizes[i] = bound(uint256(keccak256(abi.encodePacked(seed, i + 256))), 1, maxVarSize);
+            bitsRemaining -= sizes[i];
+
+            uint256 maxVal = (1 << sizes[i]) - 1; // Equal to (2 ** size) - 1, but won't revert on overflow for 256 bits.
+            vals[i] = bound(uint256(keccak256(abi.encodePacked(seed, i))), 0, maxVal);
+        }
+
+        // Pack all values into the slot.
+        for (uint256 i = 0; i < nvars; i++) {
+            stdstore.target(address(test)).sig("getRandomPacked(uint8,uint8)").with_key(sizes[i]).with_key(offsets[i])
+                .checked_write(vals[i]);
+        }
+
+        // Verify the read data matches.
+        for (uint256 i = 0; i < nvars; i++) {
+            uint256 readVal = stdstore.target(address(test)).sig("getRandomPacked(uint8,uint8)").with_key(sizes[i])
+                .with_key(offsets[i]).read_uint();
+
+            uint256 retVal = test.getRandomPacked(uint8(sizes[i]), uint8(offsets[i]));
+
+            assertEq(readVal, vals[i]);
+            assertEq(retVal, vals[i]);
+        }
+    }
 }
 
 contract StorageTest {
@@ -281,6 +324,8 @@ contract StorageTest {
     int256 public tG = type(int256).min;
     bool public tH = true;
     bytes32 private tI = ~bytes32(hex"1337");
+
+    uint256 randomPacking;
 
     constructor() {
         basic = UnpackedStruct({a: 1337, b: 1337});
@@ -316,5 +361,25 @@ contract StorageTest {
             pop(staticcall(gas(), sload(tE.slot), 0, 0, 0, 0))
         }
         t = tI;
+    }
+
+    function setRandomPacking(uint256 val) public {
+        randomPacking = val;
+    }
+
+    function setRandomPacking(uint256 val, uint256 size, uint256 offset) public {
+        // Generate mask based on the size of the value
+        uint256 mask = (1 << size) - 1;
+        // Zero out all bits for the word we're about to set
+        uint256 cleanedWord = uint256(randomPacking) & ~(mask << offset);
+        // Place val in the correct spot of the cleaned word
+        randomPacking = cleanedWord | val << offset;
+    }
+
+    function getRandomPacked(uint8 size, uint8 offset) public view returns (uint256) {
+        // Generate mask based on the size of the value
+        uint256 mask = (1 << size) - 1;
+        // Shift to place the bits in the correct position, and use mask to zero out remaining bits
+        return uint256(randomPacking >> offset) & mask;
     }
 }


### PR DESCRIPTION
This was initially designed to fix probles with USDC, but it seems that we are now able to modify pretty much any packed storage variables.

This is still a WIP as I believe binary operations can be rewritten a bit cleaner but it already works.

I've updated some of the negative tests on failing packed variables decoding to being positive.

The solution is to try finding such `offsetLeft` and `offsetRight` for a storage slot, that it's `value[offsetLeft:-offsetRight]` exactly equals the return data of the given function