### PR TITLE
feat(console): use correct signatures

### DIFF
--- a/src/console.sol
+++ b/src/console.sol
@@ -38,12 +38,12 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log()"));
     }
 
-    function logInt(int p0) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(int)", p0));
+    function logInt(int256 p0) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(int256)", p0));
     }
 
-    function logUint(uint p0) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
+    function logUint(uint256 p0) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256)", p0));
     }
 
     function logString(string memory p0) internal pure {
@@ -190,12 +190,12 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bytes32)", p0));
     }
 
-    function log(uint p0) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint)", p0));
+    function log(uint256 p0) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256)", p0));
     }
 
-    function log(int p0) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(int)", p0));
+    function log(int256 p0) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(int256)", p0));
     }
 
     function log(string memory p0) internal pure {
@@ -210,28 +210,28 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address)", p0));
     }
 
-    function log(uint p0, uint p1) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint)", p0, p1));
+    function log(uint256 p0, uint256 p1) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256)", p0, p1));
     }
 
-    function log(uint p0, string memory p1) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string)", p0, p1));
+    function log(uint256 p0, string memory p1) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string)", p0, p1));
     }
 
-    function log(uint p0, bool p1) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool)", p0, p1));
+    function log(uint256 p0, bool p1) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool)", p0, p1));
     }
 
-    function log(uint p0, address p1) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address)", p0, p1));
+    function log(uint256 p0, address p1) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address)", p0, p1));
     }
 
-    function log(string memory p0, uint p1) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint)", p0, p1));
+    function log(string memory p0, uint256 p1) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256)", p0, p1));
     }
 
-    function log(string memory p0, int p1) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,int)", p0, p1));
+    function log(string memory p0, int256 p1) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,int256)", p0, p1));
     }
 
     function log(string memory p0, string memory p1) internal pure {
@@ -246,8 +246,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,address)", p0, p1));
     }
 
-    function log(bool p0, uint p1) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint)", p0, p1));
+    function log(bool p0, uint256 p1) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256)", p0, p1));
     }
 
     function log(bool p0, string memory p1) internal pure {
@@ -262,8 +262,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address)", p0, p1));
     }
 
-    function log(address p0, uint p1) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint)", p0, p1));
+    function log(address p0, uint256 p1) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256)", p0, p1));
     }
 
     function log(address p0, string memory p1) internal pure {
@@ -278,88 +278,88 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address,address)", p0, p1));
     }
 
-    function log(uint p0, uint p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint)", p0, p1, p2));
+    function log(uint256 p0, uint256 p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256)", p0, p1, p2));
     }
 
-    function log(uint p0, uint p1, string memory p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string)", p0, p1, p2));
+    function log(uint256 p0, uint256 p1, string memory p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string)", p0, p1, p2));
     }
 
-    function log(uint p0, uint p1, bool p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool)", p0, p1, p2));
+    function log(uint256 p0, uint256 p1, bool p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool)", p0, p1, p2));
     }
 
-    function log(uint p0, uint p1, address p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address)", p0, p1, p2));
+    function log(uint256 p0, uint256 p1, address p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address)", p0, p1, p2));
     }
 
-    function log(uint p0, string memory p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint)", p0, p1, p2));
+    function log(uint256 p0, string memory p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256)", p0, p1, p2));
     }
 
-    function log(uint p0, string memory p1, string memory p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string)", p0, p1, p2));
+    function log(uint256 p0, string memory p1, string memory p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string)", p0, p1, p2));
     }
 
-    function log(uint p0, string memory p1, bool p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool)", p0, p1, p2));
+    function log(uint256 p0, string memory p1, bool p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool)", p0, p1, p2));
     }
 
-    function log(uint p0, string memory p1, address p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address)", p0, p1, p2));
+    function log(uint256 p0, string memory p1, address p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address)", p0, p1, p2));
     }
 
-    function log(uint p0, bool p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint)", p0, p1, p2));
+    function log(uint256 p0, bool p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256)", p0, p1, p2));
     }
 
-    function log(uint p0, bool p1, string memory p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string)", p0, p1, p2));
+    function log(uint256 p0, bool p1, string memory p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string)", p0, p1, p2));
     }
 
