### PR TITLE
Fix typo in `StdJson.sol` usage comments

### DIFF
--- a/src/StdJson.sol
+++ b/src/StdJson.sol
@@ -9,7 +9,7 @@ import {VmSafe} from "./Vm.sol";
 // To parse:
 // ```
 // using stdJson for string;
-// string memory json = vm.readFile("some_peth");
+// string memory json = vm.readFile("some_path");
 // json.parseUint("<json_path>");
 // ```
 // To write:


### PR DESCRIPTION
Fixed minor typo in `StdJson.sol` (`some_peth` -> `some_path`)

`eth` on the brain, I get it :joy: 