### PR TITLE
🐛 Fix `logMemory` in `safeconsole`

### DIFF
--- a/src/safeconsole.sol
+++ b/src/safeconsole.sol
@@ -11,6 +11,7 @@ library safeconsole {
     function _sendLogPayload(uint256 offset, uint256 size) private pure {
         function(uint256, uint256) internal view fnIn = _sendLogPayloadView;
         function(uint256, uint256) internal pure pureSendLogPayload;
+        /// @solidity memory-safe-assembly
         assembly {
             pureSendLogPayload := fnIn
         }
@@ -18,6 +19,7 @@ library safeconsole {
     }
 
     function _sendLogPayloadView(uint256 offset, uint256 size) private view {
+        /// @solidity memory-safe-assembly
         assembly {
             pop(staticcall(gas(), CONSOLE_ADDR, offset, size, 0x0, 0x0))
         }
@@ -26,6 +28,7 @@ library safeconsole {
     function _memcopy(uint256 fromOffset, uint256 toOffset, uint256 length) private pure {
         function(uint256, uint256, uint256) internal view fnIn = _memcopyView;
         function(uint256, uint256, uint256) internal pure pureMemcopy;
+        /// @solidity memory-safe-assembly
         assembly {
             pureMemcopy := fnIn
         }
@@ -33,6 +36,7 @@ library safeconsole {
     }
 
     function _memcopyView(uint256 fromOffset, uint256 toOffset, uint256 length) private view {
+        /// @solidity memory-safe-assembly
         assembly {
             pop(staticcall(gas(), 0x4, fromOffset, length, toOffset, length))
         }
@@ -44,6 +48,7 @@ library safeconsole {
             bytes32 m0;
             bytes32 m1;
             bytes32 m2;
+            /// @solidity memory-safe-assembly
             assembly {
                 m0 := mload(sub(offset, 0x60))
                 m1 := mload(sub(offset, 0x40))
@@ -54,6 +59,7 @@ library safeconsole {
                 mstore(sub(offset, 0x20), length)
             }
             _sendLogPayload(offset - 0x44, length + 0x44);
+            /// @solidity memory-safe-assembly
             assembly {
                 mstore(sub(offset, 0x60), m0)
                 mstore(sub(offset, 0x40), m1)
@@ -65,12 +71,14 @@ library safeconsole {
             bytes32 m1;
             bytes32 m2;
             uint256 endOffset = offset + length;
+            /// @solidity memory-safe-assembly
             assembly {
                 m0 := mload(add(endOffset, 0x00))
                 m1 := mload(add(endOffset, 0x20))
                 m2 := mload(add(endOffset, 0x40))
             }
             _memcopy(offset, offset + 0x60, length);
+            /// @solidity memory-safe-assembly
             assembly {
                 // Selector of `log(bytes)`.
                 mstore(add(offset, 0x00), 0x0be77f56)
@@ -79,6 +87,7 @@ library safeconsole {
             }
             _sendLogPayload(offset + 0x1c, length + 0x44);
             _memcopy(offset + 0x60, offset, length);
+            /// @solidity memory-safe-assembly
             assembly {
                 mstore(add(endOffset, 0x00), m0)
                 mstore(add(endOffset, 0x20), m1)
@@ -90,6 +99,7 @@ library safeconsole {
     function log(address p0) internal pure {
         bytes32 m0;
         bytes32 m1;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -98,6 +108,7 @@ library safeconsole {
             mstore(0x20, p0)
         }
         _sendLogPayload(0x1c, 0x24);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -107,6 +118,7 @@ library safeconsole {
     function log(bool p0) internal pure {
         bytes32 m0;
         bytes32 m1;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -115,6 +127,7 @@ library safeconsole {
             mstore(0x20, p0)
         }
         _sendLogPayload(0x1c, 0x24);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -124,6 +137,7 @@ library safeconsole {
     function log(uint256 p0) internal pure {
         bytes32 m0;
         bytes32 m1;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -132,6 +146,7 @@ library safeconsole {
             mstore(0x20, p0)
         }
         _sendLogPayload(0x1c, 0x24);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -143,6 +158,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -161,6 +177,7 @@ library safeconsole {
             writeString(0x40, p0)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -173,6 +190,7 @@ library safeconsole {
         bytes32 m0;
         bytes32 m1;
         bytes32 m2;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -183,6 +201,7 @@ library safeconsole {
             mstore(0x40, p1)
         }
         _sendLogPayload(0x1c, 0x44);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -194,6 +213,7 @@ library safeconsole {
         bytes32 m0;
         bytes32 m1;
         bytes32 m2;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -204,6 +224,7 @@ library safeconsole {
             mstore(0x40, p1)
         }
         _sendLogPayload(0x1c, 0x44);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -215,6 +236,7 @@ library safeconsole {
         bytes32 m0;
         bytes32 m1;
         bytes32 m2;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -225,6 +247,7 @@ library safeconsole {
             mstore(0x40, p1)
         }
         _sendLogPayload(0x1c, 0x44);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -238,6 +261,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -258,6 +282,7 @@ library safeconsole {
             writeString(0x60, p1)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -271,6 +296,7 @@ library safeconsole {
         bytes32 m0;
         bytes32 m1;
         bytes32 m2;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -281,6 +307,7 @@ library safeconsole {
             mstore(0x40, p1)
         }
         _sendLogPayload(0x1c, 0x44);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -292,6 +319,7 @@ library safeconsole {
         bytes32 m0;
         bytes32 m1;
         bytes32 m2;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -302,6 +330,7 @@ library safeconsole {
             mstore(0x40, p1)
         }
         _sendLogPayload(0x1c, 0x44);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -313,6 +342,7 @@ library safeconsole {
         bytes32 m0;
         bytes32 m1;
         bytes32 m2;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -323,6 +353,7 @@ library safeconsole {
             mstore(0x40, p1)
         }
         _sendLogPayload(0x1c, 0x44);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -336,6 +367,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -356,6 +388,7 @@ library safeconsole {
             writeString(0x60, p1)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -369,6 +402,7 @@ library safeconsole {
         bytes32 m0;
         bytes32 m1;
         bytes32 m2;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -379,6 +413,7 @@ library safeconsole {
             mstore(0x40, p1)
         }
         _sendLogPayload(0x1c, 0x44);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -390,6 +425,7 @@ library safeconsole {
         bytes32 m0;
         bytes32 m1;
         bytes32 m2;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -400,6 +436,7 @@ library safeconsole {
             mstore(0x40, p1)
         }
         _sendLogPayload(0x1c, 0x44);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -411,6 +448,7 @@ library safeconsole {
         bytes32 m0;
         bytes32 m1;
         bytes32 m2;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -421,6 +459,7 @@ library safeconsole {
             mstore(0x40, p1)
         }
         _sendLogPayload(0x1c, 0x44);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -434,6 +473,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -454,6 +494,7 @@ library safeconsole {
             writeString(0x60, p1)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -469,6 +510,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -489,6 +531,7 @@ library safeconsole {
             writeString(0x60, p0)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -504,6 +547,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -524,6 +568,7 @@ library safeconsole {
             writeString(0x60, p0)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -539,6 +584,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -559,6 +605,7 @@ library safeconsole {
             writeString(0x60, p0)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -576,6 +623,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -599,6 +647,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -615,6 +664,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -627,6 +677,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -640,6 +691,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -652,6 +704,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -665,6 +718,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -677,6 +731,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -692,6 +747,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -714,6 +770,7 @@ library safeconsole {
             writeString(0x80, p2)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -729,6 +786,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -741,6 +799,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -754,6 +813,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -766,6 +826,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -779,6 +840,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -791,6 +853,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -806,6 +869,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -828,6 +892,7 @@ library safeconsole {
             writeString(0x80, p2)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -843,6 +908,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -855,6 +921,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -868,6 +935,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -880,6 +948,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -893,6 +962,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -905,6 +975,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -920,6 +991,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -942,6 +1014,7 @@ library safeconsole {
             writeString(0x80, p2)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -959,6 +1032,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -981,6 +1055,7 @@ library safeconsole {
             writeString(0x80, p1)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -998,6 +1073,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1020,6 +1096,7 @@ library safeconsole {
             writeString(0x80, p1)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1037,6 +1114,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1059,6 +1137,7 @@ library safeconsole {
             writeString(0x80, p1)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1078,6 +1157,7 @@ library safeconsole {
         bytes32 m5;
         bytes32 m6;
         bytes32 m7;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1103,6 +1183,7 @@ library safeconsole {
             writeString(0xc0, p2)
         }
         _sendLogPayload(0x1c, 0xe4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1120,6 +1201,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1132,6 +1214,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1145,6 +1228,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1157,6 +1241,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1170,6 +1255,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1182,6 +1268,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1197,6 +1284,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1219,6 +1307,7 @@ library safeconsole {
             writeString(0x80, p2)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1234,6 +1323,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1246,6 +1336,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1259,6 +1350,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1271,6 +1363,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1284,6 +1377,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1296,6 +1390,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1311,6 +1406,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1333,6 +1429,7 @@ library safeconsole {
             writeString(0x80, p2)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1348,6 +1445,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1360,6 +1458,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1373,6 +1472,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1385,6 +1485,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1398,6 +1499,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1410,6 +1512,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1425,6 +1528,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1447,6 +1551,7 @@ library safeconsole {
             writeString(0x80, p2)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1464,6 +1569,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1486,6 +1592,7 @@ library safeconsole {
             writeString(0x80, p1)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1503,6 +1610,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1525,6 +1633,7 @@ library safeconsole {
             writeString(0x80, p1)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1542,6 +1651,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1564,6 +1674,7 @@ library safeconsole {
             writeString(0x80, p1)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1583,6 +1694,7 @@ library safeconsole {
         bytes32 m5;
         bytes32 m6;
         bytes32 m7;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1608,6 +1720,7 @@ library safeconsole {
             writeString(0xc0, p2)
         }
         _sendLogPayload(0x1c, 0xe4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1625,6 +1738,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1637,6 +1751,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1650,6 +1765,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1662,6 +1778,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1675,6 +1792,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1687,6 +1805,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1702,6 +1821,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1724,6 +1844,7 @@ library safeconsole {
             writeString(0x80, p2)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1739,6 +1860,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1751,6 +1873,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1764,6 +1887,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1776,6 +1900,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1789,6 +1914,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1801,6 +1927,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1816,6 +1943,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1838,6 +1966,7 @@ library safeconsole {
             writeString(0x80, p2)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1853,6 +1982,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1865,6 +1995,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1878,6 +2009,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1890,6 +2022,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1903,6 +2036,7 @@ library safeconsole {
         bytes32 m1;
         bytes32 m2;
         bytes32 m3;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -1915,6 +2049,7 @@ library safeconsole {
             mstore(0x60, p2)
         }
         _sendLogPayload(0x1c, 0x64);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1930,6 +2065,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1952,6 +2088,7 @@ library safeconsole {
             writeString(0x80, p2)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -1969,6 +2106,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -1991,6 +2129,7 @@ library safeconsole {
             writeString(0x80, p1)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2008,6 +2147,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2030,6 +2170,7 @@ library safeconsole {
             writeString(0x80, p1)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2047,6 +2188,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2069,6 +2211,7 @@ library safeconsole {
             writeString(0x80, p1)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2088,6 +2231,7 @@ library safeconsole {
         bytes32 m5;
         bytes32 m6;
         bytes32 m7;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2113,6 +2257,7 @@ library safeconsole {
             writeString(0xc0, p2)
         }
         _sendLogPayload(0x1c, 0xe4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2132,6 +2277,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2154,6 +2300,7 @@ library safeconsole {
             writeString(0x80, p0)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2171,6 +2318,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2193,6 +2341,7 @@ library safeconsole {
             writeString(0x80, p0)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2210,6 +2359,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2232,6 +2382,7 @@ library safeconsole {
             writeString(0x80, p0)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2251,6 +2402,7 @@ library safeconsole {
         bytes32 m5;
         bytes32 m6;
         bytes32 m7;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2276,6 +2428,7 @@ library safeconsole {
             writeString(0xc0, p2)
         }
         _sendLogPayload(0x1c, 0xe4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2295,6 +2448,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2317,6 +2471,7 @@ library safeconsole {
             writeString(0x80, p0)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2334,6 +2489,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2356,6 +2512,7 @@ library safeconsole {
             writeString(0x80, p0)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2373,6 +2530,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2395,6 +2553,7 @@ library safeconsole {
             writeString(0x80, p0)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2414,6 +2573,7 @@ library safeconsole {
         bytes32 m5;
         bytes32 m6;
         bytes32 m7;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2439,6 +2599,7 @@ library safeconsole {
             writeString(0xc0, p2)
         }
         _sendLogPayload(0x1c, 0xe4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2458,6 +2619,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2480,6 +2642,7 @@ library safeconsole {
             writeString(0x80, p0)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2497,6 +2660,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2519,6 +2683,7 @@ library safeconsole {
             writeString(0x80, p0)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2536,6 +2701,7 @@ library safeconsole {
         bytes32 m3;
         bytes32 m4;
         bytes32 m5;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2558,6 +2724,7 @@ library safeconsole {
             writeString(0x80, p0)
         }
         _sendLogPayload(0x1c, 0xa4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2577,6 +2744,7 @@ library safeconsole {
         bytes32 m5;
         bytes32 m6;
         bytes32 m7;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2602,6 +2770,7 @@ library safeconsole {
             writeString(0xc0, p2)
         }
         _sendLogPayload(0x1c, 0xe4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2623,6 +2792,7 @@ library safeconsole {
         bytes32 m5;
         bytes32 m6;
         bytes32 m7;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2648,6 +2818,7 @@ library safeconsole {
             writeString(0xc0, p1)
         }
         _sendLogPayload(0x1c, 0xe4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2669,6 +2840,7 @@ library safeconsole {
         bytes32 m5;
         bytes32 m6;
         bytes32 m7;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2694,6 +2866,7 @@ library safeconsole {
             writeString(0xc0, p1)
         }
         _sendLogPayload(0x1c, 0xe4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2715,6 +2888,7 @@ library safeconsole {
         bytes32 m5;
         bytes32 m6;
         bytes32 m7;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2740,6 +2914,7 @@ library safeconsole {
             writeString(0xc0, p1)
         }
         _sendLogPayload(0x1c, 0xe4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2763,6 +2938,7 @@ library safeconsole {
         bytes32 m7;
         bytes32 m8;
         bytes32 m9;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2791,6 +2967,7 @@ library safeconsole {
             writeString(0x100, p2)
         }
         _sendLogPayload(0x1c, 0x124);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2811,6 +2988,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -2825,6 +3003,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2840,6 +3019,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -2854,6 +3034,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2869,6 +3050,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -2883,6 +3065,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2900,6 +3083,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -2924,6 +3108,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2941,6 +3126,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -2955,6 +3141,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2970,6 +3157,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -2984,6 +3172,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -2999,6 +3188,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3013,6 +3203,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3030,6 +3221,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3054,6 +3246,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3071,6 +3264,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3085,6 +3279,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3100,6 +3295,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3114,6 +3310,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3129,6 +3326,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3143,6 +3341,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3160,6 +3359,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3184,6 +3384,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3203,6 +3404,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3227,6 +3429,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3246,6 +3449,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3270,6 +3474,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3289,6 +3494,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3313,6 +3519,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3334,6 +3541,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3361,6 +3569,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3380,6 +3589,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3394,6 +3604,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3409,6 +3620,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3423,6 +3635,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3438,6 +3651,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3452,6 +3666,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3469,6 +3684,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3493,6 +3709,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3510,6 +3727,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3524,6 +3742,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3539,6 +3758,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3553,6 +3773,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3568,6 +3789,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3582,6 +3804,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3599,6 +3822,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3623,6 +3847,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3640,6 +3865,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3654,6 +3880,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3669,6 +3896,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3683,6 +3911,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3698,6 +3927,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3712,6 +3942,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3729,6 +3960,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3753,6 +3985,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3772,6 +4005,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3796,6 +4030,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3815,6 +4050,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3839,6 +4075,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3858,6 +4095,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3882,6 +4120,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3903,6 +4142,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -3930,6 +4170,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3949,6 +4190,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3963,6 +4205,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -3978,6 +4221,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -3992,6 +4236,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4007,6 +4252,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -4021,6 +4267,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4038,6 +4285,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4062,6 +4310,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4079,6 +4328,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -4093,6 +4343,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4108,6 +4359,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -4122,6 +4374,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4137,6 +4390,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -4151,6 +4405,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4168,6 +4423,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4192,6 +4448,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4209,6 +4466,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -4223,6 +4481,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4238,6 +4497,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -4252,6 +4512,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4267,6 +4528,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -4281,6 +4543,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4298,6 +4561,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4322,6 +4586,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4341,6 +4606,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4365,6 +4631,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4384,6 +4651,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4408,6 +4676,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4427,6 +4696,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4451,6 +4721,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4472,6 +4743,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4499,6 +4771,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4520,6 +4793,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4544,6 +4818,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4563,6 +4838,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4587,6 +4863,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4606,6 +4883,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4630,6 +4908,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4651,6 +4930,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4678,6 +4958,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4699,6 +4980,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4723,6 +5005,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4742,6 +5025,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4766,6 +5050,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4785,6 +5070,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4809,6 +5095,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4830,6 +5117,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4857,6 +5145,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4878,6 +5167,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4902,6 +5192,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4921,6 +5212,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4945,6 +5237,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -4964,6 +5257,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -4988,6 +5282,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5009,6 +5304,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5036,6 +5332,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5059,6 +5356,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5086,6 +5384,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5109,6 +5408,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5136,6 +5436,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5159,6 +5460,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5186,6 +5488,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5211,6 +5514,7 @@ library safeconsole {
         bytes32 m8;
         bytes32 m9;
         bytes32 m10;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5241,6 +5545,7 @@ library safeconsole {
             writeString(0x120, p3)
         }
         _sendLogPayload(0x1c, 0x144);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5262,6 +5567,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5276,6 +5582,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5291,6 +5598,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5305,6 +5613,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5320,6 +5629,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5334,6 +5644,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5351,6 +5662,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5375,6 +5687,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5392,6 +5705,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5406,6 +5720,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5421,6 +5736,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5435,6 +5751,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5450,6 +5767,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5464,6 +5782,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5481,6 +5800,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5505,6 +5825,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5522,6 +5843,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5536,6 +5858,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5551,6 +5874,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5565,6 +5889,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5580,6 +5905,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5594,6 +5920,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5611,6 +5938,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5635,6 +5963,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5654,6 +5983,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5678,6 +6008,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5697,6 +6028,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5721,6 +6053,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5740,6 +6073,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5764,6 +6098,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5785,6 +6120,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5812,6 +6148,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5831,6 +6168,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5845,6 +6183,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5860,6 +6199,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5874,6 +6214,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5889,6 +6230,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5903,6 +6245,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5920,6 +6263,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -5944,6 +6288,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5961,6 +6306,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -5975,6 +6321,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -5990,6 +6337,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6004,6 +6352,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6019,6 +6368,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6033,6 +6383,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6050,6 +6401,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6074,6 +6426,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6091,6 +6444,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6105,6 +6459,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6120,6 +6475,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6134,6 +6490,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6149,6 +6506,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6163,6 +6521,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6180,6 +6539,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6204,6 +6564,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6223,6 +6584,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6247,6 +6609,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6266,6 +6629,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6290,6 +6654,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6309,6 +6674,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6333,6 +6699,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6354,6 +6721,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6381,6 +6749,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6400,6 +6769,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6414,6 +6784,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6429,6 +6800,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6443,6 +6815,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6458,6 +6831,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6472,6 +6846,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6489,6 +6864,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6513,6 +6889,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6530,6 +6907,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6544,6 +6922,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6559,6 +6938,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6573,6 +6953,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6588,6 +6969,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6602,6 +6984,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6619,6 +7002,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6643,6 +7027,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6660,6 +7045,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6674,6 +7060,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6689,6 +7076,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6703,6 +7091,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6718,6 +7107,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -6732,6 +7122,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6749,6 +7140,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6773,6 +7165,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6792,6 +7185,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6816,6 +7210,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6835,6 +7230,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6859,6 +7255,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6878,6 +7275,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6902,6 +7300,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6923,6 +7322,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6950,6 +7350,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -6971,6 +7372,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -6995,6 +7397,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7014,6 +7417,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7038,6 +7442,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7057,6 +7462,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7081,6 +7487,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7102,6 +7509,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7129,6 +7537,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7150,6 +7559,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7174,6 +7584,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7193,6 +7604,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7217,6 +7629,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7236,6 +7649,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7260,6 +7674,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7281,6 +7696,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7308,6 +7724,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7329,6 +7746,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7353,6 +7771,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7372,6 +7791,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7396,6 +7816,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7415,6 +7836,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7439,6 +7861,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7460,6 +7883,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7487,6 +7911,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7510,6 +7935,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7537,6 +7963,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7560,6 +7987,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7587,6 +8015,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7610,6 +8039,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7637,6 +8067,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7662,6 +8093,7 @@ library safeconsole {
         bytes32 m8;
         bytes32 m9;
         bytes32 m10;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7692,6 +8124,7 @@ library safeconsole {
             writeString(0x120, p3)
         }
         _sendLogPayload(0x1c, 0x144);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7713,6 +8146,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -7727,6 +8161,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7742,6 +8177,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -7756,6 +8192,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7771,6 +8208,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -7785,6 +8223,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7802,6 +8241,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7826,6 +8266,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7843,6 +8284,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -7857,6 +8299,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7872,6 +8315,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -7886,6 +8330,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7901,6 +8346,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -7915,6 +8361,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7932,6 +8379,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -7956,6 +8404,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -7973,6 +8422,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -7987,6 +8437,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8002,6 +8453,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8016,6 +8468,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8031,6 +8484,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8045,6 +8499,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8062,6 +8517,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8086,6 +8542,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8105,6 +8562,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8129,6 +8587,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8148,6 +8607,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8172,6 +8632,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8191,6 +8652,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8215,6 +8677,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8236,6 +8699,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8263,6 +8727,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8282,6 +8747,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8296,6 +8762,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8311,6 +8778,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8325,6 +8793,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8340,6 +8809,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8354,6 +8824,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8371,6 +8842,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8395,6 +8867,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8412,6 +8885,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8426,6 +8900,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8441,6 +8916,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8455,6 +8931,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8470,6 +8947,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8484,6 +8962,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8501,6 +8980,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8525,6 +9005,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8542,6 +9023,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8556,6 +9038,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8571,6 +9054,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8585,6 +9069,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8600,6 +9085,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8614,6 +9100,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8631,6 +9118,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8655,6 +9143,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8674,6 +9163,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8698,6 +9188,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8717,6 +9208,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8741,6 +9233,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8760,6 +9253,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8784,6 +9278,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8805,6 +9300,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8832,6 +9328,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8851,6 +9348,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8865,6 +9363,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8880,6 +9379,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8894,6 +9394,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8909,6 +9410,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8923,6 +9425,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8940,6 +9443,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -8964,6 +9468,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -8981,6 +9486,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -8995,6 +9501,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9010,6 +9517,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -9024,6 +9532,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9039,6 +9548,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -9053,6 +9563,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9070,6 +9581,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9094,6 +9606,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9111,6 +9624,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -9125,6 +9639,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9140,6 +9655,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -9154,6 +9670,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9169,6 +9686,7 @@ library safeconsole {
         bytes32 m2;
         bytes32 m3;
         bytes32 m4;
+        /// @solidity memory-safe-assembly
         assembly {
             m0 := mload(0x00)
             m1 := mload(0x20)
@@ -9183,6 +9701,7 @@ library safeconsole {
             mstore(0x80, p3)
         }
         _sendLogPayload(0x1c, 0x84);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9200,6 +9719,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9224,6 +9744,7 @@ library safeconsole {
             writeString(0xa0, p3)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9243,6 +9764,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9267,6 +9789,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9286,6 +9809,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9310,6 +9834,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9329,6 +9854,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9353,6 +9879,7 @@ library safeconsole {
             writeString(0xa0, p2)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9374,6 +9901,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9401,6 +9929,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9422,6 +9951,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9446,6 +9976,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9465,6 +9996,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9489,6 +10021,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9508,6 +10041,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9532,6 +10066,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9553,6 +10088,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9580,6 +10116,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9601,6 +10138,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9625,6 +10163,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9644,6 +10183,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9668,6 +10208,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9687,6 +10228,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9711,6 +10253,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9732,6 +10275,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9759,6 +10303,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9780,6 +10325,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9804,6 +10350,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9823,6 +10370,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9847,6 +10395,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9866,6 +10415,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9890,6 +10440,7 @@ library safeconsole {
             writeString(0xa0, p1)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9911,6 +10462,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9938,6 +10490,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -9961,6 +10514,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -9988,6 +10542,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10011,6 +10566,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10038,6 +10594,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10061,6 +10618,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10088,6 +10646,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10113,6 +10672,7 @@ library safeconsole {
         bytes32 m8;
         bytes32 m9;
         bytes32 m10;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10143,6 +10703,7 @@ library safeconsole {
             writeString(0x120, p3)
         }
         _sendLogPayload(0x1c, 0x144);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10166,6 +10727,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10190,6 +10752,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10209,6 +10772,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10233,6 +10797,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10252,6 +10817,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10276,6 +10842,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10297,6 +10864,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10324,6 +10892,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10345,6 +10914,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10369,6 +10939,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10388,6 +10959,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10412,6 +10984,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10431,6 +11004,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10455,6 +11029,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10476,6 +11051,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10503,6 +11079,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10524,6 +11101,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10548,6 +11126,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10567,6 +11146,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10591,6 +11171,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10610,6 +11191,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10634,6 +11216,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10655,6 +11238,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10682,6 +11266,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10705,6 +11290,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10732,6 +11318,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10755,6 +11342,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10782,6 +11370,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10805,6 +11394,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10832,6 +11422,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10857,6 +11448,7 @@ library safeconsole {
         bytes32 m8;
         bytes32 m9;
         bytes32 m10;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10887,6 +11479,7 @@ library safeconsole {
             writeString(0x120, p3)
         }
         _sendLogPayload(0x1c, 0x144);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10910,6 +11503,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10934,6 +11528,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10953,6 +11548,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -10977,6 +11573,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -10996,6 +11593,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11020,6 +11618,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11041,6 +11640,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11068,6 +11668,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11089,6 +11690,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11113,6 +11715,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11132,6 +11735,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11156,6 +11760,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11175,6 +11780,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11199,6 +11805,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11220,6 +11827,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11247,6 +11855,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11268,6 +11877,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11292,6 +11902,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11311,6 +11922,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11335,6 +11947,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11354,6 +11967,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11378,6 +11992,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11399,6 +12014,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11426,6 +12042,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11449,6 +12066,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11476,6 +12094,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11499,6 +12118,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11526,6 +12146,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11549,6 +12170,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11576,6 +12198,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11601,6 +12224,7 @@ library safeconsole {
         bytes32 m8;
         bytes32 m9;
         bytes32 m10;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11631,6 +12255,7 @@ library safeconsole {
             writeString(0x120, p3)
         }
         _sendLogPayload(0x1c, 0x144);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11654,6 +12279,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11678,6 +12304,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11697,6 +12324,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11721,6 +12349,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11740,6 +12369,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11764,6 +12394,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11785,6 +12416,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11812,6 +12444,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11833,6 +12466,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11857,6 +12491,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11876,6 +12511,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11900,6 +12536,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11919,6 +12556,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11943,6 +12581,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -11964,6 +12603,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -11991,6 +12631,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12012,6 +12653,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12036,6 +12678,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12055,6 +12698,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12079,6 +12723,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12098,6 +12743,7 @@ library safeconsole {
         bytes32 m4;
         bytes32 m5;
         bytes32 m6;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12122,6 +12768,7 @@ library safeconsole {
             writeString(0xa0, p0)
         }
         _sendLogPayload(0x1c, 0xc4);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12143,6 +12790,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12170,6 +12818,7 @@ library safeconsole {
             writeString(0xe0, p3)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12193,6 +12842,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12220,6 +12870,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12243,6 +12894,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12270,6 +12922,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12293,6 +12946,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12320,6 +12974,7 @@ library safeconsole {
             writeString(0xe0, p2)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12345,6 +13000,7 @@ library safeconsole {
         bytes32 m8;
         bytes32 m9;
         bytes32 m10;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12375,6 +13031,7 @@ library safeconsole {
             writeString(0x120, p3)
         }
         _sendLogPayload(0x1c, 0x144);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12400,6 +13057,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12427,6 +13085,7 @@ library safeconsole {
             writeString(0xe0, p1)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12450,6 +13109,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12477,6 +13137,7 @@ library safeconsole {
             writeString(0xe0, p1)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12500,6 +13161,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12527,6 +13189,7 @@ library safeconsole {
             writeString(0xe0, p1)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12552,6 +13215,7 @@ library safeconsole {
         bytes32 m8;
         bytes32 m9;
         bytes32 m10;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12582,6 +13246,7 @@ library safeconsole {
             writeString(0x120, p3)
         }
         _sendLogPayload(0x1c, 0x144);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12607,6 +13272,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12634,6 +13300,7 @@ library safeconsole {
             writeString(0xe0, p1)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12657,6 +13324,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12684,6 +13352,7 @@ library safeconsole {
             writeString(0xe0, p1)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12707,6 +13376,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12734,6 +13404,7 @@ library safeconsole {
             writeString(0xe0, p1)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12759,6 +13430,7 @@ library safeconsole {
         bytes32 m8;
         bytes32 m9;
         bytes32 m10;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12789,6 +13461,7 @@ library safeconsole {
             writeString(0x120, p3)
         }
         _sendLogPayload(0x1c, 0x144);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12814,6 +13487,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12841,6 +13515,7 @@ library safeconsole {
             writeString(0xe0, p1)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12864,6 +13539,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12891,6 +13567,7 @@ library safeconsole {
             writeString(0xe0, p1)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12914,6 +13591,7 @@ library safeconsole {
         bytes32 m6;
         bytes32 m7;
         bytes32 m8;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12941,6 +13619,7 @@ library safeconsole {
             writeString(0xe0, p1)
         }
         _sendLogPayload(0x1c, 0x104);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -12966,6 +13645,7 @@ library safeconsole {
         bytes32 m8;
         bytes32 m9;
         bytes32 m10;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -12996,6 +13676,7 @@ library safeconsole {
             writeString(0x120, p3)
         }
         _sendLogPayload(0x1c, 0x144);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -13023,6 +13704,7 @@ library safeconsole {
         bytes32 m8;
         bytes32 m9;
         bytes32 m10;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -13053,6 +13735,7 @@ library safeconsole {
             writeString(0x120, p2)
         }
         _sendLogPayload(0x1c, 0x144);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -13080,6 +13763,7 @@ library safeconsole {
         bytes32 m8;
         bytes32 m9;
         bytes32 m10;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -13110,6 +13794,7 @@ library safeconsole {
             writeString(0x120, p2)
         }
         _sendLogPayload(0x1c, 0x144);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -13137,6 +13822,7 @@ library safeconsole {
         bytes32 m8;
         bytes32 m9;
         bytes32 m10;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -13167,6 +13853,7 @@ library safeconsole {
             writeString(0x120, p2)
         }
         _sendLogPayload(0x1c, 0x144);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)
@@ -13196,6 +13883,7 @@ library safeconsole {
         bytes32 m10;
         bytes32 m11;
         bytes32 m12;
+        /// @solidity memory-safe-assembly
         assembly {
             function writeString(pos, w) {
                 let length := 0
@@ -13229,6 +13917,7 @@ library safeconsole {
             writeString(0x160, p3)
         }
         _sendLogPayload(0x1c, 0x184);
+        /// @solidity memory-safe-assembly
         assembly {
             mstore(0x00, m0)
             mstore(0x20, m1)

--- a/src/safeconsole.sol
+++ b/src/safeconsole.sol
@@ -48,8 +48,8 @@ library safeconsole {
                 m0 := mload(sub(offset, 0x60))
                 m1 := mload(sub(offset, 0x40))
                 m2 := mload(sub(offset, 0x20))
-                // Selector of `logBytes(bytes)`.
-                mstore(sub(offset, 0x60), 0xe17bf956)
+                // Selector of `log(bytes)`.
+                mstore(sub(offset, 0x60), 0x0be77f56)
                 mstore(sub(offset, 0x40), 0x20)
                 mstore(sub(offset, 0x20), length)
             }
@@ -72,8 +72,8 @@ library safeconsole {
             }
             _memcopy(offset, offset + 0x60, length);
             assembly {
-                // Selector of `logBytes(bytes)`.
-                mstore(add(offset, 0x00), 0xe17bf956)
+                // Selector of `log(bytes)`.
+                mstore(add(offset, 0x00), 0x0be77f56)
                 mstore(add(offset, 0x20), 0x20)
                 mstore(add(offset, 0x40), length)
             }


### PR DESCRIPTION
The `safeconsole.logMemory` method did not work as expected because it was calling the `logBytes(bytes)` method on the console pre-compile and not `log(bytes)`.

I furthermore marked all assembly blocks as "memory safe" as it doesn't change memory and to prevent it from conflicting with certain viaIR optimizations.