### PR TITLE
fix: use `vm.getBlockTimestamp` for `skip` and `rewind`

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -645,11 +645,11 @@ abstract contract StdCheats is StdCheatsSafe {
 
     // Skip forward or rewind time by the specified number of seconds
     function skip(uint256 time) internal virtual {
-        vm.warp(block.timestamp + time);
+        vm.warp(vm.getBlockTimestamp() + time);
     }
 
     function rewind(uint256 time) internal virtual {
-        vm.warp(block.timestamp - time);
+        vm.warp(vm.getBlockTimestamp() - time);
     }
 
     // Setup a prank from an address that has some ether


### PR DESCRIPTION
Given that during `via-ir` compilations, the `block.timestamp` variable might be distorted due to optimizations, the more correct way to obtain the block timestamp. See [this discussion](https://github.com/foundry-rs/foundry/issues/1373#issuecomment-2485290776)
