### PR TITLE
feat: Add prank signatures with bool delegatecall

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -1761,6 +1761,15 @@ interface Vm is VmSafe {
     /// Sets the *next* call's `msg.sender` to be the input address, and the `tx.origin` to be the second input.
     function prank(address msgSender, address txOrigin) external;
 
+    /// Sets the *next* call's `msg.sender` to be the input address.
+    /// Makes a delegatecall if `delegateCall` is true.
+    function prank(address msgSender, bool delegateCall) external;
+
+    /// Sets the *next* call's `msg.sender` to be the input address.
+    /// Sets the `tx.origin` to be the second input.
+    /// Makes a delegatecall if `delegateCall` is true.
+    function prank(address msgSender, address txOrigin, bool delegateCall) external;
+
     /// Sets `block.prevrandao`.
     /// Not available on EVM versions before Paris. Use `difficulty` instead.
     /// If used on unsupported EVM versions it will revert.

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,7 +9,7 @@ import {Vm, VmSafe} from "../src/Vm.sol";
 // added to or removed from Vm or VmSafe.
 contract VmTest is Test {
     function test_VmInterfaceId() public pure {
-        assertEq(type(Vm).interfaceId, bytes4(0xa561dbe8), "Vm");
+        assertEq(type(Vm).interfaceId, bytes4(0x7feab4f6), "Vm");
     }
 
     function test_VmSafeInterfaceId() public pure {


### PR DESCRIPTION
Updates vm.sol to add function signatures for delegatecall pranking.