### PR TITLE
chore(`ci`): pin deps in workflow and add `dependabot` to update them weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: crate-ci/typos@v1
+      - uses: crate-ci/typos@85f62a8a84f939ae994ab3763f01a0296d61a7ee # v1
 
   ci-success:
     runs-on: ubuntu-latest
@@ -102,6 +102,6 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # release/v1
         with:
           jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,6 @@ jobs:
     permissions:
       security-events: write
       actions: read
-      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-      packages: read
       actions: read
       contents: read
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,8 @@
 name: CodeQL
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["master"]


### PR DESCRIPTION
Pinning hashes for dependencies in workflows is a security best practice

Excluded from pinning are actions from the `github/*` and `actions/*` given that these are officially managed by Github and are not raised by `zizmor`

By configuring dependabot with `package-ecosystem: "github-actions"` it will open a pull request only for updating pinned hashes (not cargo, etc..): https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot#enabling-dependabot-version-updates-for-actions

The `<hash> #<branch_name>` syntax is what dependabot picks up on

Note: `foundry-toolchain@v1` has been left unpinned as it will help us catch issues more easily and it is in our interest to be up to date. Let me know if this makes sense @grandizzy or if we should pin instead.