### PR TITLE
fix: add missing console logs

### DIFF
--- a/src/console.sol
+++ b/src/console.sol
@@ -186,6 +186,10 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
     }
 
+    function log(int p0) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(int)", p0));
+    }
+
     function log(string memory p0) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string)", p0));
     }
@@ -216,6 +220,10 @@ library console {
 
     function log(string memory p0, uint p1) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint)", p0, p1));
+    }
+
+    function log(string memory p0, int p1) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,int)", p0, p1));
     }
 
     function log(string memory p0, string memory p1) internal pure {


### PR DESCRIPTION
Ref https://github.com/foundry-rs/forge-std/pull/573#issuecomment-2203315762

I copy pasted the console2 functions to console and replaced `int256` with `int`.
This is the entire diff.