### PR TITLE
feat: Add support for polygon amoy testnet

### DIFF
--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -214,9 +214,6 @@ abstract contract StdChains {
         setChainWithDefaultRpcUrl("arbitrum_nova", ChainData("Arbitrum Nova", 42170, "https://nova.arbitrum.io/rpc"));
         setChainWithDefaultRpcUrl("polygon", ChainData("Polygon", 137, "https://polygon-rpc.com"));
         setChainWithDefaultRpcUrl(
-            "polygon_mumbai", ChainData("Polygon Mumbai", 80001, "https://rpc-mumbai.maticvigil.com")
-        );
-        setChainWithDefaultRpcUrl(
             "polygon_amoy", ChainData("Polygon Amoy", 80002, "https://rpc-amoy.polygon.technology")
         );
         setChainWithDefaultRpcUrl("avalanche", ChainData("Avalanche", 43114, "https://api.avax.network/ext/bc/C/rpc"));

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -216,6 +216,9 @@ abstract contract StdChains {
         setChainWithDefaultRpcUrl(
             "polygon_mumbai", ChainData("Polygon Mumbai", 80001, "https://rpc-mumbai.maticvigil.com")
         );
+        setChainWithDefaultRpcUrl(
+            "polygon_amoy", ChainData("Polygon Amoy", 80002, "https://rpc-amoy.polygon.technology")
+        );
         setChainWithDefaultRpcUrl("avalanche", ChainData("Avalanche", 43114, "https://api.avax.network/ext/bc/C/rpc"));
         setChainWithDefaultRpcUrl(
             "avalanche_fuji", ChainData("Avalanche Fuji", 43113, "https://api.avax-test.network/ext/bc/C/rpc")

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -63,6 +63,7 @@ contract StdChainsTest is Test {
     //     _testRpc("arbitrum_nova");
     //     _testRpc("polygon");
     //     _testRpc("polygon_mumbai");
+    //     _testRpc("polygon_amoy");
     //     _testRpc("avalanche");
     //     _testRpc("avalanche_fuji");
     //     _testRpc("bnb_smart_chain");

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -62,7 +62,6 @@ contract StdChainsTest is Test {
     //     _testRpc("arbitrum_one_goerli");
     //     _testRpc("arbitrum_nova");
     //     _testRpc("polygon");
-    //     _testRpc("polygon_mumbai");
     //     _testRpc("polygon_amoy");
     //     _testRpc("avalanche");
     //     _testRpc("avalanche_fuji");


### PR DESCRIPTION
As Polygon is deprecating Mumbai testnet and preferring the new testnet, Amoy. We are adding supports for Amoy accordingly in the implementation and test file.

Reference:
1. [Polygon Blog]((https://polygon.technology/blog/introducing-the-amoy-testnet-for-polygon-pos))