### PR TITLE
refactor: order functions by visibility (public, internal, private)

### DIFF
--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -132,6 +132,10 @@ abstract contract StdChains {
         setChain(chainAlias, ChainData({name: chain.name, chainId: chain.chainId, rpcUrl: chain.rpcUrl}));
     }
 
+    function setFallbackToDefaultRpcUrls(bool useDefault) internal {
+        fallbackToDefaultRpcUrls = useDefault;
+    }
+
     function _toUpper(string memory str) private pure returns (string memory) {
         bytes memory strb = bytes(str);
         bytes memory copy = new bytes(strb.length);
@@ -183,10 +187,6 @@ abstract contract StdChains {
             }
         }
         return chain;
-    }
-
-    function setFallbackToDefaultRpcUrls(bool useDefault) internal {
-        fallbackToDefaultRpcUrls = useDefault;
     }
 
     function initializeStdChains() private {

--- a/src/StdInvariant.sol
+++ b/src/StdInvariant.sol
@@ -34,49 +34,6 @@ abstract contract StdInvariant {
 
     FuzzInterface[] private _targetedInterfaces;
 
-    // Functions for users:
-    // These are intended to be called in tests.
-
-    function excludeContract(address newExcludedContract_) internal {
-        _excludedContracts.push(newExcludedContract_);
-    }
-
-    function excludeSelector(FuzzSelector memory newExcludedSelector_) internal {
-        _excludedSelectors.push(newExcludedSelector_);
-    }
-
-    function excludeSender(address newExcludedSender_) internal {
-        _excludedSenders.push(newExcludedSender_);
-    }
-
-    function excludeArtifact(string memory newExcludedArtifact_) internal {
-        _excludedArtifacts.push(newExcludedArtifact_);
-    }
-
-    function targetArtifact(string memory newTargetedArtifact_) internal {
-        _targetedArtifacts.push(newTargetedArtifact_);
-    }
-
-    function targetArtifactSelector(FuzzArtifactSelector memory newTargetedArtifactSelector_) internal {
-        _targetedArtifactSelectors.push(newTargetedArtifactSelector_);
-    }
-
-    function targetContract(address newTargetedContract_) internal {
-        _targetedContracts.push(newTargetedContract_);
-    }
-
-    function targetSelector(FuzzSelector memory newTargetedSelector_) internal {
-        _targetedSelectors.push(newTargetedSelector_);
-    }
-
-    function targetSender(address newTargetedSender_) internal {
-        _targetedSenders.push(newTargetedSender_);
-    }
-
-    function targetInterface(FuzzInterface memory newTargetedInterface_) internal {
-        _targetedInterfaces.push(newTargetedInterface_);
-    }
-
     // Functions for forge:
     // These are called by forge to run invariant tests and don't need to be called in tests.
 
@@ -118,5 +75,48 @@ abstract contract StdInvariant {
 
     function targetInterfaces() public view returns (FuzzInterface[] memory targetedInterfaces_) {
         targetedInterfaces_ = _targetedInterfaces;
+    }
+
+    // Functions for users:
+    // These are intended to be called in tests.
+
+    function excludeContract(address newExcludedContract_) internal {
+        _excludedContracts.push(newExcludedContract_);
+    }
+
+    function excludeSelector(FuzzSelector memory newExcludedSelector_) internal {
+        _excludedSelectors.push(newExcludedSelector_);
+    }
+
+    function excludeSender(address newExcludedSender_) internal {
+        _excludedSenders.push(newExcludedSender_);
+    }
+
+    function excludeArtifact(string memory newExcludedArtifact_) internal {
+        _excludedArtifacts.push(newExcludedArtifact_);
+    }
+
+    function targetArtifact(string memory newTargetedArtifact_) internal {
+        _targetedArtifacts.push(newTargetedArtifact_);
+    }
+
+    function targetArtifactSelector(FuzzArtifactSelector memory newTargetedArtifactSelector_) internal {
+        _targetedArtifactSelectors.push(newTargetedArtifactSelector_);
+    }
+
+    function targetContract(address newTargetedContract_) internal {
+        _targetedContracts.push(newTargetedContract_);
+    }
+
+    function targetSelector(FuzzSelector memory newTargetedSelector_) internal {
+        _targetedSelectors.push(newTargetedSelector_);
+    }
+
+    function targetSender(address newTargetedSender_) internal {
+        _targetedSenders.push(newTargetedSender_);
+    }
+
+    function targetInterface(FuzzInterface memory newTargetedInterface_) internal {
+        _targetedInterfaces.push(newTargetedInterface_);
     }
 }

--- a/src/StdStyle.sol
+++ b/src/StdStyle.sol
@@ -19,10 +19,6 @@ library StdStyle {
     string constant INVERSE = "\u001b[7m";
     string constant RESET = "\u001b[0m";
 
-    function styleConcat(string memory style, string memory self) private pure returns (string memory) {
-        return string(abi.encodePacked(style, self, RESET));
-    }
-
     function red(string memory self) internal pure returns (string memory) {
         return styleConcat(RED, self);
     }
@@ -329,5 +325,9 @@ library StdStyle {
 
     function inverseBytes32(bytes32 self) internal pure returns (string memory) {
         return inverse(vm.toString(self));
+    }
+
+    function styleConcat(string memory style, string memory self) private pure returns (string memory) {
+        return string(abi.encodePacked(style, self, RESET));
     }
 }

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -160,14 +160,6 @@ abstract contract StdUtils {
         }
     }
 
-    /*//////////////////////////////////////////////////////////////////////////
-                                 PRIVATE FUNCTIONS
-    //////////////////////////////////////////////////////////////////////////*/
-
-    function addressFromLast20Bytes(bytes32 bytesValue) private pure returns (address) {
-        return address(uint160(uint256(bytesValue)));
-    }
-
     // This section is used to prevent the compilation of console, which shortens the compilation time when console is
     // not used elsewhere. We also trick the compiler into letting us make the console log methods as `pure` to avoid
     // any breaking changes to function signatures.
@@ -183,6 +175,14 @@ abstract contract StdUtils {
 
     function _sendLogPayload(bytes memory payload) internal pure {
         _castLogPayloadViewToPure(_sendLogPayloadView)(payload);
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                 PRIVATE FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    function addressFromLast20Bytes(bytes32 bytesValue) private pure returns (address) {
+        return address(uint160(uint256(bytesValue)));
     }
 
     function _sendLogPayloadView(bytes memory payload) private view {

--- a/src/safeconsole.sol
+++ b/src/safeconsole.sol
@@ -6,42 +6,6 @@ pragma solidity >=0.6.2 <0.9.0;
 library safeconsole {
     uint256 constant CONSOLE_ADDR = 0x000000000000000000000000000000000000000000636F6e736F6c652e6c6f67;
 
-    // Credit to [0age](https://twitter.com/z0age/status/1654922202930888704) and [0xdapper](https://github.com/foundry-rs/forge-std/pull/374)
-    // for the view-to-pure log trick.
-    function _sendLogPayload(uint256 offset, uint256 size) private pure {
-        function(uint256, uint256) internal view fnIn = _sendLogPayloadView;
-        function(uint256, uint256) internal pure pureSendLogPayload;
-        /// @solidity memory-safe-assembly
-        assembly {
-            pureSendLogPayload := fnIn
-        }
-        pureSendLogPayload(offset, size);
-    }
-
-    function _sendLogPayloadView(uint256 offset, uint256 size) private view {
-        /// @solidity memory-safe-assembly
-        assembly {
-            pop(staticcall(gas(), CONSOLE_ADDR, offset, size, 0x0, 0x0))
-        }
-    }
-
-    function _memcopy(uint256 fromOffset, uint256 toOffset, uint256 length) private pure {
-        function(uint256, uint256, uint256) internal view fnIn = _memcopyView;
-        function(uint256, uint256, uint256) internal pure pureMemcopy;
-        /// @solidity memory-safe-assembly
-        assembly {
-            pureMemcopy := fnIn
-        }
-        pureMemcopy(fromOffset, toOffset, length);
-    }
-
-    function _memcopyView(uint256 fromOffset, uint256 toOffset, uint256 length) private view {
-        /// @solidity memory-safe-assembly
-        assembly {
-            pop(staticcall(gas(), 0x4, fromOffset, length, toOffset, length))
-        }
-    }
-
     function logMemory(uint256 offset, uint256 length) internal pure {
         if (offset >= 0x60) {
             // Sufficient memory before slice to prepare call header.
@@ -13932,6 +13896,42 @@ library safeconsole {
             mstore(0x140, m10)
             mstore(0x160, m11)
             mstore(0x180, m12)
+        }
+    }
+
+    // Credit to [0age](https://twitter.com/z0age/status/1654922202930888704) and [0xdapper](https://github.com/foundry-rs/forge-std/pull/374)
+    // for the view-to-pure log trick.
+    function _sendLogPayload(uint256 offset, uint256 size) private pure {
+        function(uint256, uint256) internal view fnIn = _sendLogPayloadView;
+        function(uint256, uint256) internal pure pureSendLogPayload;
+        /// @solidity memory-safe-assembly
+        assembly {
+            pureSendLogPayload := fnIn
+        }
+        pureSendLogPayload(offset, size);
+    }
+
+    function _sendLogPayloadView(uint256 offset, uint256 size) private view {
+        /// @solidity memory-safe-assembly
+        assembly {
+            pop(staticcall(gas(), CONSOLE_ADDR, offset, size, 0x0, 0x0))
+        }
+    }
+
+    function _memcopy(uint256 fromOffset, uint256 toOffset, uint256 length) private pure {
+        function(uint256, uint256, uint256) internal view fnIn = _memcopyView;
+        function(uint256, uint256, uint256) internal pure pureMemcopy;
+        /// @solidity memory-safe-assembly
+        assembly {
+            pureMemcopy := fnIn
+        }
+        pureMemcopy(fromOffset, toOffset, length);
+    }
+
+    function _memcopyView(uint256 fromOffset, uint256 toOffset, uint256 length) private view {
+        /// @solidity memory-safe-assembly
+        assembly {
+            pop(staticcall(gas(), 0x4, fromOffset, length, toOffset, length))
         }
     }
 }


### PR DESCRIPTION
## Refactor Function Ordering by Visibility Modifiers

## Description

This PR addresses one of the goals outlined in issue #653

- Reorganization of functions according to visibility modifiers (Move internal functions up, private functions down)

## Changes Made

- Refactored function ordering in contracts to follow a consistent pattern:
  - Public->internal->private
- Maintained functionality without changing any function signatures or behavior

## Testing

- All existing tests continue to pass
- No functional changes were made, only code organization improvements