### PR TITLE
Update to latest cheatcodes

### DIFF
--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,10 +9,10 @@ import {Vm, VmSafe} from "../src/Vm.sol";
 // added to or removed from Vm or VmSafe.
 contract VmTest is Test {
     function test_VmInterfaceId() public pure {
-        assertEq(type(Vm).interfaceId, bytes4(0xa95c1408), "Vm");
+        assertEq(type(Vm).interfaceId, bytes4(0x21af9696), "Vm");
     }
 
     function test_VmSafeInterfaceId() public pure {
-        assertEq(type(VmSafe).interfaceId, bytes4(0x590bc2b4), "VmSafe");
+        assertEq(type(VmSafe).interfaceId, bytes4(0x92fe99ad), "VmSafe");
     }
 }


### PR DESCRIPTION
- add `delegatecall` flag to `prank` cheatcodes (https://github.com/foundry-rs/foundry/pull/8863)
- support EIP-7702 Delegations (`create/sign/attachDelegation`) (https://github.com/foundry-rs/foundry/pull/9236)
- add `contains` to check if a string contains another string (https://github.com/foundry-rs/foundry/pull/9085)