### PR TITLE
fix(StdStorage): check last read slots first

### DIFF
--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -123,7 +123,7 @@ library stdStorageSafe {
         if (reads.length == 0) {
             revert("stdStorage find(StdStorage): No storage use detected for target.");
         } else {
-            for (uint256 i = 0; i < reads.length; i++) {
+            for (uint256 i = reads.length; --i >= 0;) {
                 bytes32 prev = vm.load(who, reads[i]);
                 if (prev == bytes32(0)) {
                     emit WARNING_UninitedSlot(who, uint256(reads[i]));

--- a/test/StdStorage.t.sol
+++ b/test/StdStorage.t.sol
@@ -345,6 +345,11 @@ contract StdStorageTest is Test {
             assertEq(retVal, vals[i]);
         }
     }
+
+    function testEdgeCaseArray() public {
+        stdstore.target(address(test)).sig("edgeCaseArray(uint256)").with_key(uint256(0)).checked_write(1);
+        assertEq(test.edgeCaseArray(0), 1);
+    }
 }
 
 contract StorageTest {
@@ -377,6 +382,9 @@ contract StorageTest {
     bytes32 private tI = ~bytes32(hex"1337");
 
     uint256 randomPacking;
+
+    // Array with length matching values of elements.
+    uint256[] public edgeCaseArray = [3, 3, 3];
 
     constructor() {
         basic = UnpackedStruct({a: 1337, b: 1337});


### PR DESCRIPTION
simple optimization which resolves https://github.com/foundry-rs/forge-std/issues/580 and optimizes slots detection in some cases

It is more likely that slot we are looking for will be one of latest sloads. e.g. if execution went like
```
sload slot_1 <- currently we start from here
sload slot_2
sload slot_3 <- in most of the cases this value is returned
return
```

so this PR simply changes order in which we go through `vm.accesses` output