### PR TITLE
feat: new accessList, warm/coolSlot. Include cool cheatcode too.

### DIFF
--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,10 +9,10 @@ import {Vm, VmSafe} from "../src/Vm.sol";
 // added to or removed from Vm or VmSafe.
 contract VmTest is Test {
     function test_VmInterfaceId() public pure {
-        assertEq(type(Vm).interfaceId, bytes4(0xdb28dd7b), "Vm");
+        assertEq(type(Vm).interfaceId, bytes4(0x6bb3d14a), "Vm");
     }
 
     function test_VmSafeInterfaceId() public pure {
-        assertEq(type(VmSafe).interfaceId, bytes4(0xb572f44f), "VmSafe");
+        assertEq(type(VmSafe).interfaceId, bytes4(0x1d414059), "VmSafe");
     }
 }


### PR DESCRIPTION
- adds new cheatcodes introduced in 
https://github.com/foundry-rs/foundry/pull/10112
https://github.com/foundry-rs/foundry/pull/10128
- add `cool` by removing Experimental status
- include `expectCreate` / `expectCreate2` and `foundryVersionAtLeast/foundryVersionCmp`