-    function log(uint p0, bool p1, bool p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool)", p0, p1, p2));
+    function log(uint256 p0, bool p1, bool p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool)", p0, p1, p2));
     }
 
-    function log(uint p0, bool p1, address p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address)", p0, p1, p2));
+    function log(uint256 p0, bool p1, address p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address)", p0, p1, p2));
     }
 
-    function log(uint p0, address p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint)", p0, p1, p2));
+    function log(uint256 p0, address p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256)", p0, p1, p2));
     }
 
-    function log(uint p0, address p1, string memory p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string)", p0, p1, p2));
+    function log(uint256 p0, address p1, string memory p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string)", p0, p1, p2));
     }
 
-    function log(uint p0, address p1, bool p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool)", p0, p1, p2));
+    function log(uint256 p0, address p1, bool p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool)", p0, p1, p2));
     }
 
-    function log(uint p0, address p1, address p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address)", p0, p1, p2));
+    function log(uint256 p0, address p1, address p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address)", p0, p1, p2));
     }
 
-    function log(string memory p0, uint p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint)", p0, p1, p2));
+    function log(string memory p0, uint256 p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256)", p0, p1, p2));
     }
 
-    function log(string memory p0, uint p1, string memory p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string)", p0, p1, p2));
+    function log(string memory p0, uint256 p1, string memory p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string)", p0, p1, p2));
     }
 
-    function log(string memory p0, uint p1, bool p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool)", p0, p1, p2));
+    function log(string memory p0, uint256 p1, bool p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool)", p0, p1, p2));
     }
 
-    function log(string memory p0, uint p1, address p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address)", p0, p1, p2));
+    function log(string memory p0, uint256 p1, address p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address)", p0, p1, p2));
     }
 
-    function log(string memory p0, string memory p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint)", p0, p1, p2));
+    function log(string memory p0, string memory p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256)", p0, p1, p2));
     }
 
     function log(string memory p0, string memory p1, string memory p2) internal pure {
@@ -374,8 +374,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,address)", p0, p1, p2));
     }
 
-    function log(string memory p0, bool p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint)", p0, p1, p2));
+    function log(string memory p0, bool p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256)", p0, p1, p2));
     }
 
     function log(string memory p0, bool p1, string memory p2) internal pure {
@@ -390,8 +390,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,address)", p0, p1, p2));
     }
 
-    function log(string memory p0, address p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint)", p0, p1, p2));
+    function log(string memory p0, address p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256)", p0, p1, p2));
     }
 
     function log(string memory p0, address p1, string memory p2) internal pure {
@@ -406,24 +406,24 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,address)", p0, p1, p2));
     }
 
-    function log(bool p0, uint p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint)", p0, p1, p2));
+    function log(bool p0, uint256 p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256)", p0, p1, p2));
     }
 
-    function log(bool p0, uint p1, string memory p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string)", p0, p1, p2));
+    function log(bool p0, uint256 p1, string memory p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string)", p0, p1, p2));
     }
 
-    function log(bool p0, uint p1, bool p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool)", p0, p1, p2));
+    function log(bool p0, uint256 p1, bool p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool)", p0, p1, p2));
     }
 
-    function log(bool p0, uint p1, address p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address)", p0, p1, p2));
+    function log(bool p0, uint256 p1, address p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address)", p0, p1, p2));
     }
 
-    function log(bool p0, string memory p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint)", p0, p1, p2));
+    function log(bool p0, string memory p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256)", p0, p1, p2));
     }
 
     function log(bool p0, string memory p1, string memory p2) internal pure {
@@ -438,8 +438,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,address)", p0, p1, p2));
     }
 
-    function log(bool p0, bool p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint)", p0, p1, p2));
+    function log(bool p0, bool p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256)", p0, p1, p2));
     }
 
     function log(bool p0, bool p1, string memory p2) internal pure {
@@ -454,8 +454,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address)", p0, p1, p2));
     }
 
-    function log(bool p0, address p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint)", p0, p1, p2));
+    function log(bool p0, address p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256)", p0, p1, p2));
     }
 
     function log(bool p0, address p1, string memory p2) internal pure {
@@ -470,24 +470,24 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,address)", p0, p1, p2));
     }
 
