### PR TITLE
feat: new cheatcode `assumeUnusedAddress`

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -351,7 +351,7 @@ abstract contract StdCheatsSafe {
 
     function assumeEmptyAddress(address addr) internal view virtual {
         uint256 size;
-        assembly ("memory-safe") {
+        assembly {
             size := extcodesize(addr)
         }
         vm.assume(size == 0);

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -350,7 +350,12 @@ abstract contract StdCheatsSafe {
     }
 
     function assumeEmptyAddress(address addr) internal view virtual {
-        vm.assume(addr.code.length == 0);
+        uint256 size;
+        assembly ("memory-safe") {
+            size := extcodesize(addr)
+        }
+        vm.assume(size == 0);
+
         assumeNotPrecompile(addr);
         assumeNotZeroAddress(addr);
         assumeNotForgeAddress(addr);

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -349,7 +349,7 @@ abstract contract StdCheatsSafe {
         );
     }
 
-    function assumeEmptyAddress(address addr) internal pure virtual {
+    function assumeEmptyAddress(address addr) internal view virtual {
         vm.assume(addr.code.length == 0);
         assumeNotPrecompile(addr);
         assumeNotZeroAddress(addr);

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -349,6 +349,13 @@ abstract contract StdCheatsSafe {
         );
     }
 
+    function assumeEmptyAddress(address addr) internal pure virtual {
+        vm.assume(addr.code.length == 0);
+        assumeNotPrecompile(addr);
+        assumeNotZeroAddress(addr);
+        assumeNotForgeAddress(addr);
+    }
+
     function readEIP1559ScriptArtifact(string memory path)
         internal
         view

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -349,7 +349,7 @@ abstract contract StdCheatsSafe {
         );
     }
 
-    function assumeEmptyAddress(address addr) internal view virtual {
+    function assumeUnusedAddress(address addr) internal view virtual {
         uint256 size;
         assembly {
             size := extcodesize(addr)


### PR DESCRIPTION
Sometimes during fuzzing we want to test with a wide range of addresses, but these address need to be empty and not already have contracts deployed. This cheatcode would come in handy for that. 

Any suggestions if other overloads are necessary for extended use cases? 