### PR TITLE
chore: update `exposed_ <function_name>` be consistent with lint mixed-case-function rule

### DIFF
--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -4,19 +4,19 @@ pragma solidity >=0.7.0 <0.9.0;
 import {Test} from "../src/Test.sol";
 
 contract StdChainsMock is Test {
-    function exposed_getChain(string memory chainAlias) public returns (Chain memory) {
+    function exposedGetChain(string memory chainAlias) public returns (Chain memory) {
         return getChain(chainAlias);
     }
 
-    function exposed_getChain(uint256 chainId) public returns (Chain memory) {
+    function exposedGetChain(uint256 chainId) public returns (Chain memory) {
         return getChain(chainId);
     }
 
-    function exposed_setChain(string memory chainAlias, ChainData memory chainData) public {
+    function exposedSetChain(string memory chainAlias, ChainData memory chainData) public {
         setChain(chainAlias, chainData);
     }
 
-    function exposed_setFallbackToDefaultRpcUrls(bool useDefault) public {
+    function exposedSetFallbackToDefaultRpcUrls(bool useDefault) public {
         setFallbackToDefaultRpcUrls(useDefault);
     }
 }
@@ -89,7 +89,7 @@ contract StdChainsTest is Test {
         StdChainsMock stdChainsMock = new StdChainsMock();
 
         vm.expectRevert("StdChains getChain(string): Chain with alias \"does_not_exist\" not found.");
-        stdChainsMock.exposed_getChain("does_not_exist");
+        stdChainsMock.exposedGetChain("does_not_exist");
     }
 
     function test_RevertIf_SetChain_ChainIdExist_FirstTest() public {
@@ -97,28 +97,28 @@ contract StdChainsTest is Test {
         StdChainsMock stdChainsMock = new StdChainsMock();
 
         vm.expectRevert("StdChains setChain(string,ChainData): Chain ID 31337 already used by \"anvil\".");
-        stdChainsMock.exposed_setChain("anvil2", ChainData("Anvil", 31337, "URL"));
+        stdChainsMock.exposedSetChain("anvil2", ChainData("Anvil", 31337, "URL"));
     }
 
     function test_RevertIf_ChainBubbleUp() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
-        stdChainsMock.exposed_setChain("needs_undefined_env_var", ChainData("", 123456789, ""));
+        stdChainsMock.exposedSetChain("needs_undefined_env_var", ChainData("", 123456789, ""));
         // Forge environment variable error.
         vm.expectRevert();
-        stdChainsMock.exposed_getChain("needs_undefined_env_var");
+        stdChainsMock.exposedGetChain("needs_undefined_env_var");
     }
 
     function test_RevertIf_SetChain_ChainIdExists_SecondTest() public {
         // We deploy a mock to properly test the revert.
         StdChainsMock stdChainsMock = new StdChainsMock();
 
-        stdChainsMock.exposed_setChain("custom_chain", ChainData("Custom Chain", 123456789, "https://custom.chain/"));
+        stdChainsMock.exposedSetChain("custom_chain", ChainData("Custom Chain", 123456789, "https://custom.chain/"));
 
         vm.expectRevert('StdChains setChain(string,ChainData): Chain ID 123456789 already used by "custom_chain".');
 
-        stdChainsMock.exposed_setChain("another_custom_chain", ChainData("", 123456789, ""));
+        stdChainsMock.exposedSetChain("another_custom_chain", ChainData("", 123456789, ""));
     }
 
     function test_SetChain() public {
@@ -152,7 +152,7 @@ contract StdChainsTest is Test {
         StdChainsMock stdChainsMock = new StdChainsMock();
 
         vm.expectRevert("StdChains setChain(string,ChainData): Chain alias cannot be the empty string.");
-        stdChainsMock.exposed_setChain("", ChainData("", 123456789, ""));
+        stdChainsMock.exposedSetChain("", ChainData("", 123456789, ""));
     }
 
     function test_RevertIf_SetNoChainId0() public {
@@ -160,7 +160,7 @@ contract StdChainsTest is Test {
         StdChainsMock stdChainsMock = new StdChainsMock();
 
         vm.expectRevert("StdChains setChain(string,ChainData): Chain ID cannot be 0.");
-        stdChainsMock.exposed_setChain("alias", ChainData("", 0, ""));
+        stdChainsMock.exposedSetChain("alias", ChainData("", 0, ""));
     }
 
     function test_RevertIf_GetNoChainId0() public {
@@ -168,7 +168,7 @@ contract StdChainsTest is Test {
         StdChainsMock stdChainsMock = new StdChainsMock();
 
         vm.expectRevert("StdChains getChain(uint256): Chain ID cannot be 0.");
-        stdChainsMock.exposed_getChain(0);
+        stdChainsMock.exposedGetChain(0);
     }
 
     function test_RevertIf_GetNoEmptyAlias() public {
@@ -176,7 +176,7 @@ contract StdChainsTest is Test {
         StdChainsMock stdChainsMock = new StdChainsMock();
 
         vm.expectRevert("StdChains getChain(string): Chain alias cannot be the empty string.");
-        stdChainsMock.exposed_getChain("");
+        stdChainsMock.exposedGetChain("");
     }
 
     function test_RevertIf_ChainNotInitialized() public {
@@ -184,7 +184,7 @@ contract StdChainsTest is Test {
         StdChainsMock stdChainsMock = new StdChainsMock();
 
         vm.expectRevert("StdChains getChain(string): Chain with alias \"no_such_alias\" not found.");
-        stdChainsMock.exposed_getChain("no_such_alias");
+        stdChainsMock.exposedGetChain("no_such_alias");
     }
 
     function test_RevertIf_ChainAliasNotFound() public {
@@ -193,7 +193,7 @@ contract StdChainsTest is Test {
 
         vm.expectRevert("StdChains getChain(uint256): Chain with ID 321 not found.");
 
-        stdChainsMock.exposed_getChain(321);
+        stdChainsMock.exposedGetChain(321);
     }
 
     function test_SetChain_ExistingOne() public {
@@ -205,7 +205,7 @@ contract StdChainsTest is Test {
 
         setChain("custom_chain", ChainData("Modified Chain", 9999999999999999999, "https://modified.chain/"));
         vm.expectRevert("StdChains getChain(uint256): Chain with ID 123456789 not found.");
-        stdChainsMock.exposed_getChain(123456789);
+        stdChainsMock.exposedGetChain(123456789);
 
         Chain memory modifiedChain = getChain(9999999999999999999);
         assertEq(modifiedChain.name, "Modified Chain");
@@ -218,10 +218,10 @@ contract StdChainsTest is Test {
         StdChainsMock stdChainsMock = new StdChainsMock();
 
         // Should error if default RPCs flag is set to false.
-        stdChainsMock.exposed_setFallbackToDefaultRpcUrls(false);
+        stdChainsMock.exposedSetFallbackToDefaultRpcUrls(false);
         vm.expectRevert();
-        stdChainsMock.exposed_getChain(31337);
+        stdChainsMock.exposedGetChain(31337);
         vm.expectRevert();
-        stdChainsMock.exposed_getChain("sepolia");
+        stdChainsMock.exposedGetChain("sepolia");
     }
 }

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -352,24 +352,24 @@ contract StdCheatsTest is Test {
 
         // VM address
         vm.expectRevert();
-        stdCheatsMock.exposed_assumePayable(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+        stdCheatsMock.exposedAssumePayable(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
         // Console address
         vm.expectRevert();
-        stdCheatsMock.exposed_assumePayable(0x000000000000000000636F6e736F6c652e6c6f67);
+        stdCheatsMock.exposedAssumePayable(0x000000000000000000636F6e736F6c652e6c6f67);
 
         // Create2Deployer
         vm.expectRevert();
-        stdCheatsMock.exposed_assumePayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
+        stdCheatsMock.exposedAssumePayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
 
         // all should pass since these addresses are payable
 
         // vitalik.eth
-        stdCheatsMock.exposed_assumePayable(0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045);
+        stdCheatsMock.exposedAssumePayable(0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045);
 
         // mock payable contract
         MockContractPayable cp = new MockContractPayable();
-        stdCheatsMock.exposed_assumePayable(address(cp));
+        stdCheatsMock.exposedAssumePayable(address(cp));
     }
 
     function test_AssumeNotPayable() external {
@@ -379,24 +379,24 @@ contract StdCheatsTest is Test {
         // all should pass since these addresses are not payable
 
         // VM address
-        stdCheatsMock.exposed_assumeNotPayable(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
+        stdCheatsMock.exposedAssumeNotPayable(0x7109709ECfa91a80626fF3989D68f67F5b1DD12D);
 
         // Console address
-        stdCheatsMock.exposed_assumeNotPayable(0x000000000000000000636F6e736F6c652e6c6f67);
+        stdCheatsMock.exposedAssumeNotPayable(0x000000000000000000636F6e736F6c652e6c6f67);
 
         // Create2Deployer
-        stdCheatsMock.exposed_assumeNotPayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
+        stdCheatsMock.exposedAssumeNotPayable(0x4e59b44847b379578588920cA78FbF26c0B4956C);
 
         // all should revert since these addresses are payable
 
         // vitalik.eth
         vm.expectRevert();
-        stdCheatsMock.exposed_assumeNotPayable(0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045);
+        stdCheatsMock.exposedAssumeNotPayable(0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045);
 
         // mock payable contract
         MockContractPayable cp = new MockContractPayable();
         vm.expectRevert();
-        stdCheatsMock.exposed_assumeNotPayable(address(cp));
+        stdCheatsMock.exposedAssumeNotPayable(address(cp));
     }
 
     function testFuzz_AssumeNotPrecompile(address addr) external {
@@ -444,16 +444,16 @@ contract StdCheatsTest is Test {
 }
 
 contract StdCheatsMock is StdCheats {
-    function exposed_assumePayable(address addr) external {
+    function exposedAssumePayable(address addr) external {
         assumePayable(addr);
     }
 
-    function exposed_assumeNotPayable(address addr) external {
+    function exposedAssumeNotPayable(address addr) external {
         assumeNotPayable(addr);
     }
 
     // We deploy a mock version so we can properly test expected reverts.
-    function exposed_assumeNotBlacklisted(address token, address addr) external view {
+    function exposedAssumeNotBlacklisted(address token, address addr) external view {
         return assumeNotBlacklisted(token, addr);
     }
 }
@@ -478,7 +478,7 @@ contract StdCheatsForkTest is Test {
         StdCheatsMock stdCheatsMock = new StdCheatsMock();
         address eoa = vm.addr({privateKey: 1});
         vm.expectRevert("StdCheats assumeNotBlacklisted(address,address): Token address is not a contract.");
-        stdCheatsMock.exposed_assumeNotBlacklisted(eoa, address(0));
+        stdCheatsMock.exposedAssumeNotBlacklisted(eoa, address(0));
     }
 
     function testFuzz_AssumeNotBlacklisted_TokenWithoutBlacklist(address addr) external view {
@@ -491,7 +491,7 @@ contract StdCheatsForkTest is Test {
         // We deploy a mock version so we can properly test the revert.
         StdCheatsMock stdCheatsMock = new StdCheatsMock();
         vm.expectRevert();
-        stdCheatsMock.exposed_assumeNotBlacklisted(address(USDC), USDC_BLACKLISTED_USER);
+        stdCheatsMock.exposedAssumeNotBlacklisted(address(USDC), USDC_BLACKLISTED_USER);
     }
 
     function testFuzz_AssumeNotBlacklisted_USDC(address addr) external view {
@@ -503,7 +503,7 @@ contract StdCheatsForkTest is Test {
         // We deploy a mock version so we can properly test the revert.
         StdCheatsMock stdCheatsMock = new StdCheatsMock();
         vm.expectRevert();
-        stdCheatsMock.exposed_assumeNotBlacklisted(address(USDT), USDT_BLACKLISTED_USER);
+        stdCheatsMock.exposedAssumeNotBlacklisted(address(USDT), USDT_BLACKLISTED_USER);
     }
 
     function testFuzz_AssumeNotBlacklisted_USDT(address addr) external view {

--- a/test/StdMath.t.sol
+++ b/test/StdMath.t.sol
@@ -5,11 +5,11 @@ import {stdMath} from "../src/StdMath.sol";
 import {Test, stdError} from "../src/Test.sol";
 
 contract StdMathMock is Test {
-    function exposed_percentDelta(uint256 a, uint256 b) public pure returns (uint256) {
+    function exposedPercentDelta(uint256 a, uint256 b) public pure returns (uint256) {
         return stdMath.percentDelta(a, b);
     }
 
-    function exposed_percentDelta(int256 a, int256 b) public pure returns (uint256) {
+    function exposedPercentDelta(int256 a, int256 b) public pure returns (uint256) {
         return stdMath.percentDelta(a, b);
     }
 }
@@ -126,7 +126,7 @@ contract StdMathTest is Test {
         assertEq(stdMath.percentDelta(7500, uint256(2500)), 2e18);
 
         vm.expectRevert("stdMath percentDelta(uint256,uint256): Divisor is zero");
-        stdMathMock.exposed_percentDelta(uint256(1), 0);
+        stdMathMock.exposedPercentDelta(uint256(1), 0);
     }
 
     function testFuzz_GetPercentDelta_Uint(uint192 a, uint192 b) external pure {
@@ -164,7 +164,7 @@ contract StdMathTest is Test {
         assertEq(stdMath.percentDelta(7500, int256(2500)), 2e18);
 
         vm.expectRevert("stdMath percentDelta(int256,int256): Divisor is zero");
-        stdMathMock.exposed_percentDelta(int256(1), 0);
+        stdMathMock.exposedPercentDelta(int256(1), 0);
     }
 
     function testFuzz_GetPercentDelta_Int(int192 a, int192 b) external pure {

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -5,22 +5,22 @@ import {Test, StdUtils} from "../src/Test.sol";
 
 contract StdUtilsMock is StdUtils {
     // We deploy a mock version so we can properly test expected reverts.
-    function exposed_getTokenBalances(address token, address[] memory addresses)
+    function exposedGetTokenBalances(address token, address[] memory addresses)
         external
         returns (uint256[] memory balances)
     {
         return getTokenBalances(token, addresses);
     }
 
-    function exposed_bound(int256 num, int256 min, int256 max) external pure returns (int256) {
+    function exposedBound(int256 num, int256 min, int256 max) external pure returns (int256) {
         return bound(num, min, max);
     }
 
-    function exposed_bound(uint256 num, uint256 min, uint256 max) external pure returns (uint256) {
+    function exposedBound(uint256 num, uint256 min, uint256 max) external pure returns (uint256) {
         return bound(num, min, max);
     }
 
-    function exposed_bytesToUint(bytes memory b) external pure returns (uint256) {
+    function exposedBytesToUint(bytes memory b) external pure returns (uint256) {
         return bytesToUint(b);
     }
 }
@@ -94,7 +94,7 @@ contract StdUtilsTest is Test {
         StdUtilsMock stdUtils = new StdUtilsMock();
 
         vm.expectRevert(bytes("StdUtils bound(uint256,uint256,uint256): Max is less than min."));
-        stdUtils.exposed_bound(uint256(5), 100, 10);
+        stdUtils.exposedBound(uint256(5), 100, 10);
     }
 
     function testFuzz_RevertIf_BoundMaxLessThanMin(uint256 num, uint256 min, uint256 max) public {
@@ -103,7 +103,7 @@ contract StdUtilsTest is Test {
 
         vm.assume(min > max);
         vm.expectRevert(bytes("StdUtils bound(uint256,uint256,uint256): Max is less than min."));
-        stdUtils.exposed_bound(num, min, max);
+        stdUtils.exposedBound(num, min, max);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -188,7 +188,7 @@ contract StdUtilsTest is Test {
         StdUtilsMock stdUtils = new StdUtilsMock();
 
         vm.expectRevert(bytes("StdUtils bound(int256,int256,int256): Max is less than min."));
-        stdUtils.exposed_bound(-5, 100, 10);
+        stdUtils.exposedBound(-5, 100, 10);
     }
 
     function testFuzz_RevertIf_BoundIntMaxLessThanMin(int256 num, int256 min, int256 max) public {
@@ -197,7 +197,7 @@ contract StdUtilsTest is Test {
 
         vm.assume(min > max);
         vm.expectRevert(bytes("StdUtils bound(int256,int256,int256): Max is less than min."));
-        stdUtils.exposed_bound(num, min, max);
+        stdUtils.exposedBound(num, min, max);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -235,7 +235,7 @@ contract StdUtilsTest is Test {
 
         bytes memory thirty3Bytes = hex"ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
         vm.expectRevert("StdUtils bytesToUint(bytes): Bytes length exceeds 32.");
-        stdUtils.exposed_bytesToUint(thirty3Bytes);
+        stdUtils.exposedBytesToUint(thirty3Bytes);
     }
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -300,7 +300,7 @@ contract StdUtilsForkTest is Test {
         addresses[0] = USDC_HOLDER_0;
 
         vm.expectRevert("Multicall3: call failed");
-        stdUtils.exposed_getTokenBalances(token, addresses);
+        stdUtils.exposedGetTokenBalances(token, addresses);
     }
 
     function test_RevertIf_CannotGetTokenBalances_EOA() external {
@@ -311,7 +311,7 @@ contract StdUtilsForkTest is Test {
         address[] memory addresses = new address[](1);
         addresses[0] = USDC_HOLDER_0;
         vm.expectRevert("StdUtils getTokenBalances(address,address[]): Token address is not a contract.");
-        stdUtils.exposed_getTokenBalances(eoa, addresses);
+        stdUtils.exposedGetTokenBalances(eoa, addresses);
     }
 
     function test_GetTokenBalances_Empty() external {


### PR DESCRIPTION
Part of: https://github.com/foundry-rs/foundry/issues/12670

No user facing changes or breaking changes