-    function log(address p0, uint p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint)", p0, p1, p2));
+    function log(address p0, uint256 p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256)", p0, p1, p2));
     }
 
-    function log(address p0, uint p1, string memory p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string)", p0, p1, p2));
+    function log(address p0, uint256 p1, string memory p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string)", p0, p1, p2));
     }
 
-    function log(address p0, uint p1, bool p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool)", p0, p1, p2));
+    function log(address p0, uint256 p1, bool p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool)", p0, p1, p2));
     }
 
-    function log(address p0, uint p1, address p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address)", p0, p1, p2));
+    function log(address p0, uint256 p1, address p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address)", p0, p1, p2));
     }
 
-    function log(address p0, string memory p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint)", p0, p1, p2));
+    function log(address p0, string memory p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256)", p0, p1, p2));
     }
 
     function log(address p0, string memory p1, string memory p2) internal pure {
@@ -502,8 +502,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,address)", p0, p1, p2));
     }
 
-    function log(address p0, bool p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint)", p0, p1, p2));
+    function log(address p0, bool p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256)", p0, p1, p2));
     }
 
     function log(address p0, bool p1, string memory p2) internal pure {
@@ -518,8 +518,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,address)", p0, p1, p2));
     }
 
-    function log(address p0, address p1, uint p2) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint)", p0, p1, p2));
+    function log(address p0, address p1, uint256 p2) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256)", p0, p1, p2));
     }
 
     function log(address p0, address p1, string memory p2) internal pure {
@@ -534,344 +534,344 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,address)", p0, p1, p2));
     }
 
