### PR TITLE
refactor: Remove unnecessary pass in ItemOrder constructor

### DIFF
--- a/scripts/vm.py
+++ b/scripts/vm.py
@@ -388,7 +388,6 @@ class ItemOrder:
         assert len(list) <= len(Item), "list must not contain more items than Item"
         assert len(list) == len(set(list)), "list must not contain duplicates"
         self._list = list
-        pass
 
     def get_list(self) -> list[Item]:
         return self._list


### PR DESCRIPTION


This pull request addresses a minor code style issue by removing a redundant pass statement within the ItemOrder class's __init__ method.

The pass statement, being a null operation, was not required because the constructor already had other active lines of code. This change improves code conciseness without affecting the script's behavior or functionality.
