### PR TITLE
chore: add guidance on running compatibility checks locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Even minor pull requests, such as those fixing wording, are greatly appreciated.
 a good idea to first open an issue describing the change to solicit feedback and guidance. This will increase
 the likelihood of the PR getting merged.
 
-Please also make sure that the following commands pass if you have changed the code:
+Please make sure that the following commands pass if you have changed the code:
 
 ```sh
 forge fmt --check
@@ -96,6 +96,8 @@ forge build --skip test --use solc:0.7.0
 forge build --skip test --use solc:0.7.6
 forge build --skip test --use solc:0.8.0
 ```
+
+The CI will also ensure that the code is formatted correctly and that the tests are passing across all compiler version targets.
 
 #### Adding cheatcodes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,16 @@ forge fmt --check
 forge test -vvv
 ```
 
+To make sure your changes are compatible with all compiler version targets, run the following commands:
+
+```sh
+forge build --skip test --use solc:0.6.2
+forge build --skip test --use solc:0.6.12
+forge build --skip test --use solc:0.7.0
+forge build --skip test --use solc:0.7.6
+forge build --skip test --use solc:0.8.0
+```
+
 #### Adding cheatcodes
 
 Please follow the guide outlined in the [cheatcodes](https://github.com/foundry-rs/foundry/blob/master/docs/dev/cheatcodes.md#adding-a-new-cheatcode) documentation of Foundry.

--- a/README.md
+++ b/README.md
@@ -256,8 +256,8 @@ First, see if the answer to your question can be found in [book](https://book.ge
 If the answer is not there:
 
 -   Join the [support Telegram](https://t.me/foundry_support) to get help, or
--   Open a [discussion](https://github.com/foundry-rs/foundry/discussions/new) with your question, or
--   Open an issue with [the bug](https://github.com/foundry-rs/foundry/issues/new)
+-   Open a [discussion](https://github.com/foundry-rs/foundry/discussions/new/choose) with your question, or
+-   Open an issue with [the bug](https://github.com/foundry-rs/foundry/issues/new/choose)
 
 If you want to contribute, or follow along with contributor discussion, you can use our [main telegram](https://t.me/foundry_rs) to chat with us about the development of Foundry!
 


### PR DESCRIPTION
Closes:  https://github.com/foundry-rs/forge-std/issues/117 

- Add note on testing across compiler version targets locally
- Updates links to point to `choose` panels to enforce issue / discussion templates