### PR TITLE
feat(StdChains): add Gravity mainnet (127001)

### DIFF
--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -290,6 +290,8 @@ abstract contract StdChains {
         setChainWithDefaultRpcUrl(
             "tempo_andantino", ChainData("Tempo Andantino", 42429, "https://rpc.testnet.tempo.xyz")
         );
+
+        setChainWithDefaultRpcUrl("grav", ChainData("Gravity", 127001, "https://mainnet-rpc.gravity.xyz"));
     }
 
     // set chain info, with priority to chainAlias' rpc url in foundry.toml


### PR DESCRIPTION
### Summary

Adds [Gravity](https://gravity.xyz) L1 mainnet (chain id `127001`, native token `G`) to `StdChains` so that scripts and tests can resolve the chain via `getChain("grav")`.

Gravity L1 is a new EVM-compatible L1 (reth-based execution + Aptos-derived BFT consensus). The `grav` alias matches the `shortName` registered in [`ethereum-lists/chains`](https://github.com/ethereum-lists/chains) — the existing `gravity` short name is already taken by Gravity Alpha L2 (chain id `1625`).

### Notes / Open items
Companion change in alloy: alloy-rs/chains#275

### Checklist

- [x] `forge build` passes locally
- [x] Alias matches `ethereum-lists/chains` `shortName`