### PR TITLE
fix(config): let config-only chains load without an RPC endpoint

### DIFF
--- a/src/StdConfig.sol
+++ b/src/StdConfig.sol
@@ -47,6 +47,7 @@ contract StdConfig {
     error ChainNotInitialized(uint256 chainId);
     error UnableToParseVariable(string key);
     error WriteToFileInForbiddenCtxt();
+    error MissingRpcEndpoint(uint256 chainId);
 
     // -- STORAGE (CACHE FROM CONFIG FILE) ------------------------------------
 
@@ -104,13 +105,17 @@ contract StdConfig {
             _chainKeys.push(chain_key);
 
             // Cache the configured RPC endpoint for that chain.
-            // Falls back to `[rpc_endpoints]`. Panics if no rpc endpoint is configured.
+            // Falls back to `[rpc_endpoints]`. A chain section may exist only to carry
+            // config values, in which case no endpoint is needed, so a missing one is
+            // deferred to `getRpcUrl` instead of failing the whole load here.
             try vm.parseTomlString(content, string.concat("$.", chain_key, ".endpoint_url")) returns (
                 string memory url
             ) {
                 _rpcOf[chainId] = vm.resolveEnv(url);
             } catch {
-                _rpcOf[chainId] = vm.resolveEnv(vm.rpcUrl(chain_key));
+                try vm.rpcUrl(chain_key) returns (string memory url) {
+                    _rpcOf[chainId] = vm.resolveEnv(url);
+                } catch {}
             }
 
             // Iterate through all the available `TypeKind`s (except `None`) to create the sub-section paths
@@ -353,13 +358,18 @@ contract StdConfig {
     }
 
     /// @notice Reads the RPC URL for a specific chain id.
+    /// @dev    Reverts with `MissingRpcEndpoint` if the chain was configured without an
+    ///         endpoint. Loading such a chain is allowed, since its config values are
+    ///         still usable; only asking for the endpoint is an error.
     function getRpcUrl(uint256 chainId) public view returns (string memory) {
-        return _rpcOf[chainId];
+        string memory url = _rpcOf[chainId];
+        if (bytes(url).length == 0) revert MissingRpcEndpoint(chainId);
+        return url;
     }
 
     /// @notice Reads the RPC URL for the current chain.
     function getRpcUrl() public view returns (string memory) {
-        return _rpcOf[vm.getChainId()];
+        return getRpcUrl(vm.getChainId());
     }
 
     // -- SETTER FUNCTIONS (SINGLE VALUES) -------------------------------------

--- a/test/Config.t.sol
+++ b/test/Config.t.sol
@@ -378,4 +378,51 @@ contract ConfigTest is Test, Config {
         new StdConfig(badParseConfig, false);
         vm.removeFile(badParseConfig);
     }
+
+    function test_loadConfigWithoutRpcEndpoint() public {
+        // A chain section may exist only to carry config values. Loading it should not
+        // require an endpoint, since nothing on the `_loadConfig` path ever reads one.
+        string memory configOnly = "./test/fixtures/config_no_endpoint.toml";
+        vm.writeFile(
+            configOnly,
+            string.concat(
+                "[mainnet]\n",
+                "endpoint_url = \"https://ethereum.reth.rs/rpc\"\n",
+                "\n",
+                "# No endpoint_url, and no matching entry in `[rpc_endpoints]`.\n",
+                "[optimism.uint]\n",
+                "some_number = 7\n"
+            )
+        );
+
+        _loadConfig(configOnly, false);
+
+        assertEq(config.getChainIds().length, 2, "both chains should load");
+        assertEq(config.get(10, "some_number").toUint256(), 7, "config values stay readable");
+        assertEq(config.getRpcUrl(1), "https://ethereum.reth.rs/rpc", "configured endpoints still resolve");
+
+        vm.removeFile(configOnly);
+    }
+
+    function testRevert_MissingRpcEndpoint() public {
+        // Loading a chain without an endpoint is fine; asking for the endpoint is not.
+        string memory configOnly = "./test/fixtures/config_no_endpoint_revert.toml";
+        vm.writeFile(
+            configOnly,
+            string.concat(
+                "[mainnet]\n",
+                "endpoint_url = \"https://ethereum.reth.rs/rpc\"\n",
+                "\n",
+                "[optimism.uint]\n",
+                "some_number = 7\n"
+            )
+        );
+
+        _loadConfig(configOnly, false);
+
+        vm.expectRevert(abi.encodeWithSelector(StdConfig.MissingRpcEndpoint.selector, uint256(10)));
+        config.getRpcUrl(10);
+
+        vm.removeFile(configOnly);
+    }
 }


### PR DESCRIPTION
The `StdConfig` constructor resolves an RPC endpoint for every chain section, and fails the whole load when neither `endpoint_url` nor `[rpc_endpoints]` supplies one:

```solidity
try vm.parseTomlString(content, string.concat("$.", chain_key, ".endpoint_url")) returns (string memory url) {
    _rpcOf[chainId] = vm.resolveEnv(url);
} catch {
    _rpcOf[chainId] = vm.resolveEnv(vm.rpcUrl(chain_key));
}
```

`_rpcOf` is only read by `getRpcUrl`, and `getRpcUrl` is only called by `_loadConfigAndForks` when it creates forks. So a chain section that exists purely to carry config values is rejected for lacking something nothing on that path would ever read:

```toml
[anvil]
endpoint_url = "http://127.0.0.1:8545"

[optimism.uint]
some_number = 7
```

```
[FAIL: invalid rpc url: optimism]
```

This defers the resolution. Loading such a chain now succeeds and its values stay readable. Asking for the endpoint reverts with `MissingRpcEndpoint(chainId)`.

## Behaviour change worth flagging

`getRpcUrl` previously returned an empty string for a chain with no endpoint, and now reverts. That is deliberate, since a caller asking for an endpoint that does not exist is better off knowing than receiving `""`, and it gives `_loadConfigAndForks` a failure that names the chain rather than the previous `invalid rpc url`. Nothing changes for a chain that has an endpoint configured. Happy to return the empty string instead if you would rather keep it non-reverting.

## Tests

Two cases in `test/Config.t.sol`, following the temp-fixture pattern already used by the `testRevert_` tests:

- `test_loadConfigWithoutRpcEndpoint` loads a config with one endpoint-less chain, asserts both chains load, that the config values are readable, and that a configured endpoint still resolves.
- `testRevert_MissingRpcEndpoint` asserts the endpoint lookup reverts for that chain.

```
forge test                  208 passed, 0 failed
forge fmt --check           clean
forge build --deny warnings clean
```

Negative control: reverting only the constructor change, leaving the new error declared so it still compiles, makes both new tests fail with `invalid rpc url: optimism` while the other nine in the file are unaffected.

## Context

Reported as foundry-rs/foundry#13119. The premise there does not reproduce on current `master`: the config in that issue loads fine, empty chain sections are already skipped at `StdConfig.sol:100`, and a missing type sub-section is already tolerated by the surrounding `try ... catch {}`. This is the adjacent gap that is real.
