### PR TITLE
style: remove unnecessary blank line between pragma directives in Tes…

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.6.2 <0.9.0;
-
 pragma experimental ABIEncoderV2;
 
 // 💬 ABOUT


### PR DESCRIPTION
Remove empty line between `pragma solidity` and `pragma experimental ABIEncoderV2` to maintain consistency with other files in the codebase (StdAssertions.sol, Vm.sol, etc.) where pragma directives are placed consecutively without blank lines.