### PR TITLE
docs: add NatSpec to Script and Test base contracts

### DIFF
--- a/src/Script.sol
+++ b/src/Script.sol
@@ -21,8 +21,10 @@ import {VmSafe} from "./Vm.sol";
 // 📦 BOILERPLATE
 import {ScriptBase} from "./Base.sol";
 
-// ⭐️ SCRIPT
+/// @notice Default base contract for Forge scripts.
+/// @dev Includes safe cheatcodes, chain helpers, utility helpers, and console modules.
 abstract contract Script is ScriptBase, StdChains, StdCheatsSafe, StdUtils {
-    // Note: IS_SCRIPT() must return true.
+    /// @notice Marker used by Forge to identify script contracts.
+    /// @dev The generated `IS_SCRIPT()` getter must return true.
     bool public IS_SCRIPT = true;
 }

--- a/src/Test.sol
+++ b/src/Test.sol
@@ -25,8 +25,10 @@ import {Vm} from "./Vm.sol";
 // 📦 BOILERPLATE
 import {TestBase} from "./Base.sol";
 
-// ⭐️ TEST
+/// @notice Default base contract for Forge tests.
+/// @dev Includes assertions, cheatcodes, invariant helpers, chain helpers, utility helpers, and console modules.
 abstract contract Test is TestBase, StdAssertions, StdChains, StdCheats, StdInvariant, StdUtils {
-    // Note: IS_TEST() must return true.
+    /// @notice Marker used by Forge to identify test contracts.
+    /// @dev The generated `IS_TEST()` getter must return true.
     bool public IS_TEST = true;
 }


### PR DESCRIPTION
## Summary

- Add NatSpec to the `Script` and `Test` base contracts.
- Document the `IS_SCRIPT` and `IS_TEST` marker getters.
- Keep the change documentation-only with no behavior changes.

## Motivation

This continues the NatSpec coverage work tracked in #653. `Script.sol` and `Test.sol` are still listed as missing public-facing NatSpec coverage, and documenting them helps generated forge-std reference docs include the default base contracts and their marker getters.

Part of #653.

## Testing

- `forge fmt --check src/Script.sol src/Test.sol`
- `forge build`
- `forge test --no-match-contract ConfigTest -vvv`
- `git diff --check`

