### PR TITLE
chore: fix bound log

### DIFF
--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -59,7 +59,7 @@ abstract contract StdUtils {
 
     function bound(uint256 x, uint256 min, uint256 max) internal pure virtual returns (uint256 result) {
         result = _bound(x, min, max);
-        console2_log_StdUtils("Bound Result", result);
+        console2_log_StdUtils("Bound result", result);
     }
 
     function _bound(int256 x, int256 min, int256 max) internal pure virtual returns (int256 result) {


### PR DESCRIPTION
Make the logs for `bound(uint256 x, uint256 min, uint256 max)` and `bound(int256 x, int256 min, int256 max)` consistent.