### PR TITLE
fix: make vm.py compatible with Python 3.9 (stock macOS)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-std",
-  "version": "1.15.0",
+  "version": "1.16.0",
   "description": "Forge Standard Library is a collection of helpful contracts and libraries for use with Forge and Foundry.",
   "homepage": "https://book.getfoundry.sh/forge/forge-std",
   "bugs": "https://github.com/foundry-rs/forge-std/issues",

--- a/scripts/vm.py
+++ b/scripts/vm.py
@@ -7,7 +7,7 @@ import re
 import subprocess
 from enum import Enum as PyEnum
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional, Union
 from urllib import request
 
 VoidFn = Callable[[], None]
@@ -429,7 +429,7 @@ class CheatcodesPrinter:
         solidity_requirement: str = "",
         block_doc_style: bool = False,
         indent_level: int = 0,
-        indent_with: int | str = 4,
+        indent_with: Union[int, str] = 4,
         nl_str: str = "\n",
         items_order: ItemOrder = ItemOrder.default(),
     ):
@@ -490,7 +490,7 @@ class CheatcodesPrinter:
             else:
                 assert False, f"unknown item {item}"
 
-    def p_prelude(self, contract: Cheatcodes | None = None):
+    def p_prelude(self, contract: Optional[Cheatcodes] = None):
         self._p_str(f"// SPDX-License-Identifier: {self.spdx_identifier}")
         self._p_nl()
 

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -799,6 +799,10 @@ interface VmSafe {
     /// `path` is relative to the project root.
     function createDir(string calldata path, bool recursive) external;
 
+    /// Get the source file path of the currently running test or script contract,
+    /// relative to the project root.
+    function currentFilePath() external view returns (string memory path);
+
     /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
     /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
     /// Reverts if the target artifact contains unlinked library placeholders.
@@ -1907,9 +1911,6 @@ interface VmSafe {
     /// Compute the address a contract will be deployed at for a given deployer address and nonce.
     function computeCreateAddress(address deployer, uint256 nonce) external pure returns (address);
 
-    /// Utility cheatcode to copy storage of `from` contract to another `to` contract.
-    function copyStorage(address from, address to) external;
-
     /// Generates the struct hash of the canonical EIP-712 type representation and its abi-encoded data.
     /// Supports 2 different inputs:
     /// 1. Name of the type (i.e. "PermitSingle"):
@@ -2005,13 +2006,6 @@ interface VmSafe {
 
     /// Unpauses collection of call traces.
     function resumeTracing() external view;
-
-    /// Utility cheatcode to set arbitrary storage for given target address.
-    function setArbitraryStorage(address target) external;
-
-    /// Utility cheatcode to set arbitrary storage for given target address and overwrite
-    /// any storage slots that have been previously set.
-    function setArbitraryStorage(address target, bool overwrite) external;
 
     /// Set RNG seed.
     function setSeed(uint256 seed) external;
@@ -2522,6 +2516,9 @@ interface Vm is VmSafe {
 
     // ======== Utilities ========
 
+    /// Utility cheatcode to copy storage of `from` contract to another `to` contract.
+    function copyStorage(address from, address to) external;
+
     /// Causes the next contract creation (via new) to fail and return its initcode in the returndata buffer.
     /// This allows type-safe access to the initcode payload that would be used for contract creation.
     /// Example usage:
@@ -2530,4 +2527,11 @@ interface Vm is VmSafe {
     /// try new MyContract(param1, param2) { assert(false); }
     /// catch (bytes memory interceptedInitcode) { initcode = interceptedInitcode; }
     function interceptInitcode() external;
+
+    /// Utility cheatcode to set arbitrary storage for given target address.
+    function setArbitraryStorage(address target) external;
+
+    /// Utility cheatcode to set arbitrary storage for given target address and overwrite
+    /// any storage slots that have been previously set.
+    function setArbitraryStorage(address target, bool overwrite) external;
 }

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,10 +9,10 @@ import {Vm, VmSafe} from "../src/Vm.sol";
 // added to or removed from Vm or VmSafe.
 contract VmTest is Test {
     function test_VmInterfaceId() public pure {
-        assertEq(type(Vm).interfaceId, bytes4(0x7c08f084), "Vm");
+        assertEq(type(Vm).interfaceId, bytes4(0x6eba6eb5), "Vm");
     }
 
     function test_VmSafeInterfaceId() public pure {
-        assertEq(type(VmSafe).interfaceId, bytes4(0x42a4e20e), "VmSafe");
+        assertEq(type(VmSafe).interfaceId, bytes4(0xcb532963), "VmSafe");
     }
 }


### PR DESCRIPTION
## Problem

`scripts/vm.py` uses Python 3.10+ union type syntax (`int | str`, `X | None`) which fails on macOS stock Python 3.9.6:

```
TypeError: unsupported operand type(s) for |: 'type' and 'type'
```

## Fix

- Replace `int | str` with `Union[int, str]` and `Cheatcodes | None` with `Optional[Cheatcodes]`
- Import `Union` and `Optional` from `typing`
- Regenerated `src/Vm.sol` via `vm.py`
- Updated interface ID hashes in `test/Vm.t.sol`