### PR TITLE
feat: add Radius Network chain

### DIFF
--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -265,6 +265,11 @@ abstract contract StdChains {
         setChainWithDefaultRpcUrl("race", ChainData("Race", 6805, "https://racemainnet.io"));
         setChainWithDefaultRpcUrl("race_sepolia", ChainData("Race Sepolia", 6806, "https://racemainnet.io"));
 
+        setChainWithDefaultRpcUrl("radius", ChainData("Radius", 723487, "https://rpc.radiustech.xyz"));
+        setChainWithDefaultRpcUrl(
+            "radius_testnet", ChainData("Radius Testnet", 72344, "https://rpc.testnet.radiustech.xyz")
+        );
+
         setChainWithDefaultRpcUrl("metal", ChainData("Metal", 1750, "https://metall2.drpc.org"));
         setChainWithDefaultRpcUrl("metal_sepolia", ChainData("Metal Sepolia", 1740, "https://testnet.rpc.metall2.com"));
 


### PR DESCRIPTION
Add Radius (723487) and Radius Testnet (72344) to `StdChains`.

Radius is an EVM-compatible stablecoin platform with sub-second finality and stablecoin-native fees (~$0.0001/tx).

## Chain details

| | Mainnet | Testnet |
|---|---|---|
| Chain ID | 723487 | 72344 |
| RPC | https://rpc.radiustech.xyz | https://rpc.testnet.radiustech.xyz |
| Explorer | https://network.radiustech.xyz | https://testnet.radiustech.xyz |
| Native currency | RUSD (18 decimals) | RUSD (18 decimals) |

- EIP-1559 and legacy transactions supported
- Shanghai supported

Website: https://radiustech.xyz
Docs: https://docs.radiustech.xyz
alloy-rs/chains: https://github.com/alloy-rs/chains/pull/269
ethereum-lists/chains: https://github.com/ethereum-lists/chains/pull/8168 (merged)