### PR TITLE
fix: correct JSON references to TOML in StdToml.sol comments

### DIFF
--- a/src/StdToml.sol
+++ b/src/StdToml.sol
@@ -10,16 +10,16 @@ import {VmSafe} from "./Vm.sol";
 // ```
 // using stdToml for string;
 // string memory toml = vm.readFile("<some_path>");
-// toml.readUint("<json_path>");
+// toml.readUint("<toml_path>");
 // ```
 // To write:
 // ```
 // using stdToml for string;
-// string memory json = "json";
-// json.serialize("a", uint256(123));
-// string memory semiFinal = json.serialize("b", string("test"));
-// string memory finalJson = json.serialize("c", semiFinal);
-// finalJson.write("<some_path>");
+// string memory toml = "toml";
+// toml.serialize("a", uint256(123));
+// string memory semiFinal = toml.serialize("b", string("test"));
+// string memory finalToml = toml.serialize("c", semiFinal);
+// finalToml.write("<some_path>");
 // ```
 
 library stdToml {


### PR DESCRIPTION

Changes:
- Replace `<json_path>` with `<toml_path>` in usage example
- Replace variable names from `json`/`finalJson` to `toml`/`finalToml`
- Ensure consistency between library name (stdToml) and documentation

This appears to be a copy-paste error from StdJson.sol that caused confusion in the TOML library documentation. The fix only affects comments and does not change any functionality.