### PR TITLE
feat: add boundLog to enable log-uniform sampling

### DIFF
--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -87,6 +87,27 @@ abstract contract StdUtils {
         console2_log_StdUtils("Bound result", vm.toString(result));
     }
 
+    function _boundLog(uint256 x, uint8 min, uint8 max) internal pure virtual returns (uint256 result) {
+        require(min <= max, "StdUtils boundLog(uint256,uint8,uint8): Max is less than min.");
+
+        // If x is between min and max, DO NOT return x directly. This is to ensure that the sampling remains uniform in log space
+
+        // select an exponent between [min, max]
+        uint256 range = uint256(max) - uint256(min) + 1;
+        uint256 m0 = min + (x % range);
+
+        // randomize the input value, use it to generate a number between 2 ** m0 and 2 **(m0+1)-1
+        x = uint256(keccak256(abi.encode(x)));
+        uint256 m1 = x % 2 ** max;
+        result = 2 ** m0 + (m1 >> (max - m0));
+
+    }
+
+    function boundLog(uint256 x, uint8 min, uint8 max) internal pure virtual returns (uint256 result) {
+        result = _boundLog(x, min, max);
+        console2_log_StdUtils("Bound (Log) result", result);
+    }
+
     function boundPrivateKey(uint256 privateKey) internal pure virtual returns (uint256 result) {
         result = _bound(privateKey, 1, SECP256K1_ORDER - 1);
     }

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -201,6 +201,37 @@ contract StdUtilsTest is Test {
     }
 
     /*//////////////////////////////////////////////////////////////////////////
+                                     BOUND LOG
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function test_boundLog() public {
+
+        for (uint256 i = 0; i <= 255; ++i) {
+            assertEq(boundLog(0, uint8(0), uint8(i)), 2**0 + ((uint256(keccak256(abi.encode(uint256(0)))) % 2**i) >> i));
+            assertEq(boundLog(i, uint8(0), uint8(i)), 2**i + ((uint256(keccak256(abi.encode(uint256(i)))) % 2**i)));
+
+            assertEq(boundLog(0, uint8(i), uint8(255)), 2**i + ((uint256(keccak256(abi.encode(uint256(0)))) % 2**255) >> (255 - i)));
+
+            assertEq(boundLog(0, uint8(i), uint8(i)), 2**i + (uint256(keccak256(abi.encode(uint256(0)))) % 2**i));
+
+        }
+
+    }
+
+
+    function test_boundLog(uint256 x, uint8 min, uint8 max) public {
+
+        if (min > max) (min, max) = (max, min);
+
+        uint256 result = boundLog(x, min, max);
+
+        assertGe(result, 2 ** min);
+        assertLe(result, max == 255 ? type(uint256).max : 2 ** (max + 1) - 1);
+        assertEq(result, boundLog(x, min, max));
+    }
+
+
+    /*//////////////////////////////////////////////////////////////////////////
                                 BOUND PRIVATE KEY
     //////////////////////////////////////////////////////////////////////////*/
 


### PR DESCRIPTION
Using `bound` to generate random inputs is heavily skewed towards the upper end of the range [see below]. To explore a more balanced distribution of values, users should have the option to sample in log space instead. 

This PR adds `boundLog(uint256 x, uint8 min, uint8 max)`, which generates a random number between [`2**min`, `2**(max+1)-1`] that is uniformly distributed in log space (ie. data generated follows a [log-uniform distribution](https://en.wikipedia.org/wiki/Reciprocal_distribution))

Note: contrarily to `bound`, `boundLog` WILL NOT return `x` when the input `x` is within the provided [`2**min`, `2**(max+1)-1`] bounds. 

## 
`bound` vs `boundLog` sampling between `1` and `2^32`, `N=10**6`
![image](https://github.com/user-attachments/assets/bdc7ce4f-56c8-465d-ab6b-70e8015822db)
