### PR TITLE
fix(StdInvariant): correct `targetArtifactSelector` type

### DIFF
--- a/src/StdInvariant.sol
+++ b/src/StdInvariant.sol
@@ -9,6 +9,11 @@ abstract contract StdInvariant {
         bytes4[] selectors;
     }
 
+    struct FuzzArtifactSelector {
+        string artifact;
+        bytes4[] selectors;
+    }
+
     struct FuzzInterface {
         address addr;
         string[] artifacts;
@@ -22,7 +27,8 @@ abstract contract StdInvariant {
     string[] private _excludedArtifacts;
     string[] private _targetedArtifacts;
 
-    FuzzSelector[] private _targetedArtifactSelectors;
+    FuzzArtifactSelector[] private _targetedArtifactSelectors;
+
     FuzzSelector[] private _targetedSelectors;
 
     FuzzInterface[] private _targetedInterfaces;
@@ -46,7 +52,7 @@ abstract contract StdInvariant {
         _targetedArtifacts.push(newTargetedArtifact_);
     }
 
-    function targetArtifactSelector(FuzzSelector memory newTargetedArtifactSelector_) internal {
+    function targetArtifactSelector(FuzzArtifactSelector memory newTargetedArtifactSelector_) internal {
         _targetedArtifactSelectors.push(newTargetedArtifactSelector_);
     }
 
@@ -85,7 +91,7 @@ abstract contract StdInvariant {
         targetedArtifacts_ = _targetedArtifacts;
     }
 
-    function targetArtifactSelectors() public view returns (FuzzSelector[] memory targetedArtifactSelectors_) {
+    function targetArtifactSelectors() public view returns (FuzzArtifactSelector[] memory targetedArtifactSelectors_) {
         targetedArtifactSelectors_ = _targetedArtifactSelectors;
     }
 


### PR DESCRIPTION
The return type of `targetArtifactSelector` is `(string, bytes4[])[]`.
See: <https://github.com/foundry-rs/foundry/blob/db8ea58ba607075ce0f39bb975a38da6b4889ea1/crates/evm/evm/src/executors/invariant/mod.rs#L377-L379>