### PR TITLE
perf(StdAssertions): avoid vm call for trivial conditions

### DIFF
--- a/src/StdAssertions.sol
+++ b/src/StdAssertions.sol
@@ -49,35 +49,51 @@ abstract contract StdAssertions {
     }
 
     function assertTrue(bool data) internal pure virtual {
-        vm.assertTrue(data);
+        if (!data) {
+            vm.assertTrue(data);
+        }
     }
 
     function assertTrue(bool data, string memory err) internal pure virtual {
-        vm.assertTrue(data, err);
+        if (!data) {
+            vm.assertTrue(data, err);
+        }
     }
 
     function assertFalse(bool data) internal pure virtual {
-        vm.assertFalse(data);
+        if (data) {
+            vm.assertFalse(data);
+        }
     }
 
     function assertFalse(bool data, string memory err) internal pure virtual {
-        vm.assertFalse(data, err);
+        if (data) {
+            vm.assertFalse(data, err);
+        }
     }
 
     function assertEq(bool left, bool right) internal pure virtual {
-        vm.assertEq(left, right);
+        if (left != right) {
+            vm.assertEq(left, right);
+        }
     }
 
     function assertEq(bool left, bool right, string memory err) internal pure virtual {
-        vm.assertEq(left, right, err);
+        if (left != right) {
+            vm.assertEq(left, right, err);
+        }
     }
 
     function assertEq(uint256 left, uint256 right) internal pure virtual {
-        vm.assertEq(left, right);
+        if (left != right) {
+            vm.assertEq(left, right);
+        }
     }
 
     function assertEq(uint256 left, uint256 right, string memory err) internal pure virtual {
-        vm.assertEq(left, right, err);
+        if (left != right) {
+            vm.assertEq(left, right, err);
+        }
     }
 
     function assertEqDecimal(uint256 left, uint256 right, uint256 decimals) internal pure virtual {
@@ -89,11 +105,15 @@ abstract contract StdAssertions {
     }
 
     function assertEq(int256 left, int256 right) internal pure virtual {
-        vm.assertEq(left, right);
+        if (left != right) {
+            vm.assertEq(left, right);
+        }
     }
 
     function assertEq(int256 left, int256 right, string memory err) internal pure virtual {
-        vm.assertEq(left, right, err);
+        if (left != right) {
+            vm.assertEq(left, right, err);
+        }
     }
 
     function assertEqDecimal(int256 left, int256 right, uint256 decimals) internal pure virtual {
@@ -105,27 +125,39 @@ abstract contract StdAssertions {
     }
 
     function assertEq(address left, address right) internal pure virtual {
-        vm.assertEq(left, right);
+        if (left != right) {
+            vm.assertEq(left, right);
+        }
     }
 
     function assertEq(address left, address right, string memory err) internal pure virtual {
-        vm.assertEq(left, right, err);
+        if (left != right) {
+            vm.assertEq(left, right, err);
+        }
     }
 
     function assertEq(bytes32 left, bytes32 right) internal pure virtual {
-        vm.assertEq(left, right);
+        if (left != right) {
+            vm.assertEq(left, right);
+        }
     }
 
     function assertEq(bytes32 left, bytes32 right, string memory err) internal pure virtual {
-        vm.assertEq(left, right, err);
+        if (left != right) {
+            vm.assertEq(left, right, err);
+        }
     }
 
     function assertEq32(bytes32 left, bytes32 right) internal pure virtual {
-        assertEq(left, right);
+        if (left != right) {
+            vm.assertEq(left, right);
+        }
     }
 
     function assertEq32(bytes32 left, bytes32 right, string memory err) internal pure virtual {
-        assertEq(left, right, err);
+        if (left != right) {
+            vm.assertEq(left, right, err);
+        }
     }
 
     function assertEq(string memory left, string memory right) internal pure virtual {
@@ -206,19 +238,27 @@ abstract contract StdAssertions {
     }
 
     function assertNotEq(bool left, bool right) internal pure virtual {
-        vm.assertNotEq(left, right);
+        if (left == right) {
+            vm.assertNotEq(left, right);
+        }
     }
 
     function assertNotEq(bool left, bool right, string memory err) internal pure virtual {
-        vm.assertNotEq(left, right, err);
+        if (left == right) {
+            vm.assertNotEq(left, right, err);
+        }
     }
 
     function assertNotEq(uint256 left, uint256 right) internal pure virtual {
-        vm.assertNotEq(left, right);
+        if (left == right) {
+            vm.assertNotEq(left, right);
+        }
     }
 
     function assertNotEq(uint256 left, uint256 right, string memory err) internal pure virtual {
-        vm.assertNotEq(left, right, err);
+        if (left == right) {
+            vm.assertNotEq(left, right, err);
+        }
     }
 
     function assertNotEqDecimal(uint256 left, uint256 right, uint256 decimals) internal pure virtual {
@@ -234,11 +274,15 @@ abstract contract StdAssertions {
     }
 
     function assertNotEq(int256 left, int256 right) internal pure virtual {
-        vm.assertNotEq(left, right);
+        if (left == right) {
+            vm.assertNotEq(left, right);
+        }
     }
 
     function assertNotEq(int256 left, int256 right, string memory err) internal pure virtual {
-        vm.assertNotEq(left, right, err);
+        if (left == right) {
+            vm.assertNotEq(left, right, err);
+        }
     }
 
     function assertNotEqDecimal(int256 left, int256 right, uint256 decimals) internal pure virtual {
@@ -250,27 +294,39 @@ abstract contract StdAssertions {
     }
 
     function assertNotEq(address left, address right) internal pure virtual {
-        vm.assertNotEq(left, right);
+        if (left == right) {
+            vm.assertNotEq(left, right);
+        }
     }
 
     function assertNotEq(address left, address right, string memory err) internal pure virtual {
-        vm.assertNotEq(left, right, err);
+        if (left == right) {
+            vm.assertNotEq(left, right, err);
+        }
     }
 
     function assertNotEq(bytes32 left, bytes32 right) internal pure virtual {
-        vm.assertNotEq(left, right);
+        if (left == right) {
+            vm.assertNotEq(left, right);
+        }
     }
 
     function assertNotEq(bytes32 left, bytes32 right, string memory err) internal pure virtual {
-        vm.assertNotEq(left, right, err);
+        if (left == right) {
+            vm.assertNotEq(left, right, err);
+        }
     }
 
     function assertNotEq32(bytes32 left, bytes32 right) internal pure virtual {
-        assertNotEq(left, right);
+        if (left == right) {
+            vm.assertNotEq(left, right);
+        }
     }
 
     function assertNotEq32(bytes32 left, bytes32 right, string memory err) internal pure virtual {
-        assertNotEq(left, right, err);
+        if (left == right) {
+            vm.assertNotEq(left, right, err);
+        }
     }
 
     function assertNotEq(string memory left, string memory right) internal pure virtual {
@@ -346,11 +402,15 @@ abstract contract StdAssertions {
     }
 
     function assertLt(uint256 left, uint256 right) internal pure virtual {
-        vm.assertLt(left, right);
+        if (!(left < right)) {
+            vm.assertLt(left, right);
+        }
     }
 
     function assertLt(uint256 left, uint256 right, string memory err) internal pure virtual {
-        vm.assertLt(left, right, err);
+        if (!(left < right)) {
+            vm.assertLt(left, right, err);
+        }
     }
 
     function assertLtDecimal(uint256 left, uint256 right, uint256 decimals) internal pure virtual {
@@ -362,11 +422,15 @@ abstract contract StdAssertions {
     }
 
     function assertLt(int256 left, int256 right) internal pure virtual {
-        vm.assertLt(left, right);
+        if (!(left < right)) {
+            vm.assertLt(left, right);
+        }
     }
 
     function assertLt(int256 left, int256 right, string memory err) internal pure virtual {
-        vm.assertLt(left, right, err);
+        if (!(left < right)) {
+            vm.assertLt(left, right, err);
+        }
     }
 
     function assertLtDecimal(int256 left, int256 right, uint256 decimals) internal pure virtual {
@@ -378,11 +442,15 @@ abstract contract StdAssertions {
     }
 
     function assertGt(uint256 left, uint256 right) internal pure virtual {
-        vm.assertGt(left, right);
+        if (!(left > right)) {
+            vm.assertGt(left, right);
+        }
     }
 
     function assertGt(uint256 left, uint256 right, string memory err) internal pure virtual {
-        vm.assertGt(left, right, err);
+        if (!(left > right)) {
+            vm.assertGt(left, right, err);
+        }
     }
 
     function assertGtDecimal(uint256 left, uint256 right, uint256 decimals) internal pure virtual {
@@ -394,11 +462,15 @@ abstract contract StdAssertions {
     }
 
     function assertGt(int256 left, int256 right) internal pure virtual {
-        vm.assertGt(left, right);
+        if (!(left > right)) {
+            vm.assertGt(left, right);
+        }
     }
 
     function assertGt(int256 left, int256 right, string memory err) internal pure virtual {
-        vm.assertGt(left, right, err);
+        if (!(left > right)) {
+            vm.assertGt(left, right, err);
+        }
     }
 
     function assertGtDecimal(int256 left, int256 right, uint256 decimals) internal pure virtual {
@@ -410,11 +482,15 @@ abstract contract StdAssertions {
     }
 
     function assertLe(uint256 left, uint256 right) internal pure virtual {
-        vm.assertLe(left, right);
+        if (!(left <= right)) {
+            vm.assertLe(left, right);
+        }
     }
 
     function assertLe(uint256 left, uint256 right, string memory err) internal pure virtual {
-        vm.assertLe(left, right, err);
+        if (!(left <= right)) {
+            vm.assertLe(left, right, err);
+        }
     }
 
     function assertLeDecimal(uint256 left, uint256 right, uint256 decimals) internal pure virtual {
@@ -426,11 +502,15 @@ abstract contract StdAssertions {
     }
 
     function assertLe(int256 left, int256 right) internal pure virtual {
-        vm.assertLe(left, right);
+        if (!(left <= right)) {
+            vm.assertLe(left, right);
+        }
     }
 
     function assertLe(int256 left, int256 right, string memory err) internal pure virtual {
-        vm.assertLe(left, right, err);
+        if (!(left <= right)) {
+            vm.assertLe(left, right, err);
+        }
     }
 
     function assertLeDecimal(int256 left, int256 right, uint256 decimals) internal pure virtual {
@@ -442,11 +522,15 @@ abstract contract StdAssertions {
     }
 
     function assertGe(uint256 left, uint256 right) internal pure virtual {
-        vm.assertGe(left, right);
+        if (!(left >= right)) {
+            vm.assertGe(left, right);
+        }
     }
 
     function assertGe(uint256 left, uint256 right, string memory err) internal pure virtual {
-        vm.assertGe(left, right, err);
+        if (!(left >= right)) {
+            vm.assertGe(left, right, err);
+        }
     }
 
     function assertGeDecimal(uint256 left, uint256 right, uint256 decimals) internal pure virtual {
@@ -458,11 +542,15 @@ abstract contract StdAssertions {
     }
 
     function assertGe(int256 left, int256 right) internal pure virtual {
-        vm.assertGe(left, right);
+        if (!(left >= right)) {
+            vm.assertGe(left, right);
+        }
     }
 
     function assertGe(int256 left, int256 right, string memory err) internal pure virtual {
-        vm.assertGe(left, right, err);
+        if (!(left >= right)) {
+            vm.assertGe(left, right, err);
+        }
     }
 
     function assertGeDecimal(int256 left, int256 right, uint256 decimals) internal pure virtual {


### PR DESCRIPTION
Avoid calling vm when the condition is trivial to check inline. This is a minor performance improvement as a couple of opcodes execute a lot faster than a full cheatcode pipeline (external call, EVM call bookkeeping, abi encoding/decoding, ...) that eventually does nothing.

For example, [Uniswap's v4-core](https://github.com/Uniswap/v4-core/) spends ~28% of the entire `forge test` CPU time in a couple of trivial `assert` functions (uint256, bytes32, true, false), ~13% for `forge coverage`. This is without accounting for the actual CALL/abi coding etc.

These numbers are skewed due to profiling overhead, however making this change does have ~5% overall test performance improvement, for no compilation time change.