### PR TITLE
test: don't expect a specific cheatcode error message

### DIFF
--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -105,9 +105,8 @@ contract StdChainsTest is Test {
         StdChainsMock stdChainsMock = new StdChainsMock();
 
         stdChainsMock.exposed_setChain("needs_undefined_env_var", ChainData("", 123456789, ""));
-        vm.expectRevert(
-            "Failed to resolve env var `UNDEFINED_RPC_URL_PLACEHOLDER` in `${UNDEFINED_RPC_URL_PLACEHOLDER}`: environment variable not found"
-        );
+        // Forge environment variable error.
+        vm.expectRevert();
         stdChainsMock.exposed_getChain("needs_undefined_env_var");
     }
 


### PR DESCRIPTION
There are no stability guarantees about error messages.

This specific error message was changed in https://github.com/foundry-rs/foundry/pull/9353.