### PR TITLE
feat: `count` assertion for `expectRevert` 

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -2182,6 +2182,24 @@ interface Vm is VmSafe {
     /// Expects an error from reverter address on next call, that exactly matches the revert data.
     function expectRevert(bytes calldata revertData, address reverter) external;
 
+    /// Expects `count` number of reverts from the upcoming calls with any revert data or reverter.
+    function expectRevert(uint64 count) external;
+
+    /// Expects `count` number of reverts from the upcoming calls that match the revert data.
+    function expectRevert(bytes4 revertData, uint64 count) external;
+
+    /// Expects `count` number of reverts from the upcoming calls that exactly match the revert data.
+    function expectRevert(bytes calldata revertData, uint64 count) external;
+
+    /// Expects `count` number of reverts from the upcoming calls from the reverter address.
+    function expectRevert(address reverter, uint64 count) external;
+
+    /// Expects `count` number of reverts from the upcoming calls from the reverter address that match the revert data.
+    function expectRevert(bytes4 revertData, address reverter, uint64 count) external;
+
+    /// Expects `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.
+    function expectRevert(bytes calldata revertData, address reverter, uint64 count) external;
+
     /// Only allows memory writes to offsets [0x00, 0x60) ∪ [min, max) in the current subcontext. If any other
     /// memory is written to, the test will fail. Can be called multiple times to add more ranges to the set.
     function expectSafeMemory(uint64 min, uint64 max) external;

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,7 +9,7 @@ import {Vm, VmSafe} from "../src/Vm.sol";
 // added to or removed from Vm or VmSafe.
 contract VmTest is Test {
     function test_VmInterfaceId() public pure {
-        assertEq(type(Vm).interfaceId, bytes4(0x21af9696), "Vm");
+        assertEq(type(Vm).interfaceId, bytes4(0xbe425eb2), "Vm");
     }
 
     function test_VmSafeInterfaceId() public pure {


### PR DESCRIPTION
Ref: https://github.com/foundry-rs/foundry/pull/9484

```solidity

    /// Expects `count` number of reverts from the upcoming calls with any revert data or reverter.
    function expectRevert(uint64 count) external;

    /// Expects `count` number of reverts from the upcoming calls that match the revert data.
    function expectRevert(bytes4 revertData, uint64 count) external;

    /// Expects `count` number of reverts from the upcoming calls that exactly match the revert data.
    function expectRevert(bytes calldata revertData, uint64 count) external;

    /// Expects `count` number of reverts from the upcoming calls from the reverter address.
    function expectRevert(address reverter, uint64 count) external;

    /// Expects `count` number of reverts from the upcoming calls from the reverter address that match the revert data.
    function expectRevert(bytes4 revertData, address reverter, uint64 count) external;

    /// Expects `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.
    function expectRevert(bytes calldata revertData, address reverter, uint64 count) external;
```