### PR TITLE
fix(StdStorage): distinguish derived return values from missing slots

### DIFF
--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -117,6 +117,19 @@ library stdStorageSafe {
         return (success && (prevReturnValue != newReturnValue));
     }
 
+    /// @notice Returns whether any slot in `reads` changes the return value of the configured target call.
+    /// @dev Only used after a search fails, to tell "none of the slots we read matter" apart from
+    /// "a slot matters, but its stored value is transformed before being returned" (e.g. rebasing tokens).
+    function _anySlotAffectsCall(StdStorage storage self, bytes32[] memory reads) private returns (bool) {
+        for (uint256 i = reads.length; i > 0;) {
+            --i;
+            if (checkSlotMutatesCall(self, reads[i])) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /// @notice Searches for the bit offset of the packed variable within `slot` from the left or right side.
     function findOffset(StdStorage storage self, bytes32 slot, bool left) internal returns (bool, uint256) {
         for (uint256 offset = 0; offset < 256; offset++) {
@@ -221,10 +234,19 @@ library stdStorageSafe {
             }
         }
 
-        require(
-            self.finds[who][fsig][keccak256(abi.encodePacked(params, field_depth))].found,
-            "stdStorage find(StdStorage): Slot(s) not found."
-        );
+        if (!self.finds[who][fsig][keccak256(abi.encodePacked(params, field_depth))].found) {
+            // Distinguish "none of the slots we read matter" from "a slot matters but never
+            // holds the returned value", which means the target transforms the stored value
+            // before returning it. Skipped for short bytes/string returns, where a word-wise
+            // comparison does not apply and a mismatch says nothing about how the value is
+            // produced. Only reached on the failing path, so this costs nothing otherwise.
+            if (callData.shortBytesStorageValue == bytes32(0) && _anySlotAffectsCall(self, callData.reads)) {
+                revert(
+                    "stdStorage find(StdStorage): Slot(s) affect the return value but none hold it. Target may derive the value (e.g. rebasing token) or pack it (try enable_packed_slots())."
+                );
+            }
+            revert("stdStorage find(StdStorage): Slot(s) not found.");
+        }
 
         if (_clear) {
             clear(self);

--- a/test/StdStorage.t.sol
+++ b/test/StdStorage.t.sol
@@ -393,6 +393,21 @@ contract StdStorageTest is Test {
         vm.expectRevert("stdStorage find(StdStorage): Slot(s) not found.");
         target.findBalanceOf(address(this));
     }
+
+    // Regression test for https://github.com/foundry-rs/forge-std/issues/140
+    // `deal()` on a scaled-balance token (e.g. an Aave aToken) fails because
+    // `balanceOf` returns the stored balance scaled by an index, so no slot ever
+    // holds the returned value verbatim. Unlike a reflection token, the balance
+    // slot *is* detected as affecting the call, so report that specifically
+    // instead of claiming no slot was found.
+    function test_RevertFindOnScaledBalanceToken() public {
+        MockScaledBalanceToken token = new MockScaledBalanceToken();
+        ScaledBalanceTokenTarget target = new ScaledBalanceTokenTarget(token);
+        vm.expectRevert(
+            "stdStorage find(StdStorage): Slot(s) affect the return value but none hold it. Target may derive the value (e.g. rebasing token) or pack it (try enable_packed_slots())."
+        );
+        target.findBalanceOf(address(this));
+    }
 }
 
 contract StorageTestTarget {
@@ -441,6 +456,21 @@ contract ReflectionTokenTarget {
     MockReflectionToken internal token;
 
     constructor(MockReflectionToken token_) {
+        token = token_;
+    }
+
+    function findBalanceOf(address who) public {
+        stdstore.target(address(token)).sig("balanceOf(address)").with_key(who).find();
+    }
+}
+
+contract ScaledBalanceTokenTarget {
+    using stdStorage for StdStorage;
+
+    StdStorage internal stdstore;
+    MockScaledBalanceToken internal token;
+
+    constructor(MockScaledBalanceToken token_) {
         token = token_;
     }
 
@@ -585,5 +615,23 @@ contract MockReflectionToken {
         uint256 x = _a + _b + _c + _balances[account];
         x; // suppress unused warning
         return 42;
+    }
+}
+
+// Minimal mock of a scaled-balance token (e.g. an Aave aToken): `balanceOf`
+// returns the stored scaled balance multiplied by a liquidity index. Mutating
+// the balance slot does change the return value, but the slot never holds that
+// value, so stdStorage detects a relevant slot yet still cannot match it.
+contract MockScaledBalanceToken {
+    uint256 internal constant RAY = 1e27;
+    uint256 internal _index = 1.5e27;
+    mapping(address => uint256) internal _scaledBalances;
+
+    constructor() {
+        _scaledBalances[msg.sender] = 1000 ether;
+    }
+
+    function balanceOf(address account) public view returns (uint256) {
+        return (_scaledBalances[account] * _index) / RAY;
     }
 }


### PR DESCRIPTION
## Motivation

Closes #140.

`deal()` fails on tokens whose balance is computed rather than stored. The original report uses an Aave aToken, whose `balanceOf` returns the stored *scaled* balance multiplied by a liquidity index:

```
balanceOf(user) == scaledBalance(user) * getReserveNormalizedIncome() / RAY
```

`stdStorage.find()` locates a slot by requiring that the value held in the slot equals the value returned by the call. For a scaled-balance token that is never true, so the search fails with:

```
stdStorage find(StdStorage): Slot(s) not found.
```

That message is misleading. The balance slot *is* found — `checkSlotMutatesCall` correctly reports that mutating it changes `balanceOf`. It is rejected one step later by the value-equality check, and the user is told nothing about why.

## Solution

Report the two failures separately. When the search fails, probe whether any recorded read slot actually influences the return value:

- **No slot influences it** → unchanged, `"Slot(s) not found."` This is the reflection-token case from #740, whose regression test is untouched.
- **A slot influences it but none hold it** → a new message naming the two realistic causes:

```
stdStorage find(StdStorage): Slot(s) affect the return value but none hold it.
Target may derive the value (e.g. rebasing token) or pack it (try enable_packed_slots()).
```

Implementation notes:

- The probe lives in a helper rather than a flag threaded through the search loop. `find()` is already at the EVM stack limit — adding a single local there fails to compile with *Stack too deep*.
- The probe only runs on the failing path, which reverts anyway, so successful lookups are unaffected.
- Short `bytes`/`string` returns are excluded. There a word-wise mismatch says nothing about how the value is produced, so `test_RevertStorageFindRestoresFailedShortBytesProbe` keeps the original message.

## Testing

`test_RevertFindOnScaledBalanceToken` adds a minimal aToken-style mock (stored balance × index) and asserts the new message. It mirrors the structure of the existing `test_RevertFindOnReflectionToken`.

`forge test`: 207 passing, 0 failing. `forge fmt --check` clean.

This does not make `deal()` work on such tokens — that would require inverting the token's own accounting, which is out of scope. It tells the user what happened so they can reach for `vm.store` or the underlying scaled-balance accessor.
