### PR TITLE
docs(IERC7540): clarify requestDeposit authorization

### DIFF
--- a/src/interfaces/IERC7540.sol
+++ b/src/interfaces/IERC7540.sol
@@ -41,12 +41,12 @@ interface IERC7540Deposit is IERC7540Operator {
         address indexed controller, address indexed owner, uint256 indexed requestId, address sender, uint256 assets
     );
     /**
-     * @dev Transfers assets from sender into the Vault and submits a Request for asynchronous deposit.
+     * @dev Transfers assets from owner into the Vault and submits a Request for asynchronous deposit.
      *
      * - MUST support ERC-20 approve / transferFrom on asset as a deposit Request flow.
-     * - MUST revert if all assets cannot be requested for deposit.
-     * - owner MUST be msg.sender unless some unspecified explicit approval is given by the caller,
-     *    approval of ERC-20 tokens from owner to sender is NOT enough.
+     * - owner MUST equal msg.sender unless the owner has approved the msg.sender as an operator.
+     * - MUST revert if all assets cannot be requested for deposit or mint.
+     * - MUST emit the DepositRequest event.
      *
      * @param assets the amount of deposit assets to transfer from owner
      * @param controller the controller of the request who will be able to operate the request


### PR DESCRIPTION
  Clarify `IERC7540.requestDeposit` to match the owner-based operator authorization model, and document the required `DepositRequest` emission plus deposit/mint failure condition. 