### PR TITLE
Fix overflow risk in StdMath.percentDelta using 512-bit mulDiv

### DIFF
--- a/src/StdMath.sol
+++ b/src/StdMath.sol
@@ -4,6 +4,54 @@ pragma solidity >=0.6.2 <0.9.0;
 library stdMath {
     int256 private constant INT256_MIN = -57896044618658097711785492504343953926634992332820282019728792003956564819968;
 
+    function mulDiv(uint256 x, uint256 y, uint256 denominator) internal pure returns (uint256 result) {
+        // Compute floor(x * y / denominator) with full 512-bit precision to avoid overflow.
+        // This implementation is adapted from well-known public domain algorithms
+        // (e.g., Uniswap v3 FullMath / OpenZeppelin Math.mulDiv).
+        assembly {
+            let mm := mulmod(x, y, not(0))
+            let prod0 := mul(x, y)
+            let prod1 := sub(sub(mm, prod0), lt(mm, prod0))
+
+            // If the high 256 bits are zero, we can perform a standard division.
+            if iszero(prod1) {
+                result := div(prod0, denominator)
+                leave
+            }
+
+            // Ensure the result is less than 2^256. Also prevents denominator == 0.
+            if iszero(gt(denominator, prod1)) { revert(0, 0) }
+
+            // Make division exact by subtracting the remainder from [prod1 prod0].
+            let remainder := mulmod(x, y, denominator)
+            prod1 := sub(prod1, gt(remainder, prod0))
+            prod0 := sub(prod0, remainder)
+
+            // Factor powers of two out of denominator and compute largest power-of-two divisor.
+            let twos := and(denominator, sub(0, denominator))
+            denominator := div(denominator, twos)
+
+            // Divide [prod1 prod0] by the factors of two.
+            prod0 := div(prod0, twos)
+            twos := add(div(sub(0, twos), twos), 1)
+            prod0 := or(prod0, mul(prod1, twos))
+
+            // Compute the modular inverse of the denominator modulo 2^256.
+            // Newton-Raphson iteration to improve the precision.
+            let inv := mul(3, denominator)
+            inv := xor(inv, 2)
+            inv := mul(inv, sub(2, mul(denominator, inv)))
+            inv := mul(inv, sub(2, mul(denominator, inv)))
+            inv := mul(inv, sub(2, mul(denominator, inv)))
+            inv := mul(inv, sub(2, mul(denominator, inv)))
+            inv := mul(inv, sub(2, mul(denominator, inv)))
+            inv := mul(inv, sub(2, mul(denominator, inv)))
+
+            // Multiply by the modular inverse to perform the division.
+            result := mul(prod0, inv)
+        }
+    }
+
     function abs(int256 a) internal pure returns (uint256) {
         // Required or it will fail when `a = type(int256).min`
         if (a == INT256_MIN) {
@@ -33,7 +81,7 @@ library stdMath {
         require(b != 0, "stdMath percentDelta(uint256,uint256): Divisor is zero");
         uint256 absDelta = delta(a, b);
 
-        return absDelta * 1e18 / b;
+        return mulDiv(absDelta, 1e18, b);
     }
 
     function percentDelta(int256 a, int256 b) internal pure returns (uint256) {
@@ -42,6 +90,6 @@ library stdMath {
         // Prevent division by zero
         require(absB != 0, "stdMath percentDelta(int256,int256): Divisor is zero");
 
-        return absDelta * 1e18 / absB;
+        return mulDiv(absDelta, 1e18, absB);
     }
 }


### PR DESCRIPTION


### Summary
Replace percent delta calculation `absDelta * 1e18 / denom` with a 512-bit precise `mulDiv` to avoid overflow and ensure consistent behavior across compiler versions.

### Changes
- Add internal `mulDiv(uint256,uint256,uint256)` in `src/StdMath.sol` (512-bit precise, Yul-based).
- Use `mulDiv` in `percentDelta(uint256,uint256)` and `percentDelta(int256,int256)`.

