### PR TITLE
cheats: fix assume not precompile

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -322,8 +322,8 @@ abstract contract StdCheatsSafe {
         // Note: For some chains like Optimism these are technically predeploys (i.e. bytecode placed at a specific
         // address), but the same rationale for excluding them applies so we include those too.
 
-        // These should be present on all EVM-compatible chains.
-        vm.assume(addr < address(0x1) || addr > address(0x9));
+        // These are reserved by Ethereum and may be on all EVM-compatible chains.
+        vm.assume(addr < address(0x1) || addr > address(0x100));
 
         // forgefmt: disable-start
         if (chainId == 10 || chainId == 420) {

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -323,7 +323,7 @@ abstract contract StdCheatsSafe {
         // address), but the same rationale for excluding them applies so we include those too.
 
         // These are reserved by Ethereum and may be on all EVM-compatible chains.
-        vm.assume(addr < address(0x1) || addr > address(0x100));
+        vm.assume(addr < address(0x1) || addr > address(0xff));
 
         // forgefmt: disable-start
         if (chainId == 10 || chainId == 420) {


### PR DESCRIPTION
After the cancun hardfork, the point evaluation precompile was added at `address(10)` which the `assumeNotPrecompile` implementation did not take into account. Pectra is scheduled to include BLS precompiles and likely more precompiles will be introduced in other future hardforks. We might as well reserve the least significant byte for Ethereum precompiles, as the address space is large and there is no need to make calls from these addresses, and in return code will not break on new EVM specs.

This was causing test failures in the Optimism test suite when we updated the EVM version to cancun.