### PR TITLE
chore: sync state gas field

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -258,7 +258,7 @@ interface VmSafe {
     struct Gas {
         // The gas limit of the call.
         uint64 gasLimit;
-        // The total gas used.
+        // The total regular gas used.
         uint64 gasTotalUsed;
         // DEPRECATED: The amount of gas used for memory expansion. Ref: <https://github.com/foundry-rs/foundry/pull/7934#pullrequestreview-2069236939>
         uint64 gasMemoryUsed;
@@ -266,6 +266,8 @@ interface VmSafe {
         int64 gasRefunded;
         // The amount of gas remaining.
         uint64 gasRemaining;
+        // The net state gas used. Zero for reverted or halted frames; may be negative within a nested frame when state gas is refunded.
+        int64 gasStateUsed;
     }
 
     /// The result of the `stopDebugTraceRecording` call

--- a/test/StdStorage.t.sol
+++ b/test/StdStorage.t.sol
@@ -68,20 +68,30 @@ contract StdStorageTest is Test {
     }
 
     function test_StorageDeepMap() public {
-        uint256 slot = stdstore.target(address(test)).sig(test.deep_map.selector).with_key(address(this))
-            .with_key(address(this)).find();
+        uint256 slot = stdstore.target(address(test))
+            .sig(test.deep_map.selector)
+            .with_key(address(this))
+            .with_key(address(this))
+            .find();
         assertEq(uint256(keccak256(abi.encode(address(this), keccak256(abi.encode(address(this), uint256(5)))))), slot);
     }
 
     function test_StorageCheckedWriteDeepMap() public {
-        stdstore.target(address(test)).sig(test.deep_map.selector).with_key(address(this)).with_key(address(this))
+        stdstore.target(address(test))
+            .sig(test.deep_map.selector)
+            .with_key(address(this))
+            .with_key(address(this))
             .checked_write(100);
         assertEq(100, test.deep_map(address(this), address(this)));
     }
 
     function test_StorageDeepMapStructA() public {
-        uint256 slot = stdstore.target(address(test)).sig(test.deep_map_struct.selector).with_key(address(this))
-            .with_key(address(this)).depth(0).find();
+        uint256 slot = stdstore.target(address(test))
+            .sig(test.deep_map_struct.selector)
+            .with_key(address(this))
+            .with_key(address(this))
+            .depth(0)
+            .find();
         assertEq(
             bytes32(
                 uint256(keccak256(abi.encode(address(this), keccak256(abi.encode(address(this), uint256(6)))))) + 0
@@ -91,8 +101,12 @@ contract StdStorageTest is Test {
     }
 
     function test_StorageDeepMapStructB() public {
-        uint256 slot = stdstore.target(address(test)).sig(test.deep_map_struct.selector).with_key(address(this))
-            .with_key(address(this)).depth(1).find();
+        uint256 slot = stdstore.target(address(test))
+            .sig(test.deep_map_struct.selector)
+            .with_key(address(this))
+            .with_key(address(this))
+            .depth(1)
+            .find();
         assertEq(
             bytes32(
                 uint256(keccak256(abi.encode(address(this), keccak256(abi.encode(address(this), uint256(6)))))) + 1
@@ -102,16 +116,24 @@ contract StdStorageTest is Test {
     }
 
     function test_StorageCheckedWriteDeepMapStructA() public {
-        stdstore.target(address(test)).sig(test.deep_map_struct.selector).with_key(address(this))
-            .with_key(address(this)).depth(0).checked_write(100);
+        stdstore.target(address(test))
+            .sig(test.deep_map_struct.selector)
+            .with_key(address(this))
+            .with_key(address(this))
+            .depth(0)
+            .checked_write(100);
         (uint256 a, uint256 b) = test.deep_map_struct(address(this), address(this));
         assertEq(100, a);
         assertEq(0, b);
     }
 
     function test_StorageCheckedWriteDeepMapStructB() public {
-        stdstore.target(address(test)).sig(test.deep_map_struct.selector).with_key(address(this))
-            .with_key(address(this)).depth(1).checked_write(100);
+        stdstore.target(address(test))
+            .sig(test.deep_map_struct.selector)
+            .with_key(address(this))
+            .with_key(address(this))
+            .depth(1)
+            .checked_write(100);
         (uint256 a, uint256 b) = test.deep_map_struct(address(this), address(this));
         assertEq(0, a);
         assertEq(100, b);
@@ -190,11 +212,17 @@ contract StdStorageTest is Test {
     }
 
     function testFuzz_StorageCheckedWriteMapPacked(address addr, uint128 value) public {
-        stdstore.enable_packed_slots().target(address(test)).sig(test.read_struct_lower.selector).with_key(addr)
+        stdstore.enable_packed_slots()
+            .target(address(test))
+            .sig(test.read_struct_lower.selector)
+            .with_key(addr)
             .checked_write(value);
         assertEq(test.read_struct_lower(addr), value);
 
-        stdstore.enable_packed_slots().target(address(test)).sig(test.read_struct_upper.selector).with_key(addr)
+        stdstore.enable_packed_slots()
+            .target(address(test))
+            .sig(test.read_struct_upper.selector)
+            .with_key(addr)
             .checked_write(value);
         assertEq(test.read_struct_upper(addr), value);
     }
@@ -203,7 +231,9 @@ contract StdStorageTest is Test {
         uint256 full = test.map_packed(address(1337));
         // keep upper 128, set lower 128 to 1337
         full = (full & (uint256((1 << 128) - 1) << 128)) | 1337;
-        stdstore.target(address(test)).sig(test.map_packed.selector).with_key(address(uint160(1337)))
+        stdstore.target(address(test))
+            .sig(test.map_packed.selector)
+            .with_key(address(uint160(1337)))
             .checked_write(full);
         assertEq(1337, test.read_struct_lower(address(1337)));
     }
@@ -300,8 +330,10 @@ contract StdStorageTest is Test {
             // clear left bits, then clear right bits and realign
             uint256 expectedValToRead = (val << leftBits) >> (leftBits + rightBits);
 
-            uint256 readVal = stdstore.target(address(test)).enable_packed_slots()
-                .sig("getRandomPacked(uint8,uint8[],uint8)").with_calldata(abi.encode(shifts, shiftSizes, elemToGet))
+            uint256 readVal = stdstore.target(address(test))
+                .enable_packed_slots()
+                .sig("getRandomPacked(uint8,uint8[],uint8)")
+                .with_calldata(abi.encode(shifts, shiftSizes, elemToGet))
                 .read_uint();
 
             assertEq(readVal, expectedValToRead);
@@ -340,14 +372,22 @@ contract StdStorageTest is Test {
 
         // Pack all values into the slot.
         for (uint256 i = 0; i < nvars; i++) {
-            stdstore.enable_packed_slots().target(address(test)).sig("getRandomPacked(uint256,uint256)")
-                .with_key(sizes[i]).with_key(offsets[i]).checked_write(vals[i]);
+            stdstore.enable_packed_slots()
+                .target(address(test))
+                .sig("getRandomPacked(uint256,uint256)")
+                .with_key(sizes[i])
+                .with_key(offsets[i])
+                .checked_write(vals[i]);
         }
 
         // Verify the read data matches.
         for (uint256 i = 0; i < nvars; i++) {
-            uint256 readVal = stdstore.enable_packed_slots().target(address(test))
-                .sig("getRandomPacked(uint256,uint256)").with_key(sizes[i]).with_key(offsets[i]).read_uint();
+            uint256 readVal = stdstore.enable_packed_slots()
+                .target(address(test))
+                .sig("getRandomPacked(uint256,uint256)")
+                .with_key(sizes[i])
+                .with_key(offsets[i])
+                .read_uint();
 
             uint256 retVal = test.getRandomPacked(sizes[i], offsets[i]);
 


### PR DESCRIPTION
Sync `Vm.Gas` with Foundry's six-field return ABI by documenting `gasTotalUsed` as regular gas and exposing `gasStateUsed` for net state gas. This keeps Forge Std callers aligned with the state-gas reporting added in foundry-rs/foundry#16387.

AI assistance was used to implement and test this change.
