### PR TITLE
chore: bump to 1.9.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-std",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "Forge Standard Library is a collection of helpful contracts and libraries for use with Forge and Foundry.",
   "homepage": "https://book.getfoundry.sh/forge/forge-std",
   "bugs": "https://github.com/foundry-rs/forge-std/issues",


### PR DESCRIPTION
In preparation for 1.9.7 release for Foundry v1.1