### PR TITLE
chore(release): bump package.json for v1.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forge-std",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "description": "Forge Standard Library is a collection of helpful contracts and libraries for use with Forge and Foundry.",
   "homepage": "https://book.getfoundry.sh/forge/forge-std",
   "bugs": "https://github.com/foundry-rs/forge-std/issues",


### PR DESCRIPTION
To include compatibility fix: https://github.com/foundry-rs/forge-std/pull/854 so users don't get the warning wall if they use 0.8.35