-    function log(uint p0, uint p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint,string)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,uint,address)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, string memory p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string,string)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, string memory p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, string memory p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, string memory p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, string memory p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,string,address)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, string memory p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,string,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, bool p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool,string)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, bool p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, bool p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, bool p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, bool p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,bool,address)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, bool p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, address p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address,string)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, address p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, address p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, address p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, uint p1, address p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,uint,address,address)", p0, p1, p2, p3));
+    function log(uint256 p0, uint256 p1, address p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,uint256,address,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint,string)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,uint,address)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, string memory p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string,string)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, string memory p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, string memory p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, string memory p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, string memory p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,string,address)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, string memory p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,string,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, bool p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool,string)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, bool p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, bool p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, bool p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, bool p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,bool,address)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, bool p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, address p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address,string)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, address p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, address p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, address p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, string memory p1, address p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,string,address,address)", p0, p1, p2, p3));
+    function log(uint256 p0, string memory p1, address p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,string,address,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint,string)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,uint,address)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, string memory p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string,string)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, string memory p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, string memory p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, string memory p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, string memory p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,string,address)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, string memory p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,string,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, bool p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool,string)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, bool p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, bool p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, bool p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, bool p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,bool,address)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, bool p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, address p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address,string)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, address p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, address p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, address p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, bool p1, address p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,bool,address,address)", p0, p1, p2, p3));
+    function log(uint256 p0, bool p1, address p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,bool,address,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint,string)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,uint,address)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, string memory p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string,string)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, string memory p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, string memory p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, string memory p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, string memory p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,string,address)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, string memory p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,string,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, bool p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool,string)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, bool p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, bool p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, bool p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, bool p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,bool,address)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, bool p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address,uint)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, address p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address,string)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, address p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,string)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, address p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address,bool)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, address p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(uint p0, address p1, address p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(uint,address,address,address)", p0, p1, p2, p3));
+    function log(uint256 p0, address p1, address p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(uint256,address,address,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint,uint)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint,string)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint,bool)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,uint,address)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string,uint)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, string memory p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string,string)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, string memory p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, string memory p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string,bool)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, string memory p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, string memory p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,string,address)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, string memory p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,string,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool,uint)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, bool p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool,string)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, bool p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, bool p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool,bool)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, bool p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, bool p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,bool,address)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, bool p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address,uint)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, address p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address,string)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, address p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, address p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address,bool)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, address p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, uint p1, address p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,uint,address,address)", p0, p1, p2, p3));
+    function log(string memory p0, uint256 p1, address p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,uint256,address,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint,uint)", p0, p1, p2, p3));
+    function log(string memory p0, string memory p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint,string)", p0, p1, p2, p3));
+    function log(string memory p0, string memory p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint,bool)", p0, p1, p2, p3));
+    function log(string memory p0, string memory p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint,address)", p0, p1, p2, p3));
+    function log(string memory p0, string memory p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,uint)", p0, p1, p2, p3));
+    function log(string memory p0, string memory p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,string,uint256)", p0, p1, p2, p3));
     }
 
     function log(string memory p0, string memory p1, string memory p2, string memory p3) internal pure {
@@ -886,8 +886,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,string,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,uint)", p0, p1, p2, p3));
+    function log(string memory p0, string memory p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,uint256)", p0, p1, p2, p3));
     }
 
     function log(string memory p0, string memory p1, bool p2, string memory p3) internal pure {
@@ -902,8 +902,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, string memory p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,uint)", p0, p1, p2, p3));
+    function log(string memory p0, string memory p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,string,address,uint256)", p0, p1, p2, p3));
     }
 
     function log(string memory p0, string memory p1, address p2, string memory p3) internal pure {
@@ -918,24 +918,24 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,string,address,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint,uint)", p0, p1, p2, p3));
+    function log(string memory p0, bool p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint,string)", p0, p1, p2, p3));
+    function log(string memory p0, bool p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint,bool)", p0, p1, p2, p3));
+    function log(string memory p0, bool p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint,address)", p0, p1, p2, p3));
+    function log(string memory p0, bool p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,uint)", p0, p1, p2, p3));
+    function log(string memory p0, bool p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,uint256)", p0, p1, p2, p3));
     }
 
     function log(string memory p0, bool p1, string memory p2, string memory p3) internal pure {
@@ -950,8 +950,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,string,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,uint)", p0, p1, p2, p3));
+    function log(string memory p0, bool p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,uint256)", p0, p1, p2, p3));
     }
 
     function log(string memory p0, bool p1, bool p2, string memory p3) internal pure {
@@ -966,8 +966,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, bool p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,uint)", p0, p1, p2, p3));
+    function log(string memory p0, bool p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,uint256)", p0, p1, p2, p3));
     }
 
     function log(string memory p0, bool p1, address p2, string memory p3) internal pure {
@@ -982,24 +982,24 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,bool,address,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint,uint)", p0, p1, p2, p3));
+    function log(string memory p0, address p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint,string)", p0, p1, p2, p3));
+    function log(string memory p0, address p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint,bool)", p0, p1, p2, p3));
+    function log(string memory p0, address p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint,address)", p0, p1, p2, p3));
+    function log(string memory p0, address p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,uint)", p0, p1, p2, p3));
+    function log(string memory p0, address p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,string,uint256)", p0, p1, p2, p3));
     }
 
     function log(string memory p0, address p1, string memory p2, string memory p3) internal pure {
@@ -1014,8 +1014,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,string,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,uint)", p0, p1, p2, p3));
+    function log(string memory p0, address p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,uint256)", p0, p1, p2, p3));
     }
 
     function log(string memory p0, address p1, bool p2, string memory p3) internal pure {
@@ -1030,8 +1030,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(string memory p0, address p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,uint)", p0, p1, p2, p3));
+    function log(string memory p0, address p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(string,address,address,uint256)", p0, p1, p2, p3));
     }
 
     function log(string memory p0, address p1, address p2, string memory p3) internal pure {
@@ -1046,88 +1046,88 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(string,address,address,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint,uint)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint,string)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint,bool)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,uint,address)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string,uint)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, string memory p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string,string)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, string memory p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, string memory p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string,bool)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, string memory p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, string memory p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,string,address)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, string memory p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,string,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool,uint)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, bool p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool,string)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, bool p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, bool p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool,bool)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, bool p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, bool p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,bool,address)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, bool p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address,uint)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, address p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address,string)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, address p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, address p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address,bool)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, address p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, uint p1, address p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,uint,address,address)", p0, p1, p2, p3));
+    function log(bool p0, uint256 p1, address p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,uint256,address,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint,uint)", p0, p1, p2, p3));
+    function log(bool p0, string memory p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint,string)", p0, p1, p2, p3));
+    function log(bool p0, string memory p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint,bool)", p0, p1, p2, p3));
+    function log(bool p0, string memory p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint,address)", p0, p1, p2, p3));
+    function log(bool p0, string memory p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,uint)", p0, p1, p2, p3));
+    function log(bool p0, string memory p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,uint256)", p0, p1, p2, p3));
     }
 
     function log(bool p0, string memory p1, string memory p2, string memory p3) internal pure {
@@ -1142,8 +1142,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,string,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,uint)", p0, p1, p2, p3));
+    function log(bool p0, string memory p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,uint256)", p0, p1, p2, p3));
     }
 
     function log(bool p0, string memory p1, bool p2, string memory p3) internal pure {
@@ -1158,8 +1158,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, string memory p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,uint)", p0, p1, p2, p3));
+    function log(bool p0, string memory p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,uint256)", p0, p1, p2, p3));
     }
 
     function log(bool p0, string memory p1, address p2, string memory p3) internal pure {
@@ -1174,24 +1174,24 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,string,address,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint,uint)", p0, p1, p2, p3));
+    function log(bool p0, bool p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint,string)", p0, p1, p2, p3));
+    function log(bool p0, bool p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint,bool)", p0, p1, p2, p3));
+    function log(bool p0, bool p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint,address)", p0, p1, p2, p3));
+    function log(bool p0, bool p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,uint)", p0, p1, p2, p3));
+    function log(bool p0, bool p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,uint256)", p0, p1, p2, p3));
     }
 
     function log(bool p0, bool p1, string memory p2, string memory p3) internal pure {
@@ -1206,8 +1206,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,string,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,uint)", p0, p1, p2, p3));
+    function log(bool p0, bool p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,uint256)", p0, p1, p2, p3));
     }
 
     function log(bool p0, bool p1, bool p2, string memory p3) internal pure {
@@ -1222,8 +1222,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, bool p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,uint)", p0, p1, p2, p3));
+    function log(bool p0, bool p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,uint256)", p0, p1, p2, p3));
     }
 
     function log(bool p0, bool p1, address p2, string memory p3) internal pure {
@@ -1238,24 +1238,24 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,bool,address,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint,uint)", p0, p1, p2, p3));
+    function log(bool p0, address p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint,string)", p0, p1, p2, p3));
+    function log(bool p0, address p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint,bool)", p0, p1, p2, p3));
+    function log(bool p0, address p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint,address)", p0, p1, p2, p3));
+    function log(bool p0, address p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,uint)", p0, p1, p2, p3));
+    function log(bool p0, address p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,uint256)", p0, p1, p2, p3));
     }
 
     function log(bool p0, address p1, string memory p2, string memory p3) internal pure {
@@ -1270,8 +1270,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,string,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,uint)", p0, p1, p2, p3));
+    function log(bool p0, address p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,uint256)", p0, p1, p2, p3));
     }
 
     function log(bool p0, address p1, bool p2, string memory p3) internal pure {
@@ -1286,8 +1286,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(bool p0, address p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,uint)", p0, p1, p2, p3));
+    function log(bool p0, address p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,uint256)", p0, p1, p2, p3));
     }
 
     function log(bool p0, address p1, address p2, string memory p3) internal pure {
@@ -1302,88 +1302,88 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(bool,address,address,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint,uint)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint,string)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint,bool)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,uint,address)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string,uint)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, string memory p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string,string)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, string memory p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, string memory p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string,bool)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, string memory p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, string memory p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,string,address)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, string memory p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,string,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool,uint)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, bool p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool,string)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, bool p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, bool p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool,bool)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, bool p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, bool p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,bool,address)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, bool p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address,uint)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, address p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address,string)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, address p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, address p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address,bool)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, address p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, uint p1, address p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,uint,address,address)", p0, p1, p2, p3));
+    function log(address p0, uint256 p1, address p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,uint256,address,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint,uint)", p0, p1, p2, p3));
+    function log(address p0, string memory p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint,string)", p0, p1, p2, p3));
+    function log(address p0, string memory p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint,bool)", p0, p1, p2, p3));
+    function log(address p0, string memory p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint,address)", p0, p1, p2, p3));
+    function log(address p0, string memory p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,uint)", p0, p1, p2, p3));
+    function log(address p0, string memory p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,string,uint256)", p0, p1, p2, p3));
     }
 
     function log(address p0, string memory p1, string memory p2, string memory p3) internal pure {
@@ -1398,8 +1398,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,string,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,uint)", p0, p1, p2, p3));
+    function log(address p0, string memory p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,uint256)", p0, p1, p2, p3));
     }
 
     function log(address p0, string memory p1, bool p2, string memory p3) internal pure {
@@ -1414,8 +1414,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, string memory p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,uint)", p0, p1, p2, p3));
+    function log(address p0, string memory p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,string,address,uint256)", p0, p1, p2, p3));
     }
 
     function log(address p0, string memory p1, address p2, string memory p3) internal pure {
@@ -1430,24 +1430,24 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address,string,address,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint,uint)", p0, p1, p2, p3));
+    function log(address p0, bool p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint,string)", p0, p1, p2, p3));
+    function log(address p0, bool p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint,bool)", p0, p1, p2, p3));
+    function log(address p0, bool p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint,address)", p0, p1, p2, p3));
+    function log(address p0, bool p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,uint)", p0, p1, p2, p3));
+    function log(address p0, bool p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,uint256)", p0, p1, p2, p3));
     }
 
     function log(address p0, bool p1, string memory p2, string memory p3) internal pure {
@@ -1462,8 +1462,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,string,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,uint)", p0, p1, p2, p3));
+    function log(address p0, bool p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,uint256)", p0, p1, p2, p3));
     }
 
     function log(address p0, bool p1, bool p2, string memory p3) internal pure {
@@ -1478,8 +1478,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, bool p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,uint)", p0, p1, p2, p3));
+    function log(address p0, bool p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,uint256)", p0, p1, p2, p3));
     }
 
     function log(address p0, bool p1, address p2, string memory p3) internal pure {
@@ -1494,24 +1494,24 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address,bool,address,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, uint p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint,uint)", p0, p1, p2, p3));
+    function log(address p0, address p1, uint256 p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,uint256)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, uint p2, string memory p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint,string)", p0, p1, p2, p3));
+    function log(address p0, address p1, uint256 p2, string memory p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,string)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, uint p2, bool p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint,bool)", p0, p1, p2, p3));
+    function log(address p0, address p1, uint256 p2, bool p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,bool)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, uint p2, address p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint,address)", p0, p1, p2, p3));
+    function log(address p0, address p1, uint256 p2, address p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,uint256,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, string memory p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,uint)", p0, p1, p2, p3));
+    function log(address p0, address p1, string memory p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,string,uint256)", p0, p1, p2, p3));
     }
 
     function log(address p0, address p1, string memory p2, string memory p3) internal pure {
@@ -1526,8 +1526,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,string,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, bool p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,uint)", p0, p1, p2, p3));
+    function log(address p0, address p1, bool p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,uint256)", p0, p1, p2, p3));
     }
 
     function log(address p0, address p1, bool p2, string memory p3) internal pure {
@@ -1542,8 +1542,8 @@ library console {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,bool,address)", p0, p1, p2, p3));
     }
 
-    function log(address p0, address p1, address p2, uint p3) internal pure {
-        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,uint)", p0, p1, p2, p3));
+    function log(address p0, address p1, address p2, uint256 p3) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("log(address,address,address,uint256)", p0, p1, p2, p3));
     }
 
     function log(address p0, address p1, address p2, string memory p3) internal pure {


### PR DESCRIPTION
Both Hardhat and Foundry have supported the correct console.log internal signatures for a few years now, and Hardhat is currently looking to remove support for the incorrect signatures entirely. See https://github.com/NomicFoundation/hardhat/pull/5764.

Note that our console.sol has 2 additional functions for `log(int256)` and `log(string,int256)` inherited from `console2`, which were added in https://github.com/foundry-rs/forge-std/pull/253.