### PR TITLE
docs: clarify JSON key selector syntax

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -1060,6 +1060,8 @@ interface VmSafe {
 
     // ======== JSON ========
 
+    /// JSON `key` parameters use selector syntax: use a leading dot for object fields
+    /// (for example, `.bar`) or `$` for the root object.
     /// Checks if `key` exists in a JSON object.
     function keyExistsJson(string calldata json, string calldata key) external view returns (bool);
 

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -1060,9 +1060,10 @@ interface VmSafe {
 
     // ======== JSON ========
 
+    /// Checks if `key` exists in a JSON object.
+    ///
     /// JSON `key` parameters use selector syntax: use a leading dot for object fields
     /// (for example, `.bar`) or `$` for the root object.
-    /// Checks if `key` exists in a JSON object.
     function keyExistsJson(string calldata json, string calldata key) external view returns (bool);
 
     /// Parses a string of JSON data at `key` and coerces it to `address`.


### PR DESCRIPTION
## Summary
- document that JSON `key` parameters use selector syntax
- call out leading-dot object field selectors, such as `.bar`, and `$` for root

Fixes #394