### PR TITLE
chore(`ci`): rescope permissions according to principle of least privilege

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: CI
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   workflow_dispatch:
@@ -15,6 +14,8 @@ jobs:
     name: build +${{ matrix.toolchain }} ${{ matrix.flags }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -51,6 +52,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -73,6 +76,8 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -84,6 +89,8 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v5
         with:
@@ -93,7 +100,6 @@ jobs:
   ci-success:
     runs-on: ubuntu-latest
     if: always()
-    permissions: {}
     needs:
       - build
       - test

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,7 +1,6 @@
 name: CodeQL
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   push:
@@ -23,6 +22,7 @@ jobs:
     permissions:
       security-events: write
       actions: read
+      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,7 +1,6 @@
 name: Sync Release Branch
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   release:


### PR DESCRIPTION
By assigning

```
permissions: {}
```

we disable all permissions by default

we then grant it on a per-job basis to exactly what is strictly required