### PR TITLE
fix: stop stdStorage access recording

### DIFF
--- a/src/StdStorage.sol
+++ b/src/StdStorage.sol
@@ -177,6 +177,7 @@ library stdStorageSafe {
                 callData.shortBytesStorageValue = _parseShortBytesReturn(rdat);
             }
             (callData.reads,) = vm.accesses(address(who));
+            vm.stopRecord();
         }
 
         if (callData.reads.length == 0) {

--- a/test/StdStorage.t.sol
+++ b/test/StdStorage.t.sol
@@ -21,6 +21,16 @@ contract StdStorageTest is Test {
         assertEq(uint256(0), stdstore.target(address(test)).sig("exists()").find());
     }
 
+    function test_StorageFindStopsRecording() public {
+        stdstore.target(address(test)).sig("exists()").find();
+        (bytes32[] memory readsBefore,) = vm.accesses(address(test));
+
+        test.map_addr(address(this));
+        (bytes32[] memory readsAfter,) = vm.accesses(address(test));
+
+        assertEq(readsAfter, readsBefore);
+    }
+
     function test_StorageExtraSload() public {
         assertEq(16, stdstore.target(address(test)).sig(test.extra_sload.selector).find());
     }


### PR DESCRIPTION
## Motivation

`stdStorage.find` starts storage-access recording but leaves it enabled after reading the results. This keeps Foundry on the inspector slow path for the remainder of any test that uses `stdstore` or ERC20 `deal`. This addresses the forge-std side of [foundry-rs/foundry#16376](https://github.com/foundry-rs/foundry/pull/16376).

## Solution

Call `vm.stopRecord()` immediately after retrieving the recorded accesses, and add a regression test proving subsequent storage reads are not recorded.

## Testing

- `forge fmt --check`
- `forge test` (207 passed)

Prompted by: @DaniPopes