### PR TITLE
Add BattleChain mainnet (626) and testnet (627)

### DIFF
--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -303,6 +303,13 @@ abstract contract StdChains {
         );
 
         _setChainWithDefaultRpcUrl("grav", ChainData("Gravity", 127001, "https://mainnet-rpc.gravity.xyz"));
+
+        _setChainWithDefaultRpcUrl(
+            "battlechain", ChainData("BattleChain Mainnet", 626, "https://mainnet.battlechain.com")
+        );
+        _setChainWithDefaultRpcUrl(
+            "battlechain_testnet", ChainData("BattleChain Testnet", 627, "https://testnet.battlechain.com")
+        );
     }
 
     // set chain info, with priority to chainAlias' rpc url in foundry.toml


### PR DESCRIPTION
Adds `battlechain` (626) and `battlechain_testnet` (627) chain aliases with default RPC URLs to `_initializeStdChains`.

BattleChain is a ZKsync-based Ethereum L2; native currency is ETH.