### PR TITLE
feat(StdMath): Add INT256_MIN_ABS constant to avoid magic number dupl…

### DIFF
--- a/src/StdMath.sol
+++ b/src/StdMath.sol
@@ -3,11 +3,12 @@ pragma solidity >=0.6.2 <0.9.0;
 
 library stdMath {
     int256 private constant INT256_MIN = -57896044618658097711785492504343953926634992332820282019728792003956564819968;
+    uint256 private constant INT256_MIN_ABS = 57896044618658097711785492504343953926634992332820282019728792003956564819968;
 
     function abs(int256 a) internal pure returns (uint256) {
         // Required or it will fail when `a = type(int256).min`
         if (a == INT256_MIN) {
-            return 57896044618658097711785492504343953926634992332820282019728792003956564819968;
+            return INT256_MIN_ABS;
         }
 
         return uint256(a > 0 ? a : -a);


### PR DESCRIPTION
Introduces a new constant INT256_MIN_ABS in the stdMath library to store the absolute value of INT256_MIN. The abs() function now uses this constant instead of duplicating the magic number. This change improves code readability, maintainability, and follows the DRY principle. It also prevents potential overflow issues that could occur when trying to calculate -INT256_MIN directly.