### PR TITLE
Update LibRLP.sol reference to Solady canonical source

### DIFF
--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -95,7 +95,7 @@ abstract contract StdUtils {
     }
 
     /// @dev Compute the address a contract will be deployed at for a given deployer address and nonce
-    /// @notice adapted from Solmate implementation (https://github.com/Rari-Capital/solmate/blob/main/src/utils/LibRLP.sol)
+    /// @notice adapted from Solmate implementation (https://github.com/Vectorized/solady/blob/main/src/utils/LibRLP.sol)
     function computeCreateAddress(address deployer, uint256 nonce) internal pure virtual returns (address) {
         console2_log_StdUtils("computeCreateAddress is deprecated. Please use vm.computeCreateAddress instead.");
         return vm.computeCreateAddress(deployer, nonce);


### PR DESCRIPTION
Replace the outdated and broken GitHub link to Solmate's LibRLP.sol with the new canonical source in the Solady library:
https://github.com/Vectorized/solady/blob/main/src/utils/LibRLP.sol
This ensures the documentation points to an actively maintained and accessible implementation of LibRLP, as the original file was removed from Solmate.
Reference: Solady LibRLP.sol
https://github.com/Vectorized/solady/blob/main/src/utils/LibRLP.sol