### PR TITLE
feat(cheatcode): promptSecretUint

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -555,6 +555,9 @@ interface VmSafe {
     /// Prompts the user for a hidden string value in the terminal.
     function promptSecret(string calldata promptText) external returns (string memory input);
 
+    /// Prompts the user for hidden uint256 in the terminal (usually pk).
+    function promptSecretUint(string calldata promptText) external returns (uint256);
+
     /// Prompts the user for uint256 in the terminal.
     function promptUint(string calldata promptText) external returns (uint256);
 

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,7 +9,7 @@ contract VmTest is Test {
     // inadvertently moved between Vm and VmSafe. This test must be updated each time a function is
     // added to or removed from Vm or VmSafe.
     function test_interfaceId() public pure {
-        assertEq(type(VmSafe).interfaceId, bytes4(0x1c17c241), "VmSafe");
+        assertEq(type(VmSafe).interfaceId, bytes4(0x3aa0699f), "VmSafe");
         assertEq(type(Vm).interfaceId, bytes4(0xb91a22ba), "Vm");
     }
 }

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,7 +9,7 @@ contract VmTest is Test {
     // inadvertently moved between Vm and VmSafe. This test must be updated each time a function is
     // added to or removed from Vm or VmSafe.
     function test_interfaceId() public pure {
-        assertEq(type(VmSafe).interfaceId, bytes4(0x536a6b28), "VmSafe");
+        assertEq(type(VmSafe).interfaceId, bytes4(0x1c17c241), "VmSafe");
         assertEq(type(Vm).interfaceId, bytes4(0xb91a22ba), "Vm");
     }
 }


### PR DESCRIPTION
Following https://github.com/foundry-rs/foundry/pull/8082, this PR adds `promptSecretUint(string)(uint)` cheatcode to Vm interface.

~PS: I ran vm.py and it results in the interface being out of date with `randomAddress()(address)`, `randomUint()(uint)` & `randomUint(uint,uint)(uint)` methods, let me know if you'd prefer to just include them in this PR.~ nvm, saw 562.