### PR TITLE
feat: add modifier to run `afterTest` in tests that inherit StdAfterTest

### DIFF
--- a/src/StdAfterTest.sol
+++ b/src/StdAfterTest.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.2 <0.9.0;
+
+// Inheritted by test contracts where afterTest() is needed
+abstract contract StdAfterTest {
+    // This modifier needs to applied to the test after which we want to run the afterTest() function
+    modifier runAftetTest() {
+        _;
+        afterTest();
+    }
+
+    // This is needs to be overriden by the Test contract that inherits this
+    function afterTest() public virtual;
+}


### PR DESCRIPTION
Ref: https://github.com/foundry-rs/forge-std/issues/617 

Implementing this directly in foundry would add unnecessary complexity to `ContractRunner`. See https://github.com/foundry-rs/foundry/pull/8985#issuecomment-2393165001 

This approach is cleaner and easier. 

Implemented the modifier and `afterTest()` fn that needs to be overridden in a separate abstract contract `StdAfterTest`; and not in existing `StdCheatsSafe` as this would break existing tests. Hence, making this feature opt-in.