### PR TITLE
ci(github): update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
 
@@ -35,6 +35,7 @@ jobs:
           fi
 
       - name: Check compatibility with 0.8.0
+        id: 0.8.0
         if: always()
         run: |
           output=$(forge build --skip test --use solc:0.8.0)
@@ -45,6 +46,7 @@ jobs:
           fi
 
       - name: Check compatibility with 0.7.6
+        id: 0.7.6
         if: always()
         run: |
           output=$(forge build --skip test --use solc:0.7.6)
@@ -55,6 +57,7 @@ jobs:
           fi
 
       - name: Check compatibility with 0.7.0
+        id: 0.7.0
         if: always()
         run: |
           output=$(forge build --skip test --use solc:0.7.0)
@@ -65,6 +68,7 @@ jobs:
           fi
 
       - name: Check compatibility with 0.6.12
+        id: 0.6.12
         if: always()
         run: |
           output=$(forge build --skip test --use solc:0.6.12)
@@ -75,6 +79,7 @@ jobs:
           fi
 
       - name: Check compatibility with 0.6.2
+        id: 0.6.2
         if: always()
         run: |
           output=$(forge build --skip test --use solc:0.6.2)
@@ -104,10 +109,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
 
@@ -120,10 +125,10 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install Foundry
-        uses: onbjerg/foundry-toolchain@v1
+        uses: foundry-rs/foundry-toolchain@v1
         with:
           version: nightly
 


### PR DESCRIPTION
update to correct foundry github action repo  
add identifier to compat checks

Also, shouldn't the Via-IR compilation time checks use the latest solc?