### PR TITLE
fix(StdCheats): enable packed slots when dealing token balances

### DIFF
--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -827,8 +827,8 @@ abstract contract StdCheats is StdCheatsSafe {
         (, bytes memory balData) = token.staticcall(abi.encodeWithSelector(0x70a08231, to));
         uint256 prevBal = abi.decode(balData, (uint256));
 
-        // update balance
-        _stdstore.target(token).sig(0x70a08231).with_key(to).checked_write(give);
+        // update balance (packed-aware for tokens like USDC / sUSD that pack balance into a slot)
+        _stdstore.enable_packed_slots().target(token).sig(0x70a08231).with_key(to).checked_write(give);
 
         // update total supply
         if (adjust) {
@@ -850,7 +850,7 @@ abstract contract StdCheats is StdCheatsSafe {
         uint256 prevBal = abi.decode(balData, (uint256));
 
         // update balance
-        _stdstore.target(token).sig(0x00fdd58e).with_key(to).with_key(id).checked_write(give);
+        _stdstore.enable_packed_slots().target(token).sig(0x00fdd58e).with_key(to).with_key(id).checked_write(give);
 
         // update total supply
         if (adjust) {
@@ -884,9 +884,9 @@ abstract contract StdCheats is StdCheatsSafe {
         (, bytes memory toBalData) = token.staticcall(abi.encodeWithSelector(0x70a08231, to));
         uint256 toPrevBal = abi.decode(toBalData, (uint256));
 
-        // update balances
-        _stdstore.target(token).sig(0x70a08231).with_key(abi.decode(ownerData, (address))).checked_write(--fromPrevBal);
-        _stdstore.target(token).sig(0x70a08231).with_key(to).checked_write(++toPrevBal);
+        // update balances (packed-aware)
+        _stdstore.enable_packed_slots().target(token).sig(0x70a08231).with_key(abi.decode(ownerData, (address))).checked_write(--fromPrevBal);
+        _stdstore.enable_packed_slots().target(token).sig(0x70a08231).with_key(to).checked_write(++toPrevBal);
 
         // update owner
         _stdstore.target(token).sig(0x6352211e).with_key(id).checked_write(to);

--- a/src/StdCheats.sol
+++ b/src/StdCheats.sol
@@ -885,7 +885,8 @@ abstract contract StdCheats is StdCheatsSafe {
         uint256 toPrevBal = abi.decode(toBalData, (uint256));
 
         // update balances (packed-aware)
-        _stdstore.enable_packed_slots().target(token).sig(0x70a08231).with_key(abi.decode(ownerData, (address))).checked_write(--fromPrevBal);
+        _stdstore.enable_packed_slots().target(token).sig(0x70a08231).with_key(abi.decode(ownerData, (address)))
+            .checked_write(--fromPrevBal);
         _stdstore.enable_packed_slots().target(token).sig(0x70a08231).with_key(to).checked_write(++toPrevBal);
 
         // update owner

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -687,7 +687,6 @@ contract BarERC721 {
     mapping(address => uint256) private _balances;
 }
 
-
 /// ERC20-like balance packed with adjacent metadata in the same slot (low 128 = balance).
 contract PackedBalanceToken {
     // layout per address: [other:128][balance:128]

--- a/test/StdCheats.t.sol
+++ b/test/StdCheats.t.sol
@@ -122,6 +122,21 @@ contract StdCheatsTest is Test {
         assertEq(barToken.totalSupply(), 10000e18);
     }
 
+    function test_DealTokenPackedBalance() public {
+        // Balance packed in the low 128 bits of a storage word (USDC / sUSD class).
+        PackedBalanceToken token = new PackedBalanceToken();
+        address other = address(0xBEEF);
+        token.seed(address(this), 100, 0xdead);
+        token.seed(other, 50, 0xbeef);
+
+        deal(address(token), address(this), 999);
+        assertEq(token.balanceOf(address(this)), 999);
+        // high bits must be preserved
+        assertEq(token.other(address(this)), 0xdead);
+        assertEq(token.balanceOf(other), 50);
+        assertEq(token.other(other), 0xbeef);
+    }
+
     function test_DealERC1155Token() public {
         BarERC1155 barToken = new BarERC1155();
         address bar = address(barToken);
@@ -670,6 +685,25 @@ contract BarERC721 {
 
     mapping(uint256 => address) private _owners;
     mapping(address => uint256) private _balances;
+}
+
+
+/// ERC20-like balance packed with adjacent metadata in the same slot (low 128 = balance).
+contract PackedBalanceToken {
+    // layout per address: [other:128][balance:128]
+    mapping(address => uint256) private _slot;
+
+    function seed(address account, uint128 bal, uint128 meta) external {
+        _slot[account] = uint256(bal) | (uint256(meta) << 128);
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return uint128(_slot[account]);
+    }
+
+    function other(address account) external view returns (uint256) {
+        return uint256(uint128(_slot[account] >> 128));
+    }
 }
 
 contract RevertingContract {


### PR DESCRIPTION
## Summary

`deal` wrote balances through `stdstore` without packed mode. Tokens that store balance in a packed slot (e.g. post-upgrade USDC, Optimism sUSD) fail `find` or would clobber neighbor fields. Use `enable_packed_slots()` for balance writes in `deal` / `dealERC1155` / `dealERC721`.

## Linked issue

Fixes #293

## Test plan

- [x] Existing `test_Deal*` suite passes
- [x] New `test_DealTokenPackedBalance` (balance in low 128 bits; high bits preserved)

## AI assistance

Prepared with AI assistance; I reviewed and tested the change.

## Risk

Packed mode is slightly more expensive on find. Unpacked ERC20s still work (covered by existing tests).
