### PR TITLE
Fixing Variable Shadowing in Solidity: uint256 Redeclaration Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ contract TestContract is Test {
 
 contract ErrorsTest {
     function arithmeticError(uint256 a) public {
-        uint256 a = a - 100;
+        a = a - 100;
     }
 }
 ```


### PR DESCRIPTION
The issue arises because the variable `a` is already declared as a parameter of the `arithmeticError` function:

```solidity
function arithmeticError(uint256 a) public {
    uint256 a = a - 100; // Error: `a` is already declared as a parameter
}

When you redeclare a with uint256 a = a - 100;, the compiler throws an error because you're trying to shadow the parameter a by declaring a new variable with the same name. This is not allowed in Solidity.

To fix this, simply remove the type declaration (uint256) and use the parameter a directly:

solidity
Code kopieren

function arithmeticError(uint256 a) public {
    a = a - 100; // Correct: modifies the existing parameter `a`
}

