### PR TITLE
fix: config test to use reth, remove log from bound

### DIFF
--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -57,7 +57,6 @@ abstract contract StdUtils {
 
     function bound(uint256 x, uint256 min, uint256 max) internal pure virtual returns (uint256 result) {
         result = _bound(x, min, max);
-        console2_log_StdUtils("Bound result", result);
     }
 
     function _bound(int256 x, int256 min, int256 max) internal pure virtual returns (int256 result) {
@@ -82,7 +81,6 @@ abstract contract StdUtils {
 
     function bound(int256 x, int256 min, int256 max) internal pure virtual returns (int256 result) {
         result = _bound(x, min, max);
-        console2_log_StdUtils("Bound result", vm.toString(result));
     }
 
     function boundPrivateKey(uint256 privateKey) internal pure virtual returns (uint256 result) {

--- a/test/Config.t.sol
+++ b/test/Config.t.sol
@@ -7,7 +7,7 @@ import {StdConfig} from "../src/StdConfig.sol";
 
 contract ConfigTest is Test, Config {
     function setUp() public {
-        vm.setEnv("MAINNET_RPC", "https://eth.llamarpc.com");
+        vm.setEnv("MAINNET_RPC", "https://reth-ethereum.ithaca.xyz/rpc");
         vm.setEnv("WETH_MAINNET", "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2");
         vm.setEnv("OPTIMISM_RPC", "https://mainnet.optimism.io");
         vm.setEnv("WETH_OPTIMISM", "0x4200000000000000000000000000000000000006");
@@ -20,7 +20,7 @@ contract ConfigTest is Test, Config {
         // -- MAINNET --------------------------------------------------------------
 
         // Read and assert RPC URL for Mainnet (chain ID 1)
-        assertEq(config.getRpcUrl(1), "https://eth.llamarpc.com");
+        assertEq(config.getRpcUrl(1), "https://reth-ethereum.ithaca.xyz/rpc");
 
         // Read and assert boolean values
         assertTrue(config.get(1, "is_live").toBool());
@@ -301,7 +301,7 @@ contract ConfigTest is Test, Config {
             invalidChainConfig,
             string.concat(
                 "[mainnet]\n",
-                "endpoint_url = \"https://eth.llamarpc.com\"\n",
+                "endpoint_url = \"https://reth-ethereum.ithaca.xyz/rpc\"\n",
                 "\n",
                 "[mainnet.uint]\n",
                 "valid_number = 123\n",
@@ -338,7 +338,7 @@ contract ConfigTest is Test, Config {
             badParseConfig,
             string.concat(
                 "[mainnet]\n",
-                "endpoint_url = \"https://eth.llamarpc.com\"\n",
+                "endpoint_url = \"https://reth-ethereum.ithaca.xyz/rpc\"\n",
                 "\n",
                 "[mainnet.uint]\n",
                 "bad_value = \"not_a_number\"\n"


### PR DESCRIPTION
- use reth node in config tests instead eth.llamarpc
- remove log from bound fn to address https://github.com/foundry-rs/foundry/pull/12478#issuecomment-3592285728 Projects should `console.log` bounded value in tests themselves if needed