### PR TITLE
feat: add Robinhood Chain and Robinhood Chain Testnet

### DIFF
--- a/src/StdChains.sol
+++ b/src/StdChains.sol
@@ -303,6 +303,13 @@ abstract contract StdChains {
         );
 
         _setChainWithDefaultRpcUrl("grav", ChainData("Gravity", 127001, "https://mainnet-rpc.gravity.xyz"));
+
+        _setChainWithDefaultRpcUrl(
+            "robinhood", ChainData("Robinhood Chain", 4663, "https://rpc.mainnet.chain.robinhood.com")
+        );
+        _setChainWithDefaultRpcUrl(
+            "robinhood_testnet", ChainData("Robinhood Chain Testnet", 46630, "https://rpc.testnet.chain.robinhood.com")
+        );
     }
 
     // set chain info, with priority to chainAlias' rpc url in foundry.toml


### PR DESCRIPTION
adds Robinhood Chain and its testnet to `_initializeStdChains()` so `getChain("robinhood")` / `getChain(4663)` (and the testnet equivalents) resolve in Forge tests and scripts without per-project config

- **Robinhood Chain** (mainnet)
  - chainId: `4663`
  - alias: `robinhood`
  - rpc: https://rpc.mainnet.chain.robinhood.com
  - explorer: https://robinhoodchain.blockscout.com (Blockscout, EIP-3091)
- **Robinhood Chain Testnet**
  - chainId: `46630`
  - alias: `robinhood_testnet`
  - rpc: https://rpc.testnet.chain.robinhood.com
  - explorer: https://explorer.testnet.chain.robinhood.com (Blockscout, EIP-3091)

robinhood chain is an arbitrum orbit L2 (mainnet settles on ethereum, testnet on sepolia), docs at https://docs.robinhood.com/chain

both chains are already registered in `alloy-rs/chains`, and the testnet is in `ethereum-lists/chains` (`eip155-46630`)

`test_Rpcs` is commented out upstream so no test change is needed, and the formatting matches `forge fmt`
