### PR TITLE
Clarify stdJson key syntax

### DIFF
--- a/src/StdJson.sol
+++ b/src/StdJson.sol
@@ -3,12 +3,15 @@ pragma solidity >=0.8.13 <0.9.0;
 
 import {VmSafe} from "./Vm.sol";
 
-// Helpers for parsing and writing JSON files
+// Helpers for parsing and writing JSON files.
+// `key` parameters use the same selector syntax as the `vm.parseJson*` cheatcodes,
+// for example `.a` for a nested field or `$` for the root object.
 // To parse:
 // ```
 // using stdJson for string;
 // string memory json = vm.readFile("<some_path>");
-// json.readUint("<json_path>");
+// uint256 value = json.readUint(".a");
+// bytes memory encoded = json.parseRaw("$");
 // ```
 // To write:
 // ```
@@ -23,10 +26,14 @@ import {VmSafe} from "./Vm.sol";
 library stdJson {
     VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
 
+    /// @dev Returns whether `key` exists in `json`.
+    /// `key` uses the same selector syntax as `vm.parseJson*`, such as `.a` or `$`.
     function keyExists(string memory json, string memory key) internal view returns (bool) {
         return vm.keyExistsJson(json, key);
     }
 
+    /// @dev ABI-encodes the JSON value selected by `key`.
+    /// `key` uses the same selector syntax as `vm.parseJson*`, such as `.a` or `$`.
     function parseRaw(string memory json, string memory key) internal pure returns (bytes memory) {
         return vm.parseJson(json, key);
     }


### PR DESCRIPTION
  The `stdJson` docs currently use a generic `<json_path>` placeholder, but the API actually expects the same selector syntax as `vm.parseJson*`. The existing tests already show the real usage with `.a` for a field and `$` for the root object in `test/StdJson.t.sol`, so the current comments are easy to misread.                    
                                                                                                                                                                         
  This updates the `StdJson` examples and function docs to match the behavior that is already implemented and tested today. It is a comment-only change with no ABI or runtime impact, just a documentation fix that makes the interface clearer and more accurate.  