### PR TITLE
refactor: prefix private members with underscore

### DIFF
--- a/src/StdAssertions.sol
+++ b/src/StdAssertions.sol
@@ -33,7 +33,7 @@ abstract contract StdAssertions {
     event log_named_array(string key, int256[] val);
     event log_named_array(string key, address[] val);
 
-    bytes32 private constant FAILED_SLOT = bytes32("failed");
+    bytes32 private constant _FAILED_SLOT = bytes32("failed");
 
     bool private _failed;
 
@@ -43,13 +43,13 @@ abstract contract StdAssertions {
         if (_failed) {
             return true;
         } else {
-            return vm.load(address(vm), FAILED_SLOT) != bytes32(0);
+            return vm.load(address(vm), _FAILED_SLOT) != bytes32(0);
         }
     }
 
     /// @notice Marks the test as failed and records the failure in storage.
     function fail() internal virtual {
-        vm.store(address(vm), FAILED_SLOT, bytes32(uint256(1)));
+        vm.store(address(vm), _FAILED_SLOT, bytes32(uint256(1)));
         _failed = true;
     }
 

--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -9,7 +9,7 @@ import {VmSafe} from "./Vm.sol";
  * identified by their alias, which is the same as the alias in the `[rpc_endpoints]` section of
  * the `foundry.toml` file. For best UX, ensure the alias in the `foundry.toml` file matches the
  * alias used in this contract, which can be found as the first argument to the
- * `setChainWithDefaultRpcUrl` call in the `initializeStdChains` function.
+ * `_setChainWithDefaultRpcUrl` call in the `_initializeStdChains` function.
  *
  * There are two main ways to use this contract:
  *   1. Set a chain with `setChain(string memory chainAlias, ChainData memory chain)` or
@@ -17,12 +17,12 @@ import {VmSafe} from "./Vm.sol";
  *   2. Get a chain with `getChain(string memory chainAlias)` or `getChain(uint256 chainId)`.
  *
  * The first time either of those are used, chains are initialized with the default set of RPC URLs.
- * This is done in `initializeStdChains`, which uses `setChainWithDefaultRpcUrl`. Defaults are recorded in
- * `defaultRpcUrls`.
+ * This is done in `_initializeStdChains`, which uses `_setChainWithDefaultRpcUrl`. Defaults are recorded in
+ * `_defaultRpcUrls`.
  *
  * The `setChain` function is straightforward, and it simply saves off the given chain data.
  *
- * The `getChain` methods use `getChainWithUpdatedRpcUrl` to return a chain. For example, let's say
+ * The `getChain` methods use `_getChainWithUpdatedRpcUrl` to return a chain. For example, let's say
  * we want to retrieve the RPC URL for `mainnet`:
  *   - If you have specified data with `setChain`, it will return that.
  *   - If you have configured a mainnet RPC URL in `foundry.toml`, it will return the URL, provided it
@@ -34,7 +34,7 @@ import {VmSafe} from "./Vm.sol";
 abstract contract StdChains {
     VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    bool private stdChainsInitialized;
+    bool private _stdChainsInitialized;
 
     struct ChainData {
         string name;
@@ -57,44 +57,44 @@ abstract contract StdChains {
     }
 
     // Maps from the chain's alias (matching the alias in the `foundry.toml` file) to chain data.
-    mapping(string => Chain) private chains;
+    mapping(string => Chain) private _chains;
     // Maps from the chain's alias to its default RPC URL.
-    mapping(string => string) private defaultRpcUrls;
+    mapping(string => string) private _defaultRpcUrls;
     // Maps from a chain ID to its alias.
-    mapping(uint256 => string) private idToAlias;
+    mapping(uint256 => string) private _idToAlias;
 
-    bool private fallbackToDefaultRpcUrls = true;
+    bool private _fallbackToDefaultRpcUrls = true;
 
     /// @notice Returns chain data for the given alias, with the RPC URL resolved from config or defaults.
     /// @dev Reverts if `chainAlias` is empty or has not been registered.
     function getChain(string memory chainAlias) internal virtual returns (Chain memory chain) {
         require(bytes(chainAlias).length != 0, "StdChains getChain(string): Chain alias cannot be the empty string.");
 
-        initializeStdChains();
-        chain = chains[chainAlias];
+        _initializeStdChains();
+        chain = _chains[chainAlias];
         require(
             chain.chainId != 0,
             string(abi.encodePacked("StdChains getChain(string): Chain with alias \"", chainAlias, "\" not found."))
         );
 
-        chain = getChainWithUpdatedRpcUrl(chainAlias, chain);
+        chain = _getChainWithUpdatedRpcUrl(chainAlias, chain);
     }
 
     /// @notice Returns chain data for the given chain ID, with the RPC URL resolved from config or defaults.
     /// @dev Reverts if `chainId` is `0` or has not been registered.
     function getChain(uint256 chainId) internal virtual returns (Chain memory chain) {
         require(chainId != 0, "StdChains getChain(uint256): Chain ID cannot be 0.");
-        initializeStdChains();
-        string memory chainAlias = idToAlias[chainId];
+        _initializeStdChains();
+        string memory chainAlias = _idToAlias[chainId];
 
-        chain = chains[chainAlias];
+        chain = _chains[chainAlias];
 
         require(
             chain.chainId != 0,
             string(abi.encodePacked("StdChains getChain(uint256): Chain with ID ", vm.toString(chainId), " not found."))
         );
 
-        chain = getChainWithUpdatedRpcUrl(chainAlias, chain);
+        chain = _getChainWithUpdatedRpcUrl(chainAlias, chain);
     }
 
     /// @notice Registers chain data under `chainAlias`, with priority given to the argument's `rpcUrl` field.
@@ -106,8 +106,8 @@ abstract contract StdChains {
 
         require(chain.chainId != 0, "StdChains setChain(string,ChainData): Chain ID cannot be 0.");
 
-        initializeStdChains();
-        string memory foundAlias = idToAlias[chain.chainId];
+        _initializeStdChains();
+        string memory foundAlias = _idToAlias[chain.chainId];
 
         require(
             bytes(foundAlias).length == 0 || keccak256(bytes(foundAlias)) == keccak256(bytes(chainAlias)),
@@ -122,12 +122,12 @@ abstract contract StdChains {
             )
         );
 
-        uint256 oldChainId = chains[chainAlias].chainId;
-        delete idToAlias[oldChainId];
+        uint256 oldChainId = _chains[chainAlias].chainId;
+        delete _idToAlias[oldChainId];
 
-        chains[chainAlias] =
+        _chains[chainAlias] =
             Chain({name: chain.name, chainId: chain.chainId, chainAlias: chainAlias, rpcUrl: chain.rpcUrl});
-        idToAlias[chain.chainId] = chainAlias;
+        _idToAlias[chain.chainId] = chainAlias;
     }
 
     /// @notice Registers chain data under `chainAlias`, with priority given to the argument's `rpcUrl` field.
@@ -151,7 +151,7 @@ abstract contract StdChains {
 
     // lookup rpcUrl, in descending order of priority:
     // current -> config (foundry.toml) -> environment variable -> default
-    function getChainWithUpdatedRpcUrl(string memory chainAlias, Chain memory chain)
+    function _getChainWithUpdatedRpcUrl(string memory chainAlias, Chain memory chain)
         private
         view
         returns (Chain memory)
@@ -161,8 +161,8 @@ abstract contract StdChains {
                 chain.rpcUrl = configRpcUrl;
             } catch (bytes memory err) {
                 string memory envName = string(abi.encodePacked(_toUpper(chainAlias), "_RPC_URL"));
-                if (fallbackToDefaultRpcUrls) {
-                    chain.rpcUrl = vm.envOr(envName, defaultRpcUrls[chainAlias]);
+                if (_fallbackToDefaultRpcUrls) {
+                    chain.rpcUrl = vm.envOr(envName, _defaultRpcUrls[chainAlias]);
                 } else {
                     chain.rpcUrl = vm.envString(envName);
                 }
@@ -189,124 +189,126 @@ abstract contract StdChains {
 
     /// @notice Sets whether to fall back to default RPC URLs when no URL is configured for a chain.
     function setFallbackToDefaultRpcUrls(bool useDefault) internal {
-        fallbackToDefaultRpcUrls = useDefault;
+        _fallbackToDefaultRpcUrls = useDefault;
     }
 
-    function initializeStdChains() private {
-        if (stdChainsInitialized) return;
+    function _initializeStdChains() private {
+        if (_stdChainsInitialized) return;
 
-        stdChainsInitialized = true;
+        _stdChainsInitialized = true;
 
         // If adding an RPC here, make sure to test the default RPC URL in `test_Rpcs` in `StdChains.t.sol`
-        setChainWithDefaultRpcUrl("anvil", ChainData("Anvil", 31337, "http://127.0.0.1:8545"));
-        setChainWithDefaultRpcUrl("mainnet", ChainData("Mainnet", 1, "https://eth.llamarpc.com"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("anvil", ChainData("Anvil", 31337, "http://127.0.0.1:8545"));
+        _setChainWithDefaultRpcUrl("mainnet", ChainData("Mainnet", 1, "https://eth.llamarpc.com"));
+        _setChainWithDefaultRpcUrl(
             "sepolia", ChainData("Sepolia", 11155111, "https://sepolia.infura.io/v3/b9794ad1ddf84dfb8c34d6bb5dca2001")
         );
-        setChainWithDefaultRpcUrl("holesky", ChainData("Holesky", 17000, "https://rpc.holesky.ethpandaops.io"));
-        setChainWithDefaultRpcUrl("hoodi", ChainData("Hoodi", 560048, "https://rpc.hoodi.ethpandaops.io"));
-        setChainWithDefaultRpcUrl("optimism", ChainData("Optimism", 10, "https://mainnet.optimism.io"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("holesky", ChainData("Holesky", 17000, "https://rpc.holesky.ethpandaops.io"));
+        _setChainWithDefaultRpcUrl("hoodi", ChainData("Hoodi", 560048, "https://rpc.hoodi.ethpandaops.io"));
+        _setChainWithDefaultRpcUrl("optimism", ChainData("Optimism", 10, "https://mainnet.optimism.io"));
+        _setChainWithDefaultRpcUrl(
             "optimism_sepolia", ChainData("Optimism Sepolia", 11155420, "https://sepolia.optimism.io")
         );
-        setChainWithDefaultRpcUrl("arbitrum_one", ChainData("Arbitrum One", 42161, "https://arb1.arbitrum.io/rpc"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("arbitrum_one", ChainData("Arbitrum One", 42161, "https://arb1.arbitrum.io/rpc"));
+        _setChainWithDefaultRpcUrl(
             "arbitrum_one_sepolia", ChainData("Arbitrum One Sepolia", 421614, "https://sepolia-rollup.arbitrum.io/rpc")
         );
-        setChainWithDefaultRpcUrl("arbitrum_nova", ChainData("Arbitrum Nova", 42170, "https://nova.arbitrum.io/rpc"));
-        setChainWithDefaultRpcUrl("polygon", ChainData("Polygon", 137, "https://polygon-rpc.com"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("arbitrum_nova", ChainData("Arbitrum Nova", 42170, "https://nova.arbitrum.io/rpc"));
+        _setChainWithDefaultRpcUrl("polygon", ChainData("Polygon", 137, "https://polygon-rpc.com"));
+        _setChainWithDefaultRpcUrl(
             "polygon_amoy", ChainData("Polygon Amoy", 80002, "https://rpc-amoy.polygon.technology")
         );
-        setChainWithDefaultRpcUrl("avalanche", ChainData("Avalanche", 43114, "https://api.avax.network/ext/bc/C/rpc"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("avalanche", ChainData("Avalanche", 43114, "https://api.avax.network/ext/bc/C/rpc"));
+        _setChainWithDefaultRpcUrl(
             "avalanche_fuji", ChainData("Avalanche Fuji", 43113, "https://api.avax-test.network/ext/bc/C/rpc")
         );
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl(
             "bnb_smart_chain", ChainData("BNB Smart Chain", 56, "https://bsc-dataseed1.binance.org")
         );
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl(
             "bnb_smart_chain_testnet",
             ChainData("BNB Smart Chain Testnet", 97, "https://rpc.ankr.com/bsc_testnet_chapel")
         );
-        setChainWithDefaultRpcUrl("gnosis_chain", ChainData("Gnosis Chain", 100, "https://rpc.gnosischain.com"));
-        setChainWithDefaultRpcUrl("moonbeam", ChainData("Moonbeam", 1284, "https://rpc.api.moonbeam.network"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("gnosis_chain", ChainData("Gnosis Chain", 100, "https://rpc.gnosischain.com"));
+        _setChainWithDefaultRpcUrl("moonbeam", ChainData("Moonbeam", 1284, "https://rpc.api.moonbeam.network"));
+        _setChainWithDefaultRpcUrl(
             "moonriver", ChainData("Moonriver", 1285, "https://rpc.api.moonriver.moonbeam.network")
         );
-        setChainWithDefaultRpcUrl("moonbase", ChainData("Moonbase", 1287, "https://rpc.testnet.moonbeam.network"));
-        setChainWithDefaultRpcUrl("base_sepolia", ChainData("Base Sepolia", 84532, "https://sepolia.base.org"));
-        setChainWithDefaultRpcUrl("base", ChainData("Base", 8453, "https://mainnet.base.org"));
-        setChainWithDefaultRpcUrl("blast_sepolia", ChainData("Blast Sepolia", 168587773, "https://sepolia.blast.io"));
-        setChainWithDefaultRpcUrl("blast", ChainData("Blast", 81457, "https://rpc.blast.io"));
-        setChainWithDefaultRpcUrl("fantom_opera", ChainData("Fantom Opera", 250, "https://rpc.ankr.com/fantom/"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("moonbase", ChainData("Moonbase", 1287, "https://rpc.testnet.moonbeam.network"));
+        _setChainWithDefaultRpcUrl("base_sepolia", ChainData("Base Sepolia", 84532, "https://sepolia.base.org"));
+        _setChainWithDefaultRpcUrl("base", ChainData("Base", 8453, "https://mainnet.base.org"));
+        _setChainWithDefaultRpcUrl("blast_sepolia", ChainData("Blast Sepolia", 168587773, "https://sepolia.blast.io"));
+        _setChainWithDefaultRpcUrl("blast", ChainData("Blast", 81457, "https://rpc.blast.io"));
+        _setChainWithDefaultRpcUrl("fantom_opera", ChainData("Fantom Opera", 250, "https://rpc.ankr.com/fantom/"));
+        _setChainWithDefaultRpcUrl(
             "fantom_opera_testnet", ChainData("Fantom Opera Testnet", 4002, "https://rpc.ankr.com/fantom_testnet/")
         );
-        setChainWithDefaultRpcUrl("fraxtal", ChainData("Fraxtal", 252, "https://rpc.frax.com"));
-        setChainWithDefaultRpcUrl("fraxtal_testnet", ChainData("Fraxtal Testnet", 2522, "https://rpc.testnet.frax.com"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("fraxtal", ChainData("Fraxtal", 252, "https://rpc.frax.com"));
+        _setChainWithDefaultRpcUrl(
+            "fraxtal_testnet", ChainData("Fraxtal Testnet", 2522, "https://rpc.testnet.frax.com")
+        );
+        _setChainWithDefaultRpcUrl(
             "berachain_bartio_testnet", ChainData("Berachain bArtio Testnet", 80084, "https://bartio.rpc.berachain.com")
         );
-        setChainWithDefaultRpcUrl("flare", ChainData("Flare", 14, "https://flare-api.flare.network/ext/C/rpc"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("flare", ChainData("Flare", 14, "https://flare-api.flare.network/ext/C/rpc"));
+        _setChainWithDefaultRpcUrl(
             "flare_coston2", ChainData("Flare Coston2", 114, "https://coston2-api.flare.network/ext/C/rpc")
         );
 
-        setChainWithDefaultRpcUrl("ink", ChainData("Ink", 57073, "https://rpc-gel.inkonchain.com"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("ink", ChainData("Ink", 57073, "https://rpc-gel.inkonchain.com"));
+        _setChainWithDefaultRpcUrl(
             "ink_sepolia", ChainData("Ink Sepolia", 763373, "https://rpc-gel-sepolia.inkonchain.com")
         );
 
-        setChainWithDefaultRpcUrl("mode", ChainData("Mode", 34443, "https://mode.drpc.org"));
-        setChainWithDefaultRpcUrl("mode_sepolia", ChainData("Mode Sepolia", 919, "https://sepolia.mode.network"));
+        _setChainWithDefaultRpcUrl("mode", ChainData("Mode", 34443, "https://mode.drpc.org"));
+        _setChainWithDefaultRpcUrl("mode_sepolia", ChainData("Mode Sepolia", 919, "https://sepolia.mode.network"));
 
-        setChainWithDefaultRpcUrl("zora", ChainData("Zora", 7777777, "https://zora.drpc.org"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("zora", ChainData("Zora", 7777777, "https://zora.drpc.org"));
+        _setChainWithDefaultRpcUrl(
             "zora_sepolia", ChainData("Zora Sepolia", 999999999, "https://sepolia.rpc.zora.energy")
         );
 
-        setChainWithDefaultRpcUrl("race", ChainData("Race", 6805, "https://racemainnet.io"));
-        setChainWithDefaultRpcUrl("race_sepolia", ChainData("Race Sepolia", 6806, "https://racemainnet.io"));
+        _setChainWithDefaultRpcUrl("race", ChainData("Race", 6805, "https://racemainnet.io"));
+        _setChainWithDefaultRpcUrl("race_sepolia", ChainData("Race Sepolia", 6806, "https://racemainnet.io"));
 
-        setChainWithDefaultRpcUrl("radius", ChainData("Radius", 723487, "https://rpc.radiustech.xyz"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("radius", ChainData("Radius", 723487, "https://rpc.radiustech.xyz"));
+        _setChainWithDefaultRpcUrl(
             "radius_testnet", ChainData("Radius Testnet", 72344, "https://rpc.testnet.radiustech.xyz")
         );
 
-        setChainWithDefaultRpcUrl("metal", ChainData("Metal", 1750, "https://metall2.drpc.org"));
-        setChainWithDefaultRpcUrl("metal_sepolia", ChainData("Metal Sepolia", 1740, "https://testnet.rpc.metall2.com"));
+        _setChainWithDefaultRpcUrl("metal", ChainData("Metal", 1750, "https://metall2.drpc.org"));
+        _setChainWithDefaultRpcUrl("metal_sepolia", ChainData("Metal Sepolia", 1740, "https://testnet.rpc.metall2.com"));
 
-        setChainWithDefaultRpcUrl("binary", ChainData("Binary", 624, "https://rpc.zero.thebinaryholdings.com"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("binary", ChainData("Binary", 624, "https://rpc.zero.thebinaryholdings.com"));
+        _setChainWithDefaultRpcUrl(
             "binary_sepolia", ChainData("Binary Sepolia", 625, "https://rpc.zero.thebinaryholdings.com")
         );
 
-        setChainWithDefaultRpcUrl("orderly", ChainData("Orderly", 291, "https://rpc.orderly.network"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("orderly", ChainData("Orderly", 291, "https://rpc.orderly.network"));
+        _setChainWithDefaultRpcUrl(
             "orderly_sepolia", ChainData("Orderly Sepolia", 4460, "https://testnet-rpc.orderly.org")
         );
 
-        setChainWithDefaultRpcUrl("unichain", ChainData("Unichain", 130, "https://mainnet.unichain.org"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("unichain", ChainData("Unichain", 130, "https://mainnet.unichain.org"));
+        _setChainWithDefaultRpcUrl(
             "unichain_sepolia", ChainData("Unichain Sepolia", 1301, "https://sepolia.unichain.org")
         );
 
-        setChainWithDefaultRpcUrl("tempo", ChainData("Tempo", 4217, "https://rpc.mainnet.tempo.xyz"));
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl("tempo", ChainData("Tempo", 4217, "https://rpc.mainnet.tempo.xyz"));
+        _setChainWithDefaultRpcUrl(
             "tempo_moderato", ChainData("Tempo Moderato", 42431, "https://rpc.moderato.tempo.xyz")
         );
-        setChainWithDefaultRpcUrl(
+        _setChainWithDefaultRpcUrl(
             "tempo_andantino", ChainData("Tempo Andantino", 42429, "https://rpc.testnet.tempo.xyz")
         );
 
-        setChainWithDefaultRpcUrl("grav", ChainData("Gravity", 127001, "https://mainnet-rpc.gravity.xyz"));
+        _setChainWithDefaultRpcUrl("grav", ChainData("Gravity", 127001, "https://mainnet-rpc.gravity.xyz"));
     }
 
     // set chain info, with priority to chainAlias' rpc url in foundry.toml
-    function setChainWithDefaultRpcUrl(string memory chainAlias, ChainData memory chain) private {
+    function _setChainWithDefaultRpcUrl(string memory chainAlias, ChainData memory chain) private {
         string memory rpcUrl = chain.rpcUrl;
-        defaultRpcUrls[chainAlias] = rpcUrl;
+        _defaultRpcUrls[chainAlias] = rpcUrl;
         chain.rpcUrl = "";
         setChain(chainAlias, chain);
         chain.rpcUrl = rpcUrl; // restore argument

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -8,10 +8,10 @@ import {Vm} from "./Vm.sol";
 abstract contract StdCheatsSafe {
     Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    uint256 private constant UINT256_MAX =
+    uint256 private constant _UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
-    bool private gasMeteringOff;
+    bool private _gasMeteringOff;
 
     // Data structures to parse Transaction objects from the broadcast artifact
     // that conform to EIP1559. The Raw structs are what are parsed from the JSON
@@ -283,7 +283,7 @@ abstract contract StdCheatsSafe {
     // implemented by `addr`, which should be taken into account when this function is used.
     function _isPayable(address addr) private returns (bool) {
         require(
-            addr.balance < UINT256_MAX,
+            addr.balance < _UINT256_MAX,
             "StdCheats _isPayable(address): Balance equals max uint256, so it cannot receive any more funds"
         );
         uint256 origBalanceTest = address(this).balance;
@@ -629,14 +629,14 @@ abstract contract StdCheatsSafe {
         // i.e. funcA() noGasMetering { funcB() }, where funcB has noGasMetering as well.
         // funcA will have `gasStartedOff` as false, funcB will have it as true,
         // so we only turn metering back on at the end of the funcA
-        bool gasStartedOff = gasMeteringOff;
-        gasMeteringOff = true;
+        bool gasStartedOff = _gasMeteringOff;
+        _gasMeteringOff = true;
 
         _;
 
         // if gas metering was on when this modifier was called, turn it back on at the end
         if (!gasStartedOff) {
-            gasMeteringOff = false;
+            _gasMeteringOff = false;
             vm.resumeGasMetering();
         }
     }
@@ -668,9 +668,9 @@ abstract contract StdCheatsSafe {
 abstract contract StdCheats is StdCheatsSafe {
     using stdStorage for StdStorage;
 
-    StdStorage private stdstore;
+    StdStorage private _stdstore;
     Vm private constant vm = Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
-    address private constant CONSOLE2_ADDRESS = 0x000000000000000000636F6e736F6c652e6c6f67;
+    address private constant _CONSOLE2_ADDRESS = 0x000000000000000000636F6e736F6c652e6c6f67;
 
     /// @notice Advances the block timestamp forward by `time` seconds.
     function skip(uint256 time) internal virtual {
@@ -733,7 +733,7 @@ abstract contract StdCheats is StdCheatsSafe {
     /// @notice Changes the active prank to `msgSender`.
     /// @dev Deprecated. Use `vm.startPrank` instead.
     function changePrank(address msgSender) internal virtual {
-        console2_log_StdCheats("changePrank is deprecated. Please use vm.startPrank instead.");
+        _console2_log_StdCheats("changePrank is deprecated. Please use vm.startPrank instead.");
         vm.stopPrank();
         vm.startPrank(msgSender);
     }
@@ -741,7 +741,7 @@ abstract contract StdCheats is StdCheatsSafe {
     /// @notice Changes the active prank to `msgSender` with `txOrigin` as `tx.origin`.
     /// @dev Deprecated. Use `vm.startPrank` instead.
     function changePrank(address msgSender, address txOrigin) internal virtual {
-        console2_log_StdCheats("changePrank is deprecated. Please use vm.startPrank instead.");
+        _console2_log_StdCheats("changePrank is deprecated. Please use vm.startPrank instead.");
         vm.stopPrank();
         vm.startPrank(msgSender, txOrigin);
     }
@@ -828,7 +828,7 @@ abstract contract StdCheats is StdCheatsSafe {
         uint256 prevBal = abi.decode(balData, (uint256));
 
         // update balance
-        stdstore.target(token).sig(0x70a08231).with_key(to).checked_write(give);
+        _stdstore.target(token).sig(0x70a08231).with_key(to).checked_write(give);
 
         // update total supply
         if (adjust) {
@@ -839,7 +839,7 @@ abstract contract StdCheats is StdCheatsSafe {
             } else {
                 totSup += (give - prevBal);
             }
-            stdstore.target(token).sig(0x18160ddd).checked_write(totSup);
+            _stdstore.target(token).sig(0x18160ddd).checked_write(totSup);
         }
     }
 
@@ -850,7 +850,7 @@ abstract contract StdCheats is StdCheatsSafe {
         uint256 prevBal = abi.decode(balData, (uint256));
 
         // update balance
-        stdstore.target(token).sig(0x00fdd58e).with_key(to).with_key(id).checked_write(give);
+        _stdstore.target(token).sig(0x00fdd58e).with_key(to).with_key(id).checked_write(give);
 
         // update total supply
         if (adjust) {
@@ -865,7 +865,7 @@ abstract contract StdCheats is StdCheatsSafe {
             } else {
                 totSup += (give - prevBal);
             }
-            stdstore.target(token).sig(0xbd85b039).with_key(id).checked_write(totSup);
+            _stdstore.target(token).sig(0xbd85b039).with_key(id).checked_write(totSup);
         }
     }
 
@@ -885,11 +885,11 @@ abstract contract StdCheats is StdCheatsSafe {
         uint256 toPrevBal = abi.decode(toBalData, (uint256));
 
         // update balances
-        stdstore.target(token).sig(0x70a08231).with_key(abi.decode(ownerData, (address))).checked_write(--fromPrevBal);
-        stdstore.target(token).sig(0x70a08231).with_key(to).checked_write(++toPrevBal);
+        _stdstore.target(token).sig(0x70a08231).with_key(abi.decode(ownerData, (address))).checked_write(--fromPrevBal);
+        _stdstore.target(token).sig(0x70a08231).with_key(to).checked_write(++toPrevBal);
 
         // update owner
-        stdstore.target(token).sig(0x6352211e).with_key(id).checked_write(to);
+        _stdstore.target(token).sig(0x6352211e).with_key(id).checked_write(to);
     }
 
     /// @notice Etches the runtime bytecode of `what` (from the artifacts directory) at `where`.
@@ -915,8 +915,8 @@ abstract contract StdCheats is StdCheatsSafe {
     }
 
     // Used to prevent the compilation of console, which shortens the compilation time when console is not used elsewhere.
-    function console2_log_StdCheats(string memory p0) private view {
-        (bool status,) = address(CONSOLE2_ADDRESS).staticcall(abi.encodeWithSignature("log(string)", p0));
+    function _console2_log_StdCheats(string memory p0) private view {
+        (bool status,) = address(_CONSOLE2_ADDRESS).staticcall(abi.encodeWithSignature("log(string)", p0));
         status;
     }
 }

--- a/src/StdConfig.sol
+++ b/src/StdConfig.sol
@@ -38,7 +38,7 @@ contract StdConfig {
     VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
 
     /// @dev Types: `bool`, `address`, `bytes32`, `uint`, `int`, `string`, `bytes`.
-    uint8 private constant NUM_TYPES = 7;
+    uint8 private constant _NUM_TYPES = 7;
 
     // -- ERRORS ---------------------------------------------------------------
 
@@ -114,7 +114,7 @@ contract StdConfig {
             }
 
             // Iterate through all the available `TypeKind`s (except `None`) to create the sub-section paths
-            for (uint8 t = 1; t <= NUM_TYPES; t++) {
+            for (uint8 t = 1; t <= _NUM_TYPES; t++) {
                 TypeKind ty = TypeKind(t);
                 string memory typePath = string.concat("$.", chain_key, ".", ty.toTomlKey());
 

--- a/src/StdMath.sol
+++ b/src/StdMath.sol
@@ -3,14 +3,15 @@ pragma solidity >=0.8.13 <0.9.0;
 
 /// @notice Mathematical utility functions for unsigned and signed integers.
 library stdMath {
-    int256 private constant INT256_MIN = -57896044618658097711785492504343953926634992332820282019728792003956564819968;
+    int256 private constant _INT256_MIN =
+        -57896044618658097711785492504343953926634992332820282019728792003956564819968;
 
     /// @notice Computes the absolute value of a signed integer.
     /// @param a The signed integer to compute the absolute value of.
     /// @return The absolute value as an unsigned integer.
     function abs(int256 a) internal pure returns (uint256) {
         // Required or it will fail when `a = type(int256).min`
-        if (a == INT256_MIN) {
+        if (a == _INT256_MIN) {
             return 57896044618658097711785492504343953926634992332820282019728792003956564819968;
         }
 

--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -36,7 +36,7 @@ library stdStorageSafe {
     /// @notice Returns the encoded call parameters (keys or raw calldata) for the configured target function.
     function getCallParams(StdStorage storage self) internal view returns (bytes memory) {
         if (self._calldata.length == 0) {
-            return flatten(self._keys);
+            return _flatten(self._keys);
         } else {
             return self._calldata;
         }
@@ -46,7 +46,7 @@ library stdStorageSafe {
     function callTarget(StdStorage storage self) internal view returns (bool, bytes32) {
         bytes memory cd = abi.encodePacked(self._sig, getCallParams(self));
         (bool success, bytes memory rdat) = self._target.staticcall(cd);
-        bytes32 result = bytesToBytes32(rdat, 32 * self._depth);
+        bytes32 result = _bytesToBytes32(rdat, 32 * self._depth);
 
         return (success, result);
     }
@@ -225,7 +225,7 @@ library stdStorageSafe {
         return self;
     }
 
-    function read(StdStorage storage self) private returns (bytes memory) {
+    function _read(StdStorage storage self) private returns (bytes memory) {
         FindData storage data = find(self, false);
         uint256 mask = getMaskByOffsets(data.offsetLeft, data.offsetRight);
         uint256 value = (uint256(vm.load(self._target, bytes32(data.slot))) & mask) >> data.offsetRight;
@@ -235,7 +235,7 @@ library stdStorageSafe {
 
     /// @notice Reads the found storage slot value as bytes32.
     function read_bytes32(StdStorage storage self) internal returns (bytes32) {
-        return abi.decode(read(self), (bytes32));
+        return abi.decode(_read(self), (bytes32));
     }
 
     /// @notice Reads the found storage slot value as bool.
@@ -249,17 +249,17 @@ library stdStorageSafe {
 
     /// @notice Reads the found storage slot value as address.
     function read_address(StdStorage storage self) internal returns (address) {
-        return abi.decode(read(self), (address));
+        return abi.decode(_read(self), (address));
     }
 
     /// @notice Reads the found storage slot value as uint256.
     function read_uint(StdStorage storage self) internal returns (uint256) {
-        return abi.decode(read(self), (uint256));
+        return abi.decode(_read(self), (uint256));
     }
 
     /// @notice Reads the found storage slot value as int256.
     function read_int(StdStorage storage self) internal returns (int256) {
-        return abi.decode(read(self), (int256));
+        return abi.decode(_read(self), (int256));
     }
 
     /// @notice Returns the parent mapping slot index and the key used to reach the found slot.
@@ -299,7 +299,7 @@ library stdStorageSafe {
         return uint256(root_slot);
     }
 
-    function bytesToBytes32(bytes memory b, uint256 offset) private pure returns (bytes32) {
+    function _bytesToBytes32(bytes memory b, uint256 offset) private pure returns (bytes32) {
         bytes32 out;
 
         // Cap read length by remaining bytes from `offset`, and at most 32 bytes to avoid out-of-bounds
@@ -313,7 +313,7 @@ library stdStorageSafe {
         return out;
     }
 
-    function flatten(bytes32[] memory b) private pure returns (bytes memory) {
+    function _flatten(bytes32[] memory b) private pure returns (bytes memory) {
         bytes memory result = new bytes(b.length * 32);
         for (uint256 i = 0; i < b.length; i++) {
             bytes32 k = b[i];

--- a/src/StdStyle.sol
+++ b/src/StdStyle.sol
@@ -19,13 +19,13 @@ library StdStyle {
     string constant INVERSE = "\u001b[7m";
     string constant RESET = "\u001b[0m";
 
-    function styleConcat(string memory style, string memory self) private pure returns (string memory) {
+    function _styleConcat(string memory style, string memory self) private pure returns (string memory) {
         return string(abi.encodePacked(style, self, RESET));
     }
 
     /// @notice Returns `self` wrapped in red ANSI color codes.
     function red(string memory self) internal pure returns (string memory) {
-        return styleConcat(RED, self);
+        return _styleConcat(RED, self);
     }
 
     /// @notice Returns the string representation of `self` wrapped in red ANSI color codes.
@@ -60,7 +60,7 @@ library StdStyle {
 
     /// @notice Returns `self` wrapped in green ANSI color codes.
     function green(string memory self) internal pure returns (string memory) {
-        return styleConcat(GREEN, self);
+        return _styleConcat(GREEN, self);
     }
 
     /// @notice Returns the string representation of `self` wrapped in green ANSI color codes.
@@ -95,7 +95,7 @@ library StdStyle {
 
     /// @notice Returns `self` wrapped in yellow ANSI color codes.
     function yellow(string memory self) internal pure returns (string memory) {
-        return styleConcat(YELLOW, self);
+        return _styleConcat(YELLOW, self);
     }
 
     /// @notice Returns the string representation of `self` wrapped in yellow ANSI color codes.
@@ -130,7 +130,7 @@ library StdStyle {
 
     /// @notice Returns `self` wrapped in blue ANSI color codes.
     function blue(string memory self) internal pure returns (string memory) {
-        return styleConcat(BLUE, self);
+        return _styleConcat(BLUE, self);
     }
 
     /// @notice Returns the string representation of `self` wrapped in blue ANSI color codes.
@@ -165,7 +165,7 @@ library StdStyle {
 
     /// @notice Returns `self` wrapped in magenta ANSI color codes.
     function magenta(string memory self) internal pure returns (string memory) {
-        return styleConcat(MAGENTA, self);
+        return _styleConcat(MAGENTA, self);
     }
 
     /// @notice Returns the string representation of `self` wrapped in magenta ANSI color codes.
@@ -200,7 +200,7 @@ library StdStyle {
 
     /// @notice Returns `self` wrapped in cyan ANSI color codes.
     function cyan(string memory self) internal pure returns (string memory) {
-        return styleConcat(CYAN, self);
+        return _styleConcat(CYAN, self);
     }
 
     /// @notice Returns the string representation of `self` wrapped in cyan ANSI color codes.
@@ -235,7 +235,7 @@ library StdStyle {
 
     /// @notice Returns `self` wrapped in bold ANSI style codes.
     function bold(string memory self) internal pure returns (string memory) {
-        return styleConcat(BOLD, self);
+        return _styleConcat(BOLD, self);
     }
 
     /// @notice Returns the string representation of `self` wrapped in bold ANSI style codes.
@@ -270,7 +270,7 @@ library StdStyle {
 
     /// @notice Returns `self` wrapped in dim ANSI style codes.
     function dim(string memory self) internal pure returns (string memory) {
-        return styleConcat(DIM, self);
+        return _styleConcat(DIM, self);
     }
 
     /// @notice Returns the string representation of `self` wrapped in dim ANSI style codes.
@@ -305,7 +305,7 @@ library StdStyle {
 
     /// @notice Returns `self` wrapped in italic ANSI style codes.
     function italic(string memory self) internal pure returns (string memory) {
-        return styleConcat(ITALIC, self);
+        return _styleConcat(ITALIC, self);
     }
 
     /// @notice Returns the string representation of `self` wrapped in italic ANSI style codes.
@@ -340,7 +340,7 @@ library StdStyle {
 
     /// @notice Returns `self` wrapped in underline ANSI style codes.
     function underline(string memory self) internal pure returns (string memory) {
-        return styleConcat(UNDERLINE, self);
+        return _styleConcat(UNDERLINE, self);
     }
 
     /// @notice Returns the string representation of `self` wrapped in underline ANSI style codes.
@@ -375,7 +375,7 @@ library StdStyle {
 
     /// @notice Returns `self` wrapped in inverse ANSI style codes.
     function inverse(string memory self) internal pure returns (string memory) {
-        return styleConcat(INVERSE, self);
+        return _styleConcat(INVERSE, self);
     }
 
     /// @notice Returns the string representation of `self` wrapped in inverse ANSI style codes.

--- a/src/StdUtils.sol
+++ b/src/StdUtils.sol
@@ -11,12 +11,12 @@ abstract contract StdUtils {
     //////////////////////////////////////////////////////////////////////////*/
 
     VmSafe private constant vm = VmSafe(address(uint160(uint256(keccak256("hevm cheat code")))));
-    address private constant CONSOLE2_ADDRESS = 0x000000000000000000636F6e736F6c652e6c6f67;
-    uint256 private constant INT256_MIN_ABS =
+    address private constant _CONSOLE2_ADDRESS = 0x000000000000000000636F6e736F6c652e6c6f67;
+    uint256 private constant _INT256_MIN_ABS =
         57896044618658097711785492504343953926634992332820282019728792003956564819968;
-    uint256 private constant SECP256K1_ORDER =
+    uint256 private constant _SECP256K1_ORDER =
         115792089237316195423570985008687907852837564279074904382605163141518161494337;
-    uint256 private constant UINT256_MAX =
+    uint256 private constant _UINT256_MAX =
         115792089237316195423570985008687907853269984665640564039457584007913129639935;
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -37,10 +37,10 @@ abstract contract StdUtils {
 
         uint256 size = max - min + 1;
 
-        // If the value is 0, 1, 2, 3, wrap that to min, min+1, min+2, min+3. Similarly for the UINT256_MAX side.
+        // If the value is 0, 1, 2, 3, wrap that to min, min+1, min+2, min+3. Similarly for the _UINT256_MAX side.
         // This helps ensure coverage of the min/max values.
         if (x <= 3 && size > x) return min + x;
-        if (x >= UINT256_MAX - 3 && size > UINT256_MAX - x) return max - (UINT256_MAX - x);
+        if (x >= _UINT256_MAX - 3 && size > _UINT256_MAX - x) return max - (_UINT256_MAX - x);
 
         // Otherwise, wrap x into the range [min, max], i.e. the range is inclusive.
         if (x > max) {
@@ -77,18 +77,18 @@ abstract contract StdUtils {
         // Shifting all int256 values to uint256 to use _bound function. The range of two types are:
         // int256 : -(2**255) ~ (2**255 - 1)
         // uint256:     0     ~ (2**256 - 1)
-        // So, add 2**255, INT256_MIN_ABS to the integer values.
+        // So, add 2**255, _INT256_MIN_ABS to the integer values.
         //
         // If the given integer value is -2**255, we cannot use `-uint256(-x)` because of the overflow.
         // So, use `~uint256(x) + 1` instead.
-        uint256 _x = x < 0 ? (INT256_MIN_ABS - ~uint256(x) - 1) : (uint256(x) + INT256_MIN_ABS);
-        uint256 _min = min < 0 ? (INT256_MIN_ABS - ~uint256(min) - 1) : (uint256(min) + INT256_MIN_ABS);
-        uint256 _max = max < 0 ? (INT256_MIN_ABS - ~uint256(max) - 1) : (uint256(max) + INT256_MIN_ABS);
+        uint256 _x = x < 0 ? (_INT256_MIN_ABS - ~uint256(x) - 1) : (uint256(x) + _INT256_MIN_ABS);
+        uint256 _min = min < 0 ? (_INT256_MIN_ABS - ~uint256(min) - 1) : (uint256(min) + _INT256_MIN_ABS);
+        uint256 _max = max < 0 ? (_INT256_MIN_ABS - ~uint256(max) - 1) : (uint256(max) + _INT256_MIN_ABS);
 
         uint256 y = _bound(_x, _min, _max);
 
-        // To move it back to int256 value, subtract INT256_MIN_ABS at here.
-        result = y < INT256_MIN_ABS ? int256(~(INT256_MIN_ABS - y) + 1) : int256(y - INT256_MIN_ABS);
+        // To move it back to int256 value, subtract _INT256_MIN_ABS at here.
+        result = y < _INT256_MIN_ABS ? int256(~(_INT256_MIN_ABS - y) + 1) : int256(y - _INT256_MIN_ABS);
     }
 
     /// @notice Wrapper for `_bound(int256,int256,int256)`.
@@ -104,7 +104,7 @@ abstract contract StdUtils {
     /// @param privateKey The raw private key candidate.
     /// @return result The bounded private key.
     function boundPrivateKey(uint256 privateKey) internal pure virtual returns (uint256 result) {
-        result = _bound(privateKey, 1, SECP256K1_ORDER - 1);
+        result = _bound(privateKey, 1, _SECP256K1_ORDER - 1);
     }
 
     /// @notice Converts a byte array (up to 32 bytes) into a `uint256`.
@@ -121,7 +121,7 @@ abstract contract StdUtils {
     /// @param nonce The deployer nonce used for CREATE.
     /// @return The computed CREATE address.
     function computeCreateAddress(address deployer, uint256 nonce) internal pure virtual returns (address) {
-        console2_log_StdUtils("computeCreateAddress is deprecated. Please use vm.computeCreateAddress instead.");
+        _console2_log_StdUtils("computeCreateAddress is deprecated. Please use vm.computeCreateAddress instead.");
         return vm.computeCreateAddress(deployer, nonce);
     }
 
@@ -137,7 +137,7 @@ abstract contract StdUtils {
         virtual
         returns (address)
     {
-        console2_log_StdUtils("computeCreate2Address is deprecated. Please use vm.computeCreate2Address instead.");
+        _console2_log_StdUtils("computeCreate2Address is deprecated. Please use vm.computeCreate2Address instead.");
         return vm.computeCreate2Address(salt, initcodeHash, deployer);
     }
 
@@ -147,7 +147,7 @@ abstract contract StdUtils {
     /// @param initCodeHash The hash of the full init code.
     /// @return The computed CREATE2 address.
     function computeCreate2Address(bytes32 salt, bytes32 initCodeHash) internal pure returns (address) {
-        console2_log_StdUtils("computeCreate2Address is deprecated. Please use vm.computeCreate2Address instead.");
+        _console2_log_StdUtils("computeCreate2Address is deprecated. Please use vm.computeCreate2Address instead.");
         return vm.computeCreate2Address(salt, initCodeHash);
     }
 
@@ -203,7 +203,7 @@ abstract contract StdUtils {
                                  PRIVATE FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    function addressFromLast20Bytes(bytes32 bytesValue) private pure returns (address) {
+    function _addressFromLast20Bytes(bytes32 bytesValue) private pure returns (address) {
         return address(uint160(uint256(bytesValue)));
     }
 
@@ -226,22 +226,22 @@ abstract contract StdUtils {
 
     function _sendLogPayloadView(bytes memory payload) private view {
         uint256 payloadLength = payload.length;
-        address consoleAddress = CONSOLE2_ADDRESS;
+        address consoleAddress = _CONSOLE2_ADDRESS;
         assembly ("memory-safe") {
             let payloadStart := add(payload, 32)
             let r := staticcall(gas(), consoleAddress, payloadStart, payloadLength, 0, 0)
         }
     }
 
-    function console2_log_StdUtils(string memory p0) private pure {
+    function _console2_log_StdUtils(string memory p0) private pure {
         _sendLogPayload(abi.encodeWithSignature("log(string)", p0));
     }
 
-    function console2_log_StdUtils(string memory p0, uint256 p1) private pure {
+    function _console2_log_StdUtils(string memory p0, uint256 p1) private pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,uint256)", p0, p1));
     }
 
-    function console2_log_StdUtils(string memory p0, string memory p1) private pure {
+    function _console2_log_StdUtils(string memory p0, string memory p1) private pure {
         _sendLogPayload(abi.encodeWithSignature("log(string,string)", p0, p1));
     }
 }


### PR DESCRIPTION
Towards #653

Addresses the second goal of #653 ("Mark private variables and functions with underscore prefix") by aligning the remaining files with the convention already used in `StdAssertions.sol`, `StdInvariant.sol`, and `StdConfig.sol`.

No public/internal/external function signatures or behavior changed — all renames are limited to `private` members.

### Renamed private state variables / helper functions
- **StdChains**: `_stdChainsInitialized`, `_chains`, `_defaultRpcUrls`, `_idToAlias`, `_fallbackToDefaultRpcUrls`, `_initializeStdChains`, `_getChainWithUpdatedRpcUrl`, `_setChainWithDefaultRpcUrl`
- **StdCheats**: `_gasMeteringOff`, `_stdstore`, `_console2_log_StdCheats`
- **StdStorage**: `_read`, `_bytesToBytes32`, `_flatten`
- **StdStyle**: `_styleConcat`
- **StdUtils**: `_addressFromLast20Bytes`, `_console2_log_StdUtils`

### Renamed private constants
- **StdAssertions**: `_FAILED_SLOT`
- **StdCheats**: `_UINT256_MAX`, `_CONSOLE2_ADDRESS`
- **StdConfig**: `_NUM_TYPES`
- **StdMath**: `_INT256_MIN`
- **StdUtils**: `_UINT256_MAX`, `_INT256_MIN_ABS`, `_SECP256K1_ORDER`, `_CONSOLE2_ADDRESS`

### Exclusions
- The `vm` private constant — universal alias across forge-std and broader user code.
- `UINT256_MAX` in `StdStorage.sol` — declared without an explicit visibility modifier, which defaults to `internal` in Solidity, so it is out of scope for this PR.
- `internal` constants in `Base.sol` and `StdConstants.sol` — out of scope.

### Verification
`forge build` and `forge test` both pass (202/202 tests).
