### PR TITLE
feat(`vm`): vm.getArtifactPathByCode + vm.getArtifactPathByDeployedCode

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -625,8 +625,11 @@ interface VmSafe {
     /// Given a path, query the file system to get information about a file, directory, etc.
     function fsMetadata(string calldata path) external view returns (FsMetadata memory metadata);
 
-    /// Gets the artifact path from the creation code.
-    function getArtifactPath(bytes calldata creationCode) external view returns (string memory path);
+    /// Gets the artifact path from code (aka. creation code).
+    function getArtifactPathByCode(bytes calldata code) external view returns (string memory path);
+
+    /// Gets the artifact path from deployed code (aka. runtime code).
+    function getArtifactPathByDeployedCode(bytes calldata deployedCode) external view returns (string memory path);
 
     /// Gets the creation bytecode from an artifact file. Takes in the relative path to the json file or the path to the
     /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -625,6 +625,9 @@ interface VmSafe {
     /// Given a path, query the file system to get information about a file, directory, etc.
     function fsMetadata(string calldata path) external view returns (FsMetadata memory metadata);
 
+    /// Gets the artifact path from the creation code.
+    function getArtifactPath(bytes calldata creationCode) external view returns (string memory path);
+
     /// Gets the creation bytecode from an artifact file. Takes in the relative path to the json file or the path to the
     /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
     function getCode(string calldata artifactPath) external view returns (bytes memory creationBytecode);

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,7 +9,7 @@ contract VmTest is Test {
     // inadvertently moved between Vm and VmSafe. This test must be updated each time a function is
     // added to or removed from Vm or VmSafe.
     function test_interfaceId() public pure {
-        assertEq(type(VmSafe).interfaceId, bytes4(0x74d42398), "VmSafe");
+        assertEq(type(VmSafe).interfaceId, bytes4(0xaf0c5aa1), "VmSafe");
         assertEq(type(Vm).interfaceId, bytes4(0xaf15a283), "Vm");
     }
 }

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,7 +9,7 @@ contract VmTest is Test {
     // inadvertently moved between Vm and VmSafe. This test must be updated each time a function is
     // added to or removed from Vm or VmSafe.
     function test_interfaceId() public pure {
-        assertEq(type(VmSafe).interfaceId, bytes4(0xaf0c5aa1), "VmSafe");
+        assertEq(type(VmSafe).interfaceId, bytes4(0xf2259cb1), "VmSafe");
         assertEq(type(Vm).interfaceId, bytes4(0xaf15a283), "Vm");
     }
 }


### PR DESCRIPTION
Companion PR for https://github.com/foundry-rs/foundry/pull/8938

Adds new cheatcode `vm.getArtifactPath(creationCode)`  that lets users get the artifact path (`.json`) from `creationCode` after deployment. 