### PR TITLE
feat(console): add console.table

### DIFF
--- a/src/console.sol
+++ b/src/console.sol
@@ -1548,4 +1548,52 @@ library console {
     function log(address p0, address p1, address p2, address p3) internal pure {
         _sendLogPayload(abi.encodeWithSignature("log(address,address,address,address)", p0, p1, p2, p3));
     }
+
+    function table(uint256[] memory values) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("table(uint256[])", values));
+    }
+
+    function table(int256[] memory values) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("table(int256[])", values));
+    }
+
+    function table(address[] memory values) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("table(address[])", values));
+    }
+
+    function table(bytes32[] memory values) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("table(bytes32[])", values));
+    }
+
+    function table(string[] memory values) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("table(string[])", values));
+    }
+
+    function table(bool[] memory values) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("table(bool[])", values));
+    }
+
+    function table(string[] memory keys, uint256[] memory values) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("table(string[],uint256[])", keys, values));
+    }
+
+    function table(string[] memory keys, int256[] memory values) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("table(string[],int256[])", keys, values));
+    }
+
+    function table(string[] memory keys, address[] memory values) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("table(string[],address[])", keys, values));
+    }
+
+    function table(string[] memory keys, bytes32[] memory values) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("table(string[],bytes32[])", keys, values));
+    }
+
+    function table(string[] memory keys, string[] memory values) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("table(string[],string[])", keys, values));
+    }
+
+    function table(string[] memory keys, bool[] memory values) internal pure {
+        _sendLogPayload(abi.encodeWithSignature("table(string[],bool[])", keys, values));
+    }
 }


### PR DESCRIPTION
Resolves #91

- Depends on https://github.com/foundry-rs/foundry/pull/14338

Two of the most common use-cases for tables are easily logging arrays and comparing multiple labelled values, which often leads the user to manually line up the values like so:

```solidity
console.log("alice  ", 0x328809Bc894f92807417D2dAD6b7C998c1aFdac6);
console.log("bob    ", 0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e);
console.log("charlie", 0xea475d60c118d7058beF4bDd9c32bA51139a74e0);
```

Both of those use-cases can be solved with a table with a single column of values. For this reason and because it would double the variants, I've opted to not support tables with multiple value columns, though it can be added in the future.

This adds 12 variants for `console.table`:
- 6 single-array (auto-indexed, array of values)
- 6 keyed (`string[]` indexes, array of values)

Value types supported: `uint256`, `int256`, `address`, `bytes32`, `string`, `bool`.

Some notes:
- I've added this to `console` and not `console2` since it's just adding new functionality and not introducing any breaking changes. For `console2` to inherit from `console` and have its own new methods, I would need to import each method from `console` and define new ones in `console2` since libraries don't support inheritance, which would be a lot of maintenance, and also would involve the question of whether to use the same `CONSOLE_ADDRESS`
- I've chosen the box characters `┌`, `─`, `┼`, `│`, etc. to more closely match Node.js's `console.table` output and because it's more aesthetically pleasing, but if preferred, a simpler option is to use the ASCII version with just `-`, `+`, `|`

Usage example:

```solidity
string[] memory idxs = new string[](3);
idxs[0] = "alice";
idxs[1] = "bob";
idxs[2] = "charlie";
address[] memory addrs = new address[](3);
bytes32[] memory hashes = new bytes32[](3);
for (uint256 i = 0; i < idxs.length; i++) {
    addrs[i] = makeAddr(idxs[i]);
    hashes[i] = keccak256(abi.encodePacked(idxs[i]));
}
console.table(addrs);
console.table(idxs, addrs);
console.table(idxs, hashes);
```

Output:

```txt
Logs:
  ┌─────────┬────────────────────────────────────────────┐
  │ (index) │ Values                                     │
  ├─────────┼────────────────────────────────────────────┤
  │ 0       │ 0x328809Bc894f92807417D2dAD6b7C998c1aFdac6 │
  │ 1       │ 0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e │
  │ 2       │ 0xea475d60c118d7058beF4bDd9c32bA51139a74e0 │
  └─────────┴────────────────────────────────────────────┘
  ┌─────────┬────────────────────────────────────────────┐
  │ (index) │ Values                                     │
  ├─────────┼────────────────────────────────────────────┤
  │ alice   │ 0x328809Bc894f92807417D2dAD6b7C998c1aFdac6 │
  │ bob     │ 0x1D96F2f6BeF1202E4Ce1Ff6Dad0c2CB002861d3e │
  │ charlie │ 0xea475d60c118d7058beF4bDd9c32bA51139a74e0 │
  └─────────┴────────────────────────────────────────────┘
  ┌─────────┬────────────────────────────────────────────────────────────────────┐
  │ (index) │ Values                                                             │
  ├─────────┼────────────────────────────────────────────────────────────────────┤
  │ alice   │ 0x9c0257114eb9399a2985f8e75dad7600c5d89fe3824ffa99ec1c3eb8bf3b0501 │
  │ bob     │ 0x38e47a7b719dce63662aeaf43440326f551b8a7ee198cee35cb5d517f2d296a2 │
  │ charlie │ 0x87a213ce1ee769e28decedefb98f6fe48890a74ba84957ebf877fb591e37e0de │
  └─────────┴────────────────────────────────────────────────────────────────────┘
```