### PR TITLE
Add `vm.prompt` cheatcodes to Vm interface

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -464,12 +464,6 @@ interface VmSafe {
     /// Performs a foreign function call via the terminal.
     function ffi(string[] calldata commandInput) external returns (bytes memory result);
 
-    /// Prompts the user for a string value in the terminal.
-    function prompt(string calldata promptText) external returns (string memory input);
-
-    /// Prompts the user for a hidden string value in the terminal.
-    function promptSecret(string calldata promptText) external returns (string memory input);
-
     /// Given a path, query the file system to get information about a file, directory, etc.
     function fsMetadata(string calldata path) external view returns (FsMetadata memory metadata);
 
@@ -487,6 +481,12 @@ interface VmSafe {
 
     /// Get the path of the current project root.
     function projectRoot() external view returns (string memory path);
+
+    /// Prompts the user for a string value in the terminal.
+    function prompt(string calldata promptText) external returns (string memory input);
+
+    /// Prompts the user for a hidden string value in the terminal.
+    function promptSecret(string calldata promptText) external returns (string memory input);
 
     /// Reads the directory at the given path recursively, up to `maxDepth`.
     /// `maxDepth` defaults to 1, meaning only the direct children of the given directory will be returned.

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -464,6 +464,12 @@ interface VmSafe {
     /// Performs a foreign function call via the terminal.
     function ffi(string[] calldata commandInput) external returns (bytes memory result);
 
+    /// Prompts the user for a string value in the terminal.
+    function prompt(string calldata promptText) external returns (string memory input);
+
+    /// Prompts the user for a hidden string value in the terminal.
+    function promptSecret(string calldata promptText) external returns (string memory input);
+
     /// Given a path, query the file system to get information about a file, directory, etc.
     function fsMetadata(string calldata path) external view returns (FsMetadata memory metadata);
 

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,7 +9,7 @@ contract VmTest is Test {
     // inadvertently moved between Vm and VmSafe. This test must be updated each time a function is
     // added to or removed from Vm or VmSafe.
     function test_interfaceId() public pure {
-        assertEq(type(VmSafe).interfaceId, bytes4(0xce9c7617), "VmSafe");
+        assertEq(type(VmSafe).interfaceId, bytes4(0x97511f22), "VmSafe");
         assertEq(type(Vm).interfaceId, bytes4(0xaf68a970), "Vm");
     }
 }


### PR DESCRIPTION
Following https://github.com/foundry-rs/foundry/pull/7012.

Adding the `vm.prompt` and `vm.promptSecret` cheatcodes to the `Vm.sol` interface.

Fixes #528 