### PR TITLE
docs: add NatSpec to StdMath and StdError

### DIFF
--- a/src/StdError.sol
+++ b/src/StdError.sol
@@ -2,14 +2,32 @@
 // Panics work for versions >=0.8.0, but we lowered the pragma to make this compatible with Test
 pragma solidity >=0.8.13 <0.9.0;
 
+/// @notice Pre-encoded Solidity panic error selectors for use in test assertions.
 library stdError {
+    /// @notice Panic caused by `assert(false)` or an assertion failure (0x01).
     bytes public constant assertionError = abi.encodeWithSignature("Panic(uint256)", 0x01);
+
+    /// @notice Panic caused by arithmetic overflow or underflow (0x11).
     bytes public constant arithmeticError = abi.encodeWithSignature("Panic(uint256)", 0x11);
+
+    /// @notice Panic caused by division or modulo by zero (0x12).
     bytes public constant divisionError = abi.encodeWithSignature("Panic(uint256)", 0x12);
+
+    /// @notice Panic caused by converting a value that is too large or negative into an enum type (0x21).
     bytes public constant enumConversionError = abi.encodeWithSignature("Panic(uint256)", 0x21);
+
+    /// @notice Panic caused by accessing incorrectly encoded storage data (0x22).
     bytes public constant encodeStorageError = abi.encodeWithSignature("Panic(uint256)", 0x22);
+
+    /// @notice Panic caused by calling `.pop()` on an empty array (0x31).
     bytes public constant popError = abi.encodeWithSignature("Panic(uint256)", 0x31);
+
+    /// @notice Panic caused by accessing an array, bytesN, or slice at an out-of-bounds index (0x32).
     bytes public constant indexOOBError = abi.encodeWithSignature("Panic(uint256)", 0x32);
+
+    /// @notice Panic caused by allocating too much memory or creating an array that is too large (0x41).
     bytes public constant memOverflowError = abi.encodeWithSignature("Panic(uint256)", 0x41);
+
+    /// @notice Panic caused by calling a zero-initialized variable of internal function type (0x51).
     bytes public constant zeroVarError = abi.encodeWithSignature("Panic(uint256)", 0x51);
 }

--- a/src/StdMath.sol
+++ b/src/StdMath.sol
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 pragma solidity >=0.8.13 <0.9.0;
 
+/// @notice Mathematical utility functions for unsigned and signed integers.
 library stdMath {
     int256 private constant INT256_MIN = -57896044618658097711785492504343953926634992332820282019728792003956564819968;
 
+    /// @notice Computes the absolute value of a signed integer.
+    /// @param a The signed integer to compute the absolute value of.
+    /// @return The absolute value as an unsigned integer.
     function abs(int256 a) internal pure returns (uint256) {
         // Required or it will fail when `a = type(int256).min`
         if (a == INT256_MIN) {
@@ -13,10 +17,18 @@ library stdMath {
         return uint256(a > 0 ? a : -a);
     }
 
+    /// @notice Computes the absolute difference between two unsigned integers.
+    /// @param a The first unsigned integer.
+    /// @param b The second unsigned integer.
+    /// @return The absolute difference between `a` and `b`.
     function delta(uint256 a, uint256 b) internal pure returns (uint256) {
         return a > b ? a - b : b - a;
     }
 
+    /// @notice Computes the absolute difference between two signed integers.
+    /// @param a The first signed integer.
+    /// @param b The second signed integer.
+    /// @return The absolute difference between `a` and `b`.
     function delta(int256 a, int256 b) internal pure returns (uint256) {
         // a and b are of the same sign
         // this works thanks to two's complement, the left-most bit is the sign bit
@@ -28,6 +40,10 @@ library stdMath {
         return abs(a) + abs(b);
     }
 
+    /// @notice Computes the percentage difference between two unsigned integers, scaled by 1e18.
+    /// @param a The value to compare.
+    /// @param b The reference value (divisor). Must not be zero.
+    /// @return The percentage difference scaled by 1e18 (1e18 represents 100%).
     function percentDelta(uint256 a, uint256 b) internal pure returns (uint256) {
         // Prevent division by zero
         require(b != 0, "stdMath percentDelta(uint256,uint256): Divisor is zero");
@@ -36,6 +52,10 @@ library stdMath {
         return absDelta * 1e18 / b;
     }
 
+    /// @notice Computes the percentage difference between two signed integers, scaled by 1e18.
+    /// @param a The value to compare.
+    /// @param b The reference value (divisor). Its absolute value must not be zero.
+    /// @return The percentage difference scaled by 1e18 (1e18 represents 100%).
     function percentDelta(int256 a, int256 b) internal pure returns (uint256) {
         uint256 absDelta = delta(a, b);
         uint256 absB = abs(b);


### PR DESCRIPTION
Part of #653. Two more of the files listed in the NatSpec docs checklist.

## StdMath.sol

Added \`@notice\`, \`@param\`, and \`@return\` tags to the library and all five internal functions:

- \`abs(int256)\`
- \`delta(uint256, uint256)\`
- \`delta(int256, int256)\`
- \`percentDelta(uint256, uint256)\`
- \`percentDelta(int256, int256)\`

I did not rename \`INT256_MIN\` to \`_INT256_MIN\` even though the issue mentions the underscore-prefix convention for private variables. The already-merged StdAssertions.sol work (PR #666 / StdInvariant) left its private constants without the underscore prefix (for example \`FAILED_SLOT\`), so I matched that pattern to keep this PR purely additive. Happy to apply the rename in a follow-up or in this PR if you prefer the underscore convention going forward. Let me know which way you want to settle it.

## StdError.sol

Added \`@notice\` to each of the nine public panic-code constants describing what Solidity panic it corresponds to. Panic codes cross-checked against the Solidity docs.

## What is not in this PR

- No logic changes
- No interface changes
- No file reordering (internal up, private down was also listed in #653 - can do that in a follow-up if you want)
- No tests touched

## Testing

I do not have Foundry set up on this machine so I have not run \`forge fmt --check\` or \`forge test\` locally. The diff is 38 insertions and 0 deletions, all inside NatSpec comment blocks above existing declarations, so behavior is unchanged. CI should cover the formatting and test pass. If CI flags anything I will fix it in this branch.

Happy to split this into two PRs (one per file) if that is easier to review.