### PR TITLE
replace dead solmate link StdUtils.sol

### DIFF
--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -95,7 +95,7 @@ abstract contract StdUtils {
     }
 
     /// @dev Compute the address a contract will be deployed at for a given deployer address and nonce
-    /// @notice adapted from Solmate implementation (https://github.com/Rari-Capital/solmate/blob/main/src/utils/LibRLP.sol)
+    /// @notice adapted from Solmate implementation (https://github.com/transmissions11/solmate/blob/main/src/utils/LibString.sol)
     function computeCreateAddress(address deployer, uint256 nonce) internal pure virtual returns (address) {
         console2_log_StdUtils("computeCreateAddress is deprecated. Please use vm.computeCreateAddress instead.");
         return vm.computeCreateAddress(deployer, nonce);


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL

https://github.com/Rari-Capital/solmate/blob/main/src/utils/LibRLP.sol - dead link
https://github.com/transmissions11/solmate/blob/main/src/utils/LibString.sol - new link