### PR TITLE
chore: update `Vm` interface cheatcodes

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -254,7 +254,7 @@ interface VmSafe {
         bool reverted;
     }
 
-    /// Gas used. Returned by `lastCallGas`.
+    /// Gas used. Returned by `lastCallGas` and `lastFrameGas`.
     struct Gas {
         // The gas limit of the call.
         uint64 gasLimit;
@@ -437,6 +437,22 @@ interface VmSafe {
     /// The signature covers namespace || message for domain separation.
     /// Returns a 64-byte Ed25519 signature.
     function signEd25519(bytes calldata namespace, bytes calldata message, bytes32 privateKey)
+        external
+        pure
+        returns (bytes memory signature);
+
+    /// Signs `digest` as a Tempo V2 keychain signature for `account` using a secp256k1 access key.
+    /// Returns the encoded signature bytes accepted by `SignatureVerifier.verifyKeychain`.
+    function signKeychain(uint256 privateKey, address account, bytes32 digest)
+        external
+        pure
+        returns (bytes memory signature);
+
+    /// Signs `digest` as a Tempo V2 keychain signature for `account` using a root or admin secp256k1 key.
+    /// Returns the encoded signature bytes accepted by `SignatureVerifier.verifyKeychainAdmin`.
+    /// The supplied `digest` should already be domain-separated with chain ID, contract address,
+    /// and account address.
+    function signKeychainAdmin(uint256 privateKey, address account, bytes32 digest)
         external
         pure
         returns (bytes memory signature);
@@ -724,8 +740,16 @@ interface VmSafe {
         view
         returns (uint256[] memory slots);
 
-    /// Gets the gas used in the last call from the callee perspective.
-    function lastCallGas() external view returns (Gas memory gas);
+    /// Returns `true` if `spender` is on the active Tempo hardfork's implicit-approval list,
+    /// meaning it can pull TIP-20 tokens from `msg.sender` without a prior `approve()`.
+    /// Returns `false` on non-Tempo networks.
+    function isImplicitlyApproved(address spender) external view returns (bool implicitlyApproved);
+
+    /// Returns true if isolated test execution is enabled.
+    function isIsolateMode() external view returns (bool result);
+
+    /// Gets the gas used in the last call or create from the callee perspective.
+    function lastFrameGas() external view returns (Gas memory gas);
 
     /// Loads a storage slot from an address.
     function load(address target, bytes32 slot) external view returns (bytes32 data);
@@ -745,6 +769,14 @@ interface VmSafe {
 
     /// Resumes gas metering (i.e. gas usage is counted again). Noop if already on.
     function resumeGasMetering() external;
+
+    /// Performs an Ethereum JSON-RPC request to the current fork URL and returns the JSON result.
+    function rpcJson(string calldata method, string calldata params) external returns (string memory data);
+
+    /// Performs an Ethereum JSON-RPC request to the given endpoint and returns the JSON result.
+    function rpcJson(string calldata urlOrAlias, string calldata method, string calldata params)
+        external
+        returns (string memory data);
 
     /// Performs an Ethereum JSON-RPC request to the current fork URL.
     function rpc(string calldata method, string calldata params) external returns (bytes memory data);
@@ -780,6 +812,10 @@ interface VmSafe {
     /// Stops recording storage reads and writes.
     function stopRecord() external;
 
+    /// DEPRECATED: use `lastFrameGas` instead.
+    /// Gets the gas used in the last call from the callee perspective.
+    function lastCallGas() external view returns (Gas memory gas);
+
     // ======== Filesystem ========
 
     /// Closes file for reading, resetting the offset and allowing to read it from beginning with readLine.
@@ -804,12 +840,14 @@ interface VmSafe {
     function currentFilePath() external view returns (string memory path);
 
     /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    /// artifact in the form of <path>:<contract>:<version> or <path>:<contract>:<profile> where <contract> and
+    /// <version>/<profile> parts are optional.
     /// Reverts if the target artifact contains unlinked library placeholders.
     function deployCode(string calldata artifactPath) external returns (address deployedAddress);
 
     /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    /// artifact in the form of <path>:<contract>:<version> or <path>:<contract>:<profile> where <contract> and
+    /// <version>/<profile> parts are optional.
     /// Reverts if the target artifact contains unlinked library placeholders.
     /// Additionally accepts abi-encoded constructor arguments.
     function deployCode(string calldata artifactPath, bytes calldata constructorArgs)
@@ -817,13 +855,15 @@ interface VmSafe {
         returns (address deployedAddress);
 
     /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    /// artifact in the form of <path>:<contract>:<version> or <path>:<contract>:<profile> where <contract> and
+    /// <version>/<profile> parts are optional.
     /// Reverts if the target artifact contains unlinked library placeholders.
     /// Additionally accepts `msg.value`.
     function deployCode(string calldata artifactPath, uint256 value) external returns (address deployedAddress);
 
     /// Deploys a contract from an artifact file. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    /// artifact in the form of <path>:<contract>:<version> or <path>:<contract>:<profile> where <contract> and
+    /// <version>/<profile> parts are optional.
     /// Reverts if the target artifact contains unlinked library placeholders.
     /// Additionally accepts abi-encoded constructor arguments and `msg.value`.
     function deployCode(string calldata artifactPath, bytes calldata constructorArgs, uint256 value)
@@ -831,12 +871,14 @@ interface VmSafe {
         returns (address deployedAddress);
 
     /// Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    /// artifact in the form of <path>:<contract>:<version> or <path>:<contract>:<profile> where <contract> and
+    /// <version>/<profile> parts are optional.
     /// Reverts if the target artifact contains unlinked library placeholders.
     function deployCode(string calldata artifactPath, bytes32 salt) external returns (address deployedAddress);
 
     /// Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    /// artifact in the form of <path>:<contract>:<version> or <path>:<contract>:<profile> where <contract> and
+    /// <version>/<profile> parts are optional.
     /// Reverts if the target artifact contains unlinked library placeholders.
     /// Additionally accepts abi-encoded constructor arguments.
     function deployCode(string calldata artifactPath, bytes calldata constructorArgs, bytes32 salt)
@@ -844,7 +886,8 @@ interface VmSafe {
         returns (address deployedAddress);
 
     /// Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    /// artifact in the form of <path>:<contract>:<version> or <path>:<contract>:<profile> where <contract> and
+    /// <version>/<profile> parts are optional.
     /// Reverts if the target artifact contains unlinked library placeholders.
     /// Additionally accepts `msg.value`.
     function deployCode(string calldata artifactPath, uint256 value, bytes32 salt)
@@ -852,7 +895,8 @@ interface VmSafe {
         returns (address deployedAddress);
 
     /// Deploys a contract from an artifact file, using the CREATE2 salt. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    /// artifact in the form of <path>:<contract>:<version> or <path>:<contract>:<profile> where <contract> and
+    /// <version>/<profile> parts are optional.
     /// Reverts if the target artifact contains unlinked library placeholders.
     /// Additionally accepts abi-encoded constructor arguments and `msg.value`.
     function deployCode(string calldata artifactPath, bytes calldata constructorArgs, uint256 value, bytes32 salt)
@@ -898,11 +942,14 @@ interface VmSafe {
         returns (BroadcastTxSummary[] memory);
 
     /// Gets the creation bytecode from an artifact file. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    /// artifact in the form of <path>:<contract>:<version> or <path>:<contract>:<profile> where <contract> and
+    /// <version>/<profile> parts are optional. Use <profile> to select artifacts compiled with a specific profile
+    /// from foundry.toml.
     function getCode(string calldata artifactPath) external view returns (bytes memory creationBytecode);
 
     /// Gets the deployed bytecode from an artifact file. Takes in the relative path to the json file or the path to the
-    /// artifact in the form of <path>:<contract>:<version> where <contract> and <version> parts are optional.
+    /// artifact in the form of <path>:<contract>:<version> or <path>:<contract>:<profile> where <contract> and
+    /// <version>/<profile> parts are optional.
     function getDeployedCode(string calldata artifactPath) external view returns (bytes memory runtimeBytecode);
 
     /// Returns the most recent deployment for the current `chainId`.
@@ -1756,6 +1803,9 @@ interface VmSafe {
     /// If the condition is false, discard this run's fuzz inputs and generate new ones.
     function assume(bool condition) external pure;
 
+    /// Skips a fuzz/invariant input unless `spender` is implicitly approved.
+    function assumeImplicitApproval(address spender) external view;
+
     /// Discard this run's fuzz inputs and generate new ones if next call reverted.
     function assumeNoRevert() external pure;
 
@@ -1915,7 +1965,7 @@ interface VmSafe {
     /// * requires previous binding generation with `forge bind-json`.
     /// * bindings will be retrieved from the path configured in `foundry.toml`.
     /// 2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
-    /// * Note: the cheatcode will use the canonical type even if the input is malformated
+    /// * Note: the cheatcode will use the canonical type even if the input is malformed
     /// with the wrong order of elements or with extra whitespaces.
     function eip712HashStruct(string calldata typeNameOrDefinition, bytes calldata abiEncodedData)
         external
@@ -1939,7 +1989,7 @@ interface VmSafe {
     /// * requires previous binding generation with `forge bind-json`.
     /// * bindings will be retrieved from the path configured in `foundry.toml`.
     /// 2. String representation of the type (i.e. "Foo(Bar bar) Bar(uint256 baz)").
-    /// * Note: the cheatcode will output the canonical type even if the input is malformated
+    /// * Note: the cheatcode will output the canonical type even if the input is malformed
     /// with the wrong order of elements or with extra whitespaces.
     function eip712HashType(string calldata typeNameOrDefinition) external pure returns (bytes32 typeHash);
 
@@ -2270,17 +2320,25 @@ interface Vm is VmSafe {
     /// It only sets the blockhash for blocks where `block.number - 256 <= number < block.number`.
     function setBlockhash(uint256 blockNumber, bytes32 blockHash) external;
 
+    /// Sets a TIP-20 token's logo URI directly in storage.
+    /// This bypasses the token admin check, but still validates the URI against T5 constraints.
+    function setLogoURI(address token, string calldata newLogoURI) external;
+
     /// Sets the nonce of an account. Must be higher than the current nonce of the account.
     function setNonce(address account, uint64 newNonce) external;
 
     /// Sets the nonce of an account to an arbitrary value.
     function setNonceUnsafe(address account, uint64 newNonce) external;
 
-    /// Snapshot capture the gas usage of the last call by name from the callee perspective.
-    function snapshotGasLastCall(string calldata name) external returns (uint256 gasUsed);
+    /// Sets a TIP-20 token's logo URI directly in storage.
+    /// This bypasses the token admin check, but still validates the URI against T5 constraints.
+    function setTip20LogoURI(address token, string calldata newLogoURI) external;
 
-    /// Snapshot capture the gas usage of the last call by name in a group from the callee perspective.
-    function snapshotGasLastCall(string calldata group, string calldata name) external returns (uint256 gasUsed);
+    /// Snapshot capture the gas usage of the last call or create by name from the callee perspective.
+    function snapshotGasLastFrame(string calldata name) external returns (uint256 gasUsed);
+
+    /// Snapshot capture the gas usage of the last call or create by name in a group from the callee perspective.
+    function snapshotGasLastFrame(string calldata group, string calldata name) external returns (uint256 gasUsed);
 
     /// Snapshot the current state of the evm.
     /// Returns the ID of the snapshot that was created.
@@ -2356,6 +2414,14 @@ interface Vm is VmSafe {
     /// `revertTo` is being deprecated in favor of `revertToState`. It will be removed in future versions.
     function revertTo(uint256 snapshotId) external returns (bool success);
 
+    /// DEPRECATED: use `snapshotGasLastFrame` instead.
+    /// Snapshot capture the gas usage of the last call by name from the callee perspective.
+    function snapshotGasLastCall(string calldata name) external returns (uint256 gasUsed);
+
+    /// DEPRECATED: use `snapshotGasLastFrame` instead.
+    /// Snapshot capture the gas usage of the last call by name in a group from the callee perspective.
+    function snapshotGasLastCall(string calldata group, string calldata name) external returns (uint256 gasUsed);
+
     /// `snapshot` is being deprecated in favor of `snapshotState`. It will be removed in future versions.
     function snapshot() external returns (uint256 snapshotId);
 
@@ -2420,6 +2486,9 @@ interface Vm is VmSafe {
     /// Prepare an expected log with (bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData.).
     /// Call this function, then emit an event, then call a function. Internally after the call, we check if
     /// logs were emitted in the expected order with the expected topics and data (as specified by the booleans).
+    /// Must be placed immediately before the call you want to assert on. If the next call reverts and the
+    /// revert is caught by the caller (low-level call or try/catch), the expectation remains active and may
+    /// be satisfied by a log emitted from a later call.
     function expectEmit(bool checkTopic1, bool checkTopic2, bool checkTopic3, bool checkData) external;
 
     /// Same as the previous method, but also checks supplied address against emitting contract.
@@ -2428,6 +2497,9 @@ interface Vm is VmSafe {
     /// Prepare an expected log with all topic and data checks enabled.
     /// Call this function, then emit an event, then call a function. Internally after the call, we check if
     /// logs were emitted in the expected order with the expected topics and data.
+    /// Must be placed immediately before the call you want to assert on. If the next call reverts and the
+    /// revert is caught by the caller (low-level call or try/catch), the expectation remains active and may
+    /// be satisfied by a log emitted from a later call.
     function expectEmit() external;
 
     /// Same as the previous method, but also checks supplied address against emitting contract.
@@ -2452,10 +2524,22 @@ interface Vm is VmSafe {
     /// Expect a given number of logs from a specific emitter with all topic and data checks enabled.
     function expectEmit(address emitter, uint64 count) external;
 
+    /// Expects a call to `SignatureVerifier.verifyKeychainAdmin(account, digest, signature)`.
+    /// The supplied `digest` should already be domain-separated with chain ID, contract address,
+    /// and account address.
+    function expectKeychainAdminVerified(address account, bytes32 digest, bytes calldata signature) external;
+
+    /// Expects a call to `SignatureVerifier.verifyKeychain(account, digest, signature)`.
+    function expectKeychainVerified(address account, bytes32 digest, bytes calldata signature) external;
+
+    /// Expects a TIP-20 `LogoURIUpdated(address indexed updater, string newLogoURI)` event.
+    function expectLogoURIUpdated(address token, address updater, string calldata newLogoURI) external;
+
     /// Expects an error on next call that starts with the revert data.
     function expectPartialRevert(bytes4 revertData) external;
 
     /// Expects an error on next call to reverter address, that starts with the revert data.
+    /// See `expectRevert(address)` for `reverter` matching semantics.
     function expectPartialRevert(bytes4 revertData, address reverter) external;
 
     /// Expects an error on next call with any revert data.
@@ -2465,21 +2549,35 @@ interface Vm is VmSafe {
     function expectRevert(bytes4 revertData) external;
 
     /// Expects a `count` number of reverts from the upcoming calls from the reverter address that match the revert data.
+    /// See `expectRevert(address)` for `reverter` matching semantics.
     function expectRevert(bytes4 revertData, address reverter, uint64 count) external;
 
     /// Expects a `count` number of reverts from the upcoming calls from the reverter address that exactly match the revert data.
+    /// See `expectRevert(address)` for `reverter` matching semantics.
     function expectRevert(bytes calldata revertData, address reverter, uint64 count) external;
 
     /// Expects an error on next call that exactly matches the revert data.
     function expectRevert(bytes calldata revertData) external;
 
     /// Expects an error with any revert data on next call to reverter address.
+    /// The `reverter` argument is matched against the address associated with
+    /// the frame that produced the revert:
+    /// - For a CALL: the address that was called.
+    /// - For a CREATE / CREATE2: the would-be deployed address of the failed
+    /// deployment (computed from the deployer + nonce, or salt + initcode).
+    /// For a single expected revert, the innermost reverting frame wins in
+    /// nested CALL, CREATE, or mixed chains. With `count > 1`, nested
+    /// CREATE / CREATE2 chains apply the same rule independently to each
+    /// iteration; nested CALL chains keep their existing
+    /// outermost-call-per-iteration behavior.
     function expectRevert(address reverter) external;
 
     /// Expects an error from reverter address on next call, with any revert data.
+    /// See `expectRevert(address)` for `reverter` matching semantics.
     function expectRevert(bytes4 revertData, address reverter) external;
 
     /// Expects an error from reverter address on next call, that exactly matches the revert data.
+    /// See `expectRevert(address)` for `reverter` matching semantics.
     function expectRevert(bytes calldata revertData, address reverter) external;
 
     /// Expects a `count` number of reverts from the upcoming calls with any revert data or reverter.
@@ -2492,6 +2590,7 @@ interface Vm is VmSafe {
     function expectRevert(bytes calldata revertData, uint64 count) external;
 
     /// Expects a `count` number of reverts from the upcoming calls from the reverter address.
+    /// See `expectRevert(address)` for `reverter` matching semantics.
     function expectRevert(address reverter, uint64 count) external;
 
     /// Only allows memory writes to offsets [0x00, 0x60) ∪ [min, max) in the current subcontext. If any other
@@ -2502,6 +2601,9 @@ interface Vm is VmSafe {
     /// If any other memory is written to, the test will fail. Can be called multiple times to add more ranges
     /// to the set.
     function expectSafeMemoryCall(uint64 min, uint64 max) external;
+
+    /// Expects a TIP-20 `LogoURIUpdated(address indexed updater, string newLogoURI)` event.
+    function expectTip20LogoURIUpdated(address token, address updater, string calldata newLogoURI) external;
 
     /// Marks a test as skipped. Must be called at the top level of a test.
     function skip(bool skipTest) external;

--- a/test/Vm.t.sol
+++ b/test/Vm.t.sol
@@ -9,10 +9,10 @@ import {Vm, VmSafe} from "../src/Vm.sol";
 // added to or removed from Vm or VmSafe.
 contract VmTest is Test {
     function test_VmInterfaceId() public pure {
-        assertEq(type(Vm).interfaceId, bytes4(0x6eba6eb5), "Vm");
+        assertEq(type(Vm).interfaceId, bytes4(0x23dda1ff), "Vm");
     }
 
     function test_VmSafeInterfaceId() public pure {
-        assertEq(type(VmSafe).interfaceId, bytes4(0xcb532963), "VmSafe");
+        assertEq(type(VmSafe).interfaceId, bytes4(0xc784e709), "VmSafe");
     }
 }


### PR DESCRIPTION
Added:
- `signKeychain(uint256 privateKey, address account, bytes32 digest)`
- `signKeychainAdmin(uint256 privateKey, address account, bytes32 digest)`
- `isImplicitlyApproved(address spender)`
- `isIsolateMode()`
- `lastFrameGas()`
- `rpcJson(string calldata method, string calldata params)`
- `rpcJson(string calldata urlOrAlias, string calldata method, string calldata params)`
- `assumeImplicitApproval(address spender)`
- `setLogoURI(address token, string calldata newLogoURI)`
- `setTip20LogoURI(address token, string calldata newLogoURI)`
- `snapshotGasLastFrame(string calldata name)`
- `snapshotGasLastFrame(string calldata group, string calldata name)`
- `expectKeychainAdminVerified(address account, bytes32 digest, bytes calldata signature)`
- `expectKeychainVerified(address account, bytes32 digest, bytes calldata signature)`
- `expectLogoURIUpdated(address token, address updater, string calldata newLogoURI)`
- `expectTip20LogoURIUpdated(address token, address updater, string calldata newLogoURI)`

Deprecated:
- `lastCallGas()`
  - use `lastFrameGas()` instead

- `snapshotGasLastCall(string calldata name)`
  - use `snapshotGasLastFrame(string calldata name)` instead

- `snapshotGasLastCall(string calldata group, string calldata name)`
  - use `snapshotGasLastFrame(string calldata group, string calldata name)` instead