### PR TITLE
test(StdJson): cover readBytes at parseRaw's inferred-type lengths

### DIFF
--- a/src/StdJson.sol
+++ b/src/StdJson.sol
@@ -34,6 +34,10 @@ library stdJson {
 
     /// @notice ABI-encodes the JSON value selected by `key`.
     /// @dev `key` uses the same selector syntax as `vm.parseJson*`, such as `.a` or `$`.
+    /// @dev The value's type is inferred, not declared. A hex string of exactly 20 bytes is encoded
+    /// as an `address` and one of exactly 32 bytes as a `bytes32`; every other length is encoded as
+    /// dynamic `bytes`. Decoding those two lengths as `bytes` therefore reverts, so prefer
+    /// `readBytes` when the value is meant to be byte data.
     function parseRaw(string memory json, string memory key) internal pure returns (bytes memory) {
         return vm.parseJson(json, key);
     }

--- a/test/StdJson.t.sol
+++ b/test/StdJson.t.sol
@@ -30,6 +30,34 @@ contract StdJsonTest is Test {
         assertEq(json.readUint(".a"), 123);
     }
 
+    // Regression test for https://github.com/foundry-rs/forge-std/issues/592
+    // `parseRaw` infers a value's type, encoding a 20-byte hex string as an `address` and a
+    // 32-byte one as a `bytes32`. Reading either back as `bytes` reverts, which is how
+    // `readBytes` broke when it decoded `parseRaw` output instead of calling
+    // `vm.parseJsonBytes`. Pin the lengths on both sides of each inference boundary.
+    function test_ReadBytesAtInferredTypeLengths() public pure {
+        string memory nineteen = '{"a":"0x00000000000000000000000000000000000000"}';
+        assertEq(nineteen.readBytes(".a"), hex"00000000000000000000000000000000000000");
+
+        string memory twentyZeros = '{"a":"0x0000000000000000000000000000000000000000"}';
+        assertEq(twentyZeros.readBytes(".a"), hex"0000000000000000000000000000000000000000");
+
+        string memory twentyAddressShaped = '{"a":"0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad6"}';
+        assertEq(twentyAddressShaped.readBytes(".a"), hex"4bf5122f344554c53bde2ebb8cd2b7e3d1600ad6");
+
+        string memory twentyOne = '{"a":"0x000000000000000000000000000000000000000000"}';
+        assertEq(twentyOne.readBytes(".a"), hex"000000000000000000000000000000000000000000");
+
+        string memory thirtyOne = '{"a":"0x00000000000000000000000000000000000000000000000000000000000012"}';
+        assertEq(thirtyOne.readBytes(".a"), hex"00000000000000000000000000000000000000000000000000000000000012");
+
+        string memory thirtyTwo = '{"a":"0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad64bf5122f344554c53bde2ebb"}';
+        assertEq(thirtyTwo.readBytes(".a"), hex"4bf5122f344554c53bde2ebb8cd2b7e3d1600ad64bf5122f344554c53bde2ebb");
+
+        string memory thirtyThree = '{"a":"0x4bf5122f344554c53bde2ebb8cd2b7e3d1600ad64bf5122f344554c53bde2ebb00"}';
+        assertEq(thirtyThree.readBytes(".a"), hex"4bf5122f344554c53bde2ebb8cd2b7e3d1600ad64bf5122f344554c53bde2ebb00");
+    }
+
     function test_writeJson() public {
         string memory json = "json";
         json.serialize("a", uint256(123));


### PR DESCRIPTION
## Motivation

Closes #592.

The reported bug — `readBytes` returning wrong data or reverting on 20-byte
values — does not reproduce on `master`. It was real on forge-std v1.2.0, where
`readBytes` was `abi.decode(vm.parseJson(json, key), (bytes))`. It now calls
`vm.parseJsonBytes` directly, which sidesteps the cause.

The cause itself is still there, one layer down. `parseRaw` infers a value's
type instead of taking a declared one:

| hex string length | `parseRaw` output | inferred as |
| --- | --- | --- |
| 1, 19, 21, 31, 33 bytes | 96 bytes | dynamic `bytes` |
| **exactly 20 bytes** | 32 bytes | **`address`** |
| **exactly 32 bytes** | 32 bytes | **`bytes32`** |

So `abi.decode(json.parseRaw(key), (bytes))` still reverts at exactly 20 and 32
bytes. `readBytes` avoids it, but nothing in the suite says so — `readBytes` has
no test coverage at all — and nothing in the docs warns about it.

## Solution

- `test_ReadBytesAtInferredTypeLengths` asserts `readBytes` round-trips 19, 20,
  21, 31, 32 and 33 byte values, bracketing both inference boundaries. If
  `readBytes` is ever routed back through `parseRaw`, this fails.
- A `@dev` note on `parseRaw` documents the inference, so the next person
  decoding its output as `bytes` knows why it reverts.

## Testing

`forge test`: 207 passing, 0 failing. `forge fmt --check` clean. Build matrix
(stable, `--via-ir`, solc 0.8.13 and 0.8.35, each with and without IR) all green.
