### PR TITLE
feat: add keyExists to stdJson and stdToml

### DIFF
--- a/src/StdJson.sol
+++ b/src/StdJson.sol
@@ -25,6 +25,10 @@ import {VmSafe} from "./Vm.sol";
 library stdJson {
     VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
 
+    function keyExists(string memory json, string memory key) internal view returns (bool) {
+        return vm.keyExistsJson(json, key);
+    }
+
     function parseRaw(string memory json, string memory key) internal pure returns (bytes memory) {
         return vm.parseJson(json, key);
     }

--- a/src/StdJson.sol
+++ b/src/StdJson.sol
@@ -89,6 +89,106 @@ library stdJson {
         return vm.parseJsonBytesArray(json, key);
     }
 
+    function readUintOr(string memory json, string memory key, uint256 defaultValue) internal view returns (uint256) {
+        return keyExists(json, key) ? readUint(json, key) : defaultValue;
+    }
+
+    function readUintArrayOr(string memory json, string memory key, uint256[] memory defaultValue)
+        internal
+        view
+        returns (uint256[] memory)
+    {
+        return keyExists(json, key) ? readUintArray(json, key) : defaultValue;
+    }
+
+    function readIntOr(string memory json, string memory key, int256 defaultValue) internal view returns (int256) {
+        return keyExists(json, key) ? readInt(json, key) : defaultValue;
+    }
+
+    function readIntArrayOr(string memory json, string memory key, int256[] memory defaultValue)
+        internal
+        view
+        returns (int256[] memory)
+    {
+        return keyExists(json, key) ? readIntArray(json, key) : defaultValue;
+    }
+
+    function readBytes32Or(string memory json, string memory key, bytes32 defaultValue)
+        internal
+        view
+        returns (bytes32)
+    {
+        return keyExists(json, key) ? readBytes32(json, key) : defaultValue;
+    }
+
+    function readBytes32ArrayOr(string memory json, string memory key, bytes32[] memory defaultValue)
+        internal
+        view
+        returns (bytes32[] memory)
+    {
+        return keyExists(json, key) ? readBytes32Array(json, key) : defaultValue;
+    }
+
+    function readStringOr(string memory json, string memory key, string memory defaultValue)
+        internal
+        view
+        returns (string memory)
+    {
+        return keyExists(json, key) ? readString(json, key) : defaultValue;
+    }
+
+    function readStringArrayOr(string memory json, string memory key, string[] memory defaultValue)
+        internal
+        view
+        returns (string[] memory)
+    {
+        return keyExists(json, key) ? readStringArray(json, key) : defaultValue;
+    }
+
+    function readAddressOr(string memory json, string memory key, address defaultValue)
+        internal
+        view
+        returns (address)
+    {
+        return keyExists(json, key) ? readAddress(json, key) : defaultValue;
+    }
+
+    function readAddressArrayOr(string memory json, string memory key, address[] memory defaultValue)
+        internal
+        view
+        returns (address[] memory)
+    {
+        return keyExists(json, key) ? readAddressArray(json, key) : defaultValue;
+    }
+
+    function readBoolOr(string memory json, string memory key, bool defaultValue) internal view returns (bool) {
+        return keyExists(json, key) ? readBool(json, key) : defaultValue;
+    }
+
+    function readBoolArrayOr(string memory json, string memory key, bool[] memory defaultValue)
+        internal
+        view
+        returns (bool[] memory)
+    {
+        return keyExists(json, key) ? readBoolArray(json, key) : defaultValue;
+    }
+
+    function readBytesOr(string memory json, string memory key, bytes memory defaultValue)
+        internal
+        view
+        returns (bytes memory)
+    {
+        return keyExists(json, key) ? readBytes(json, key) : defaultValue;
+    }
+
+    function readBytesArrayOr(string memory json, string memory key, bytes[] memory defaultValue)
+        internal
+        view
+        returns (bytes[] memory)
+    {
+        return keyExists(json, key) ? readBytesArray(json, key) : defaultValue;
+    }
+
     function serialize(string memory jsonKey, string memory rootObject) internal returns (string memory) {
         return vm.serializeJson(jsonKey, rootObject);
     }

--- a/src/StdToml.sol
+++ b/src/StdToml.sol
@@ -89,6 +89,106 @@ library stdToml {
         return vm.parseTomlBytesArray(toml, key);
     }
 
+    function readUintOr(string memory toml, string memory key, uint256 defaultValue) internal view returns (uint256) {
+        return keyExists(toml, key) ? readUint(toml, key) : defaultValue;
+    }
+
+    function readUintArrayOr(string memory toml, string memory key, uint256[] memory defaultValue)
+        internal
+        view
+        returns (uint256[] memory)
+    {
+        return keyExists(toml, key) ? readUintArray(toml, key) : defaultValue;
+    }
+
+    function readIntOr(string memory toml, string memory key, int256 defaultValue) internal view returns (int256) {
+        return keyExists(toml, key) ? readInt(toml, key) : defaultValue;
+    }
+
+    function readIntArrayOr(string memory toml, string memory key, int256[] memory defaultValue)
+        internal
+        view
+        returns (int256[] memory)
+    {
+        return keyExists(toml, key) ? readIntArray(toml, key) : defaultValue;
+    }
+
+    function readBytes32Or(string memory toml, string memory key, bytes32 defaultValue)
+        internal
+        view
+        returns (bytes32)
+    {
+        return keyExists(toml, key) ? readBytes32(toml, key) : defaultValue;
+    }
+
+    function readBytes32ArrayOr(string memory toml, string memory key, bytes32[] memory defaultValue)
+        internal
+        view
+        returns (bytes32[] memory)
+    {
+        return keyExists(toml, key) ? readBytes32Array(toml, key) : defaultValue;
+    }
+
+    function readStringOr(string memory toml, string memory key, string memory defaultValue)
+        internal
+        view
+        returns (string memory)
+    {
+        return keyExists(toml, key) ? readString(toml, key) : defaultValue;
+    }
+
+    function readStringArrayOr(string memory toml, string memory key, string[] memory defaultValue)
+        internal
+        view
+        returns (string[] memory)
+    {
+        return keyExists(toml, key) ? readStringArray(toml, key) : defaultValue;
+    }
+
+    function readAddressOr(string memory toml, string memory key, address defaultValue)
+        internal
+        view
+        returns (address)
+    {
+        return keyExists(toml, key) ? readAddress(toml, key) : defaultValue;
+    }
+
+    function readAddressArrayOr(string memory toml, string memory key, address[] memory defaultValue)
+        internal
+        view
+        returns (address[] memory)
+    {
+        return keyExists(toml, key) ? readAddressArray(toml, key) : defaultValue;
+    }
+
+    function readBoolOr(string memory toml, string memory key, bool defaultValue) internal view returns (bool) {
+        return keyExists(toml, key) ? readBool(toml, key) : defaultValue;
+    }
+
+    function readBoolArrayOr(string memory toml, string memory key, bool[] memory defaultValue)
+        internal
+        view
+        returns (bool[] memory)
+    {
+        return keyExists(toml, key) ? readBoolArray(toml, key) : defaultValue;
+    }
+
+    function readBytesOr(string memory toml, string memory key, bytes memory defaultValue)
+        internal
+        view
+        returns (bytes memory)
+    {
+        return keyExists(toml, key) ? readBytes(toml, key) : defaultValue;
+    }
+
+    function readBytesArrayOr(string memory toml, string memory key, bytes[] memory defaultValue)
+        internal
+        view
+        returns (bytes[] memory)
+    {
+        return keyExists(toml, key) ? readBytesArray(toml, key) : defaultValue;
+    }
+
     function serialize(string memory jsonKey, string memory rootObject) internal returns (string memory) {
         return vm.serializeJson(jsonKey, rootObject);
     }

--- a/src/StdToml.sol
+++ b/src/StdToml.sol
@@ -25,6 +25,10 @@ import {VmSafe} from "./Vm.sol";
 library stdToml {
     VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
 
+    function keyExists(string memory toml, string memory key) internal view returns (bool) {
+        return vm.keyExistsToml(toml, key);
+    }
+
     function parseRaw(string memory toml, string memory key) internal pure returns (bytes memory) {
         return vm.parseToml(toml, key);
     }


### PR DESCRIPTION
Hey @zerosnacks @klkvr can I get a quick review here?

One thing I'm wondering: why are the `keyExists` cheats `view` but the other JSON/TOML parsing cheats are `pure`?