### PR TITLE
fix: correctly state dual license `MIT or Apache-2.0` in Solidity files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ forge install foundry-rs/forge-std
 ```
 
 ## Contracts
+
 ### stdError
 
 This is a helper contract for errors and reverts. In Forge, this contract is particularly helpful for the `expectRevert` cheatcode, as it provides all compiler built-in errors.
@@ -45,11 +46,12 @@ contract ErrorsTest {
 
 ### stdStorage
 
-This is a rather large contract due to all of the overloading to make the UX decent. Primarily, it is a wrapper around the `record` and `accesses` cheatcodes. It can *always* find and write the storage slot(s) associated with a particular variable without knowing the storage layout. The one _major_ caveat to this is while a slot can be found for packed storage variables, we can't write to that variable safely. If a user tries to write to a packed slot, the execution throws an error, unless it is uninitialized (`bytes32(0)`).
+This is a rather large contract due to all of the overloading to make the UX decent. Primarily, it is a wrapper around the `record` and `accesses` cheatcodes. It can _always_ find and write the storage slot(s) associated with a particular variable without knowing the storage layout. The one _major_ caveat to this is while a slot can be found for packed storage variables, we can't write to that variable safely. If a user tries to write to a packed slot, the execution throws an error, unless it is uninitialized (`bytes32(0)`).
 
 This works by recording all `SLOAD`s and `SSTORE`s during a function call. If there is a single slot read or written to, it immediately returns the slot. Otherwise, behind the scenes, we iterate through and check each one (assuming the user passed in a `depth` parameter). If the variable is a struct, you can pass in a `depth` parameter which is basically the field depth.
 
 I.e.:
+
 ```solidity
 struct T {
     // depth 0
@@ -167,11 +169,11 @@ contract Storage {
 
 This is a wrapper over miscellaneous cheatcodes that need wrappers to be more dev friendly. Currently there are only functions related to `prank`. In general, users may expect ETH to be put into an address on `prank`, but this is not the case for safety reasons. Explicitly this `hoax` function should only be used for addresses that have expected balances as it will get overwritten. If an address already has ETH, you should just use `prank`. If you want to change that balance explicitly, just use `deal`. If you want to do both, `hoax` is also right for you.
 
-
 #### Example usage:
+
 ```solidity
 
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity ^0.8.0;
 
 import "forge-std/Test.sol";
@@ -255,9 +257,9 @@ First, see if the answer to your question can be found in [book](https://getfoun
 
 If the answer is not there:
 
--   Join the [support Telegram](https://t.me/foundry_support) to get help, or
--   Open a [discussion](https://github.com/foundry-rs/foundry/discussions/new/choose) with your question, or
--   Open an issue with [the bug](https://github.com/foundry-rs/foundry/issues/new/choose)
+- Join the [support Telegram](https://t.me/foundry_support) to get help, or
+- Open a [discussion](https://github.com/foundry-rs/foundry/discussions/new/choose) with your question, or
+- Open an issue with [the bug](https://github.com/foundry-rs/foundry/issues/new/choose)
 
 If you want to contribute, or follow along with contributor discussion, you can use our [main telegram](https://t.me/foundry_rs) to chat with us about the development of Foundry!
 

--- a/src/Base.sol
+++ b/src/Base.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 import {StdStorage} from "./StdStorage.sol";

--- a/src/Config.sol
+++ b/src/Config.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity ^0.8.13;
 
 import {console} from "./console.sol";

--- a/src/LibVariable.sol
+++ b/src/LibVariable.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity ^0.8.13;
 
 // Enable globally.

--- a/src/Script.sol
+++ b/src/Script.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 // 💬 ABOUT

--- a/src/StdAssertions.sol
+++ b/src/StdAssertions.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 pragma experimental ABIEncoderV2;
 

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 pragma experimental ABIEncoderV2;
 

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 pragma experimental ABIEncoderV2;

--- a/src/StdConfig.sol
+++ b/src/StdConfig.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity ^0.8.13;
 
 import {VmSafe} from "./Vm.sol";

--- a/src/StdConstants.sol
+++ b/src/StdConstants.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 import {IMulticall3} from "./interfaces/IMulticall3.sol";

--- a/src/StdError.sol
+++ b/src/StdError.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 // Panics work for versions >=0.8.0, but we lowered the pragma to make this compatible with Test
 pragma solidity >=0.6.2 <0.9.0;
 

--- a/src/StdInvariant.sol
+++ b/src/StdInvariant.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 pragma experimental ABIEncoderV2;

--- a/src/StdJson.sol
+++ b/src/StdJson.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.0 <0.9.0;
 
 pragma experimental ABIEncoderV2;

--- a/src/StdMath.sol
+++ b/src/StdMath.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 library stdMath {

--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 import {Vm} from "./Vm.sol";

--- a/src/StdStyle.sol
+++ b/src/StdStyle.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.4.22 <0.9.0;
 
 import {VmSafe} from "./Vm.sol";

--- a/src/StdToml.sol
+++ b/src/StdToml.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.0 <0.9.0;
 
 pragma experimental ABIEncoderV2;

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 pragma experimental ABIEncoderV2;

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 pragma experimental ABIEncoderV2;

--- a/src/console.sol
+++ b/src/console.sol
@@ -1,30 +1,22 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.4.22 <0.9.0;
 
 library console {
-    address constant CONSOLE_ADDRESS =
-        0x000000000000000000636F6e736F6c652e6c6f67;
+    address constant CONSOLE_ADDRESS = 0x000000000000000000636F6e736F6c652e6c6f67;
 
     function _sendLogPayloadImplementation(bytes memory payload) internal view {
         address consoleAddress = CONSOLE_ADDRESS;
         /// @solidity memory-safe-assembly
         assembly {
-            pop(
-                staticcall(
-                    gas(),
-                    consoleAddress,
-                    add(payload, 32),
-                    mload(payload),
-                    0,
-                    0
-                )
-            )
+            pop(staticcall(gas(), consoleAddress, add(payload, 32), mload(payload), 0, 0))
         }
     }
 
-    function _castToPure(
-      function(bytes memory) internal view fnIn
-    ) internal pure returns (function(bytes memory) pure fnOut) {
+    function _castToPure(function(bytes memory) internal view fnIn)
+        internal
+        pure
+        returns (function(bytes memory) pure fnOut)
+    {
         assembly {
             fnOut := fnIn
         }

--- a/src/console2.sol
+++ b/src/console2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.4.22 <0.9.0;
 
 import {console as console2} from "./console.sol";

--- a/src/interfaces/IERC1155.sol
+++ b/src/interfaces/IERC1155.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2;
 
 import {IERC165} from "./IERC165.sol";

--- a/src/interfaces/IERC165.sol
+++ b/src/interfaces/IERC165.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2;
 
 interface IERC165 {

--- a/src/interfaces/IERC20.sol
+++ b/src/interfaces/IERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2;
 
 /// @dev Interface of the ERC20 standard as defined in the EIP.

--- a/src/interfaces/IERC4626.sol
+++ b/src/interfaces/IERC4626.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2;
 
 import {IERC20} from "./IERC20.sol";

--- a/src/interfaces/IERC6909.sol
+++ b/src/interfaces/IERC6909.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2;
 
 import {IERC165} from "./IERC165.sol";

--- a/src/interfaces/IERC721.sol
+++ b/src/interfaces/IERC721.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2;
 
 import {IERC165} from "./IERC165.sol";

--- a/src/interfaces/IERC7540.sol
+++ b/src/interfaces/IERC7540.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2;
 
 import {IERC7575} from "./IERC7575.sol";

--- a/src/interfaces/IERC7575.sol
+++ b/src/interfaces/IERC7575.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2;
 
 import {IERC165} from "./IERC165.sol";

--- a/src/interfaces/IMulticall3.sol
+++ b/src/interfaces/IMulticall3.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 pragma experimental ABIEncoderV2;

--- a/src/safeconsole.sol
+++ b/src/safeconsole.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 /// @author philogy <https://github.com/philogy>

--- a/test/CommonBase.t.sol
+++ b/test/CommonBase.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.7.0 <0.9.0;
 
 import {CommonBase} from "../src/Base.sol";

--- a/test/Config.t.sol
+++ b/test/Config.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity ^0.8.13;
 
 import {Test} from "../src/Test.sol";

--- a/test/LibVariable.t.sol
+++ b/test/LibVariable.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity ^0.8.13;
 
 import {Test} from "../src/Test.sol";

--- a/test/StdAssertions.t.sol
+++ b/test/StdAssertions.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.7.0 <0.9.0;
 
 import {StdAssertions} from "../src/StdAssertions.sol";

--- a/test/StdChains.t.sol
+++ b/test/StdChains.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.7.0 <0.9.0;
 
 import {Test} from "../src/Test.sol";

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.7.0 <0.9.0;
 
 import {StdCheats} from "../src/StdCheats.sol";

--- a/test/StdConstants.t.sol
+++ b/test/StdConstants.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.7.0 <0.9.0;
 
 import {StdConstants} from "../src/StdConstants.sol";

--- a/test/StdError.t.sol
+++ b/test/StdError.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
 import {stdError} from "../src/StdError.sol";

--- a/test/StdJson.t.sol
+++ b/test/StdJson.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.7.0 <0.9.0;
 
 import {Test, stdJson} from "../src/Test.sol";

--- a/test/StdMath.t.sol
+++ b/test/StdMath.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
 import {stdMath} from "../src/StdMath.sol";

--- a/test/StdStorage.t.sol
+++ b/test/StdStorage.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.7.0 <0.9.0;
 
 import {stdStorage, StdStorage} from "../src/StdStorage.sol";

--- a/test/StdStyle.t.sol
+++ b/test/StdStyle.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.7.0 <0.9.0;
 
 import {Test, console2, StdStyle} from "../src/Test.sol";

--- a/test/StdToml.t.sol
+++ b/test/StdToml.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.7.0 <0.9.0;
 
 import {Test, stdToml} from "../src/Test.sol";

--- a/test/StdUtils.t.sol
+++ b/test/StdUtils.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.7.0 <0.9.0;
 
 import {Test, StdUtils} from "../src/Test.sol";

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.8.0 <0.9.0;
 
 import {Test} from "../src/Test.sol";

--- a/test/compilation/CompilationScript.sol
+++ b/test/compilation/CompilationScript.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 pragma experimental ABIEncoderV2;

--- a/test/compilation/CompilationScriptBase.sol
+++ b/test/compilation/CompilationScriptBase.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 pragma experimental ABIEncoderV2;

--- a/test/compilation/CompilationTest.sol
+++ b/test/compilation/CompilationTest.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 pragma experimental ABIEncoderV2;

--- a/test/compilation/CompilationTestBase.sol
+++ b/test/compilation/CompilationTestBase.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.6.2 <0.9.0;
 
 pragma experimental ABIEncoderV2;


### PR DESCRIPTION
Many files were only marked as `// SPDX-License-Identifier: MIT` whilst we distribute as dual MIT / Apache 2.0

Other small changes are formatter related 