### PR TITLE
docs: clarify EIP-8037 gas accounting

### DIFF
--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -254,19 +254,43 @@ interface VmSafe {
         bool reverted;
     }
 
-    /// Gas used. Returned by `lastCallGas` and `lastFrameGas`.
+    /// Gas measurements returned by `lastCallGas` and `lastFrameGas`, from the callee's perspective.
+    /// Includes nested execution, but not all overhead charged to the caller.
+    /// With isolation, the isolated call is measured as a transaction, including intrinsic gas.
+    /// EIP-8037 separates regular gas (also called execution gas) from state gas for state creation.
+    /// State charges use a separate reservoir first, then regular gas when the reservoir is empty.
+    /// On EVM versions/networks without EIP-8037, state creation uses the ordinary gas schedule:
+    /// `gasStateUsed` is zero, and those costs are included in `gasTotalUsed`.
+    /// These are measurements, not a gas-limit estimate or a transaction receipt.
+    /// See <https://eips.ethereum.org/EIPS/eip-8037> and <https://getfoundry.sh/reference/cheatcodes/last-frame-gas>.
     struct Gas {
-        // The gas limit of the call.
+        // Regular gas limit of the frame, excluding the EIP-8037 state gas reservoir.
+        // This is not the transaction's combined gas limit and need not equal the gas required to succeed.
         uint64 gasLimit;
-        // The total regular gas used.
+        // Regular (execution) gas used, excluding EIP-8037 state gas, before subtracting `gasRefunded`.
+        // Includes nested execution. With isolation, includes intrinsic gas and the regular-gas calldata floor.
+        // Without EIP-8037, includes state creation costs under the ordinary gas schedule.
+        // Not the receipt's total charged gas or a sufficient gas limit; see `gasStateUsed` and `gasRefunded`.
         uint64 gasTotalUsed;
-        // DEPRECATED: The amount of gas used for memory expansion. Ref: <https://github.com/foundry-rs/foundry/pull/7934#pullrequestreview-2069236939>
+        // DEPRECATED: Always zero. Memory expansion costs are included in `gasTotalUsed`.
+        // Ref: <https://github.com/foundry-rs/foundry/pull/7934#pullrequestreview-2069236939>.
         uint64 gasMemoryUsed;
-        // The amount of gas refunded.
+        // Regular gas refund counter for the frame; can be negative in a nested frame.
+        // Without isolation, this is before the transaction-wide refund cap and calldata floor.
+        // With isolation, this is the isolated transaction's final refund reported by the EVM.
+        // Excludes EIP-8037 state gas refills, which are already reflected in `gasStateUsed`.
+        // Do not subtract it to estimate the gas limit needed to execute.
         int64 gasRefunded;
-        // The amount of gas remaining.
+        // Regular gas remaining at frame completion, excluding the EIP-8037 state gas reservoir.
+        // State charges can consume regular gas when the reservoir is empty, and state refills can restore it.
+        // Therefore `gasLimit - gasRemaining` can include state gas and need not equal `gasTotalUsed`.
         uint64 gasRemaining;
-        // The net state gas used. Zero for reverted or halted frames; may be negative within a nested frame when state gas is refunded.
+        // Net EIP-8037 state gas used for state creation, excluding regular (execution) gas.
+        // Includes nested execution and already subtracts state gas refills; do not subtract `gasRefunded` from it.
+        // Zero without EIP-8037 and for reverted or halted frames. A successful nested frame can be negative
+        // when it undoes state creation charged to an earlier frame in the same transaction.
+        // Use signed arithmetic when combining with `gasTotalUsed`. Their sum is net measured consumption,
+        // not peak gas required, the caller's full cost, or necessarily the transaction receipt's gas used.
         int64 gasStateUsed;
     }
 
@@ -788,7 +812,10 @@ interface VmSafe {
     /// Returns true if isolated test execution is enabled.
     function isIsolateMode() external view returns (bool result);
 
-    /// Gets the gas used in the last call or create from the callee perspective.
+    /// Gets gas measurements for the last completed call or create, including nested execution, from the callee's perspective.
+    /// `Gas.gasTotalUsed` excludes EIP-8037 state gas; `Gas.gasStateUsed` reports it separately (zero without EIP-8037).
+    /// With isolation, includes transaction intrinsic gas. Cheatcode calls do not replace the recorded frame.
+    /// See `Gas` for refunds and gas-limit caveats, and <https://eips.ethereum.org/EIPS/eip-8037>.
     function lastFrameGas() external view returns (Gas memory gas);
 
     /// Loads a storage slot from an address.
@@ -853,7 +880,9 @@ interface VmSafe {
     function stopRecord() external;
 
     /// DEPRECATED: use `lastFrameGas` instead.
-    /// Gets the gas used in the last call from the callee perspective.
+    /// Gets gas measurements for the last completed call, including nested execution, from the callee's perspective.
+    /// `Gas.gasTotalUsed` excludes EIP-8037 state gas; `Gas.gasStateUsed` reports it separately (zero without EIP-8037).
+    /// See `Gas` for refunds, isolation, and gas-limit caveats, and <https://eips.ethereum.org/EIPS/eip-8037>.
     function lastCallGas() external view returns (Gas memory gas);
 
     // ======== Filesystem ========
@@ -2596,9 +2625,17 @@ interface Vm is VmSafe {
     function setTip20LogoURI(address token, string calldata newLogoURI) external;
 
     /// Snapshot capture the gas usage of the last call or create by name from the callee perspective.
+    /// This scalar snapshot is not the EIP-8037 sum of regular and state gas.
+    /// It can include state gas drawn from regular gas, but excludes state gas paid from the reservoir.
+    /// Isolated frames with zero net state gas use receipt gas instead.
+    /// Use `lastFrameGas` for separate components. See <https://eips.ethereum.org/EIPS/eip-8037>.
     function snapshotGasLastFrame(string calldata name) external returns (uint256 gasUsed);
 
     /// Snapshot capture the gas usage of the last call or create by name in a group from the callee perspective.
+    /// This scalar snapshot is not the EIP-8037 sum of regular and state gas.
+    /// It can include state gas drawn from regular gas, but excludes state gas paid from the reservoir.
+    /// Isolated frames with zero net state gas use receipt gas instead.
+    /// Use `lastFrameGas` for separate components. See <https://eips.ethereum.org/EIPS/eip-8037>.
     function snapshotGasLastFrame(string calldata group, string calldata name) external returns (uint256 gasUsed);
 
     /// Snapshot the current state of the evm.
@@ -2627,22 +2664,32 @@ interface Vm is VmSafe {
 
     /// Start a snapshot capture of the current gas usage by name.
     /// The group name is derived from the contract name.
+    /// Measures regular gas-counter consumption; EIP-8037 state gas paid from the reservoir is not included.
+    /// This is not a combined transaction gas estimate. See <https://eips.ethereum.org/EIPS/eip-8037>.
     function startSnapshotGas(string calldata name) external;
 
     /// Start a snapshot capture of the current gas usage by name in a group.
+    /// Measures regular gas-counter consumption; EIP-8037 state gas paid from the reservoir is not included.
+    /// This is not a combined transaction gas estimate. See <https://eips.ethereum.org/EIPS/eip-8037>.
     function startSnapshotGas(string calldata group, string calldata name) external;
 
     /// Resets subsequent calls' `msg.sender` to be `address(this)`.
     function stopPrank() external;
 
     /// Stop the snapshot capture of the current gas by latest snapshot name, capturing the gas used since the start.
+    /// Measures regular gas-counter consumption; EIP-8037 state gas paid from the reservoir is not included.
+    /// This is not a combined transaction gas estimate. See <https://eips.ethereum.org/EIPS/eip-8037>.
     function stopSnapshotGas() external returns (uint256 gasUsed);
 
     /// Stop the snapshot capture of the current gas usage by name, capturing the gas used since the start.
     /// The group name is derived from the contract name.
+    /// Measures regular gas-counter consumption; EIP-8037 state gas paid from the reservoir is not included.
+    /// This is not a combined transaction gas estimate. See <https://eips.ethereum.org/EIPS/eip-8037>.
     function stopSnapshotGas(string calldata name) external returns (uint256 gasUsed);
 
     /// Stop the snapshot capture of the current gas usage by name in a group, capturing the gas used since the start.
+    /// Measures regular gas-counter consumption; EIP-8037 state gas paid from the reservoir is not included.
+    /// This is not a combined transaction gas estimate. See <https://eips.ethereum.org/EIPS/eip-8037>.
     function stopSnapshotGas(string calldata group, string calldata name) external returns (uint256 gasUsed);
 
     /// Stores a value to an address' storage slot.
@@ -2677,10 +2724,18 @@ interface Vm is VmSafe {
 
     /// DEPRECATED: use `snapshotGasLastFrame` instead.
     /// Snapshot capture the gas usage of the last call by name from the callee perspective.
+    /// This scalar snapshot is not the EIP-8037 sum of regular and state gas.
+    /// It can include state gas drawn from regular gas, but excludes state gas paid from the reservoir.
+    /// Isolated frames with zero net state gas use receipt gas instead.
+    /// Use `lastFrameGas` for separate components. See <https://eips.ethereum.org/EIPS/eip-8037>.
     function snapshotGasLastCall(string calldata name) external returns (uint256 gasUsed);
 
     /// DEPRECATED: use `snapshotGasLastFrame` instead.
     /// Snapshot capture the gas usage of the last call by name in a group from the callee perspective.
+    /// This scalar snapshot is not the EIP-8037 sum of regular and state gas.
+    /// It can include state gas drawn from regular gas, but excludes state gas paid from the reservoir.
+    /// Isolated frames with zero net state gas use receipt gas instead.
+    /// Use `lastFrameGas` for separate components. See <https://eips.ethereum.org/EIPS/eip-8037>.
     function snapshotGasLastCall(string calldata group, string calldata name) external returns (uint256 gasUsed);
 
     /// `snapshot` is being deprecated in favor of `snapshotState`. It will be removed in future versions.

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -813,6 +813,8 @@ interface VmSafe {
     function isIsolateMode() external view returns (bool result);
 
     /// Gets gas measurements for the last completed call or create, including nested execution, from the callee's perspective.
+    /// Extends `lastCallGas` by also recording CREATE and CREATE2 frames; it is not just a rename.
+    /// Both functions return the same `Gas` fields and measurements when they refer to the same call.
     /// `Gas.gasTotalUsed` excludes EIP-8037 state gas; `Gas.gasStateUsed` reports it separately (zero without EIP-8037).
     /// With isolation, includes transaction intrinsic gas. Cheatcode calls do not replace the recorded frame.
     /// See `Gas` for refunds and gas-limit caveats, and <https://eips.ethereum.org/EIPS/eip-8037>.
@@ -881,6 +883,8 @@ interface VmSafe {
 
     /// DEPRECATED: use `lastFrameGas` instead.
     /// Gets gas measurements for the last completed call, including nested execution, from the callee's perspective.
+    /// Unlike `lastFrameGas`, does not record CREATE or CREATE2 frames; external calls made by constructors still count.
+    /// Both functions return the same `Gas` fields and measurements when they refer to the same call.
     /// `Gas.gasTotalUsed` excludes EIP-8037 state gas; `Gas.gasStateUsed` reports it separately (zero without EIP-8037).
     /// See `Gas` for refunds, isolation, and gas-limit caveats, and <https://eips.ethereum.org/EIPS/eip-8037>.
     function lastCallGas() external view returns (Gas memory gas);

--- a/src/Vm.sol
+++ b/src/Vm.sol
@@ -254,43 +254,30 @@ interface VmSafe {
         bool reverted;
     }
 
-    /// Gas measurements returned by `lastCallGas` and `lastFrameGas`, from the callee's perspective.
-    /// Includes nested execution, but not all overhead charged to the caller.
-    /// With isolation, the isolated call is measured as a transaction, including intrinsic gas.
-    /// EIP-8037 separates regular gas (also called execution gas) from state gas for state creation.
-    /// State charges use a separate reservoir first, then regular gas when the reservoir is empty.
-    /// On EVM versions/networks without EIP-8037, state creation uses the ordinary gas schedule:
-    /// `gasStateUsed` is zero, and those costs are included in `gasTotalUsed`.
-    /// These are measurements, not a gas-limit estimate or a transaction receipt.
+    /// Gas measured for the last completed call or create frame, from the callee's perspective,
+    /// including nested execution. Isolated transactions include intrinsic gas.
+    /// Regular gas (the EIP's execution gas) and EIP-8037 state gas are reported separately.
+    /// Without EIP-8037, state creation uses the ordinary gas schedule and `gasStateUsed` is zero.
     /// See <https://eips.ethereum.org/EIPS/eip-8037> and <https://getfoundry.sh/reference/cheatcodes/last-frame-gas>.
     struct Gas {
-        // Regular gas limit of the frame, excluding the EIP-8037 state gas reservoir.
-        // This is not the transaction's combined gas limit and need not equal the gas required to succeed.
+        // Regular gas available to the frame at entry. Excludes the EIP-8037 state gas reservoir.
         uint64 gasLimit;
-        // Regular (execution) gas used, excluding EIP-8037 state gas, before subtracting `gasRefunded`.
-        // Includes nested execution. With isolation, includes intrinsic gas and the regular-gas calldata floor.
-        // Without EIP-8037, includes state creation costs under the ordinary gas schedule.
-        // Not the receipt's total charged gas or a sufficient gas limit; see `gasStateUsed` and `gasRefunded`.
+        // Regular gas spent by the frame, before refunds. Excludes EIP-8037 state gas; see `gasStateUsed`.
+        // With isolation, includes intrinsic gas and the regular-gas calldata floor.
         uint64 gasTotalUsed;
-        // DEPRECATED: Always zero. Memory expansion costs are included in `gasTotalUsed`.
+        // DEPRECATED: always zero. Memory expansion costs are included in `gasTotalUsed`.
         // Ref: <https://github.com/foundry-rs/foundry/pull/7934#pullrequestreview-2069236939>.
         uint64 gasMemoryUsed;
-        // Regular gas refund counter for the frame; can be negative in a nested frame.
-        // Without isolation, this is before the transaction-wide refund cap and calldata floor.
-        // With isolation, this is the isolated transaction's final refund reported by the EVM.
-        // Excludes EIP-8037 state gas refills, which are already reflected in `gasStateUsed`.
-        // Do not subtract it to estimate the gas limit needed to execute.
+        // Ordinary refund counter before transaction settlement; finalized for an isolated transaction.
+        // Can be negative in nested frames. State gas refills are already netted into `gasStateUsed`.
         int64 gasRefunded;
-        // Regular gas remaining at frame completion, excluding the EIP-8037 state gas reservoir.
-        // State charges can consume regular gas when the reservoir is empty, and state refills can restore it.
-        // Therefore `gasLimit - gasRemaining` can include state gas and need not equal `gasTotalUsed`.
+        // Regular gas left at frame end. Excludes the EIP-8037 state gas reservoir.
+        // State charges can draw from this allowance, so `gasLimit - gasRemaining` can include state gas.
         uint64 gasRemaining;
-        // Net EIP-8037 state gas used for state creation, excluding regular (execution) gas.
-        // Includes nested execution and already subtracts state gas refills; do not subtract `gasRefunded` from it.
-        // Zero without EIP-8037 and for reverted or halted frames. A successful nested frame can be negative
-        // when it undoes state creation charged to an earlier frame in the same transaction.
-        // Use signed arithmetic when combining with `gasTotalUsed`. Their sum is net measured consumption,
-        // not peak gas required, the caller's full cost, or necessarily the transaction receipt's gas used.
+        // Net EIP-8037 state gas: state creation charges minus refills, including nested execution.
+        // Zero without EIP-8037 or if the frame reverted or halted. Can be negative when the frame
+        // undoes state created earlier in the same transaction; use signed arithmetic with `gasTotalUsed`.
+        // Their sum measures net consumption, not the gas limit needed to execute.
         int64 gasStateUsed;
     }
 
@@ -812,12 +799,9 @@ interface VmSafe {
     /// Returns true if isolated test execution is enabled.
     function isIsolateMode() external view returns (bool result);
 
-    /// Gets gas measurements for the last completed call or create, including nested execution, from the callee's perspective.
-    /// Extends `lastCallGas` by also recording CREATE and CREATE2 frames; it is not just a rename.
-    /// Both functions return the same `Gas` fields and measurements when they refer to the same call.
-    /// `Gas.gasTotalUsed` excludes EIP-8037 state gas; `Gas.gasStateUsed` reports it separately (zero without EIP-8037).
-    /// With isolation, includes transaction intrinsic gas. Cheatcode calls do not replace the recorded frame.
-    /// See `Gas` for refunds and gas-limit caveats, and <https://eips.ethereum.org/EIPS/eip-8037>.
+    /// Gets gas measurements for the last completed call or create, from the callee's perspective.
+    /// Unlike `lastCallGas`, CREATE and CREATE2 frames are recorded too. Cheatcode calls are never recorded.
+    /// See `Gas` for field semantics and <https://getfoundry.sh/reference/cheatcodes/last-frame-gas>.
     function lastFrameGas() external view returns (Gas memory gas);
 
     /// Loads a storage slot from an address.
@@ -882,11 +866,9 @@ interface VmSafe {
     function stopRecord() external;
 
     /// DEPRECATED: use `lastFrameGas` instead.
-    /// Gets gas measurements for the last completed call, including nested execution, from the callee's perspective.
-    /// Unlike `lastFrameGas`, does not record CREATE or CREATE2 frames; external calls made by constructors still count.
-    /// Both functions return the same `Gas` fields and measurements when they refer to the same call.
-    /// `Gas.gasTotalUsed` excludes EIP-8037 state gas; `Gas.gasStateUsed` reports it separately (zero without EIP-8037).
-    /// See `Gas` for refunds, isolation, and gas-limit caveats, and <https://eips.ethereum.org/EIPS/eip-8037>.
+    /// Gets gas measurements for the last completed call, from the callee's perspective.
+    /// Unlike `lastFrameGas`, CREATE and CREATE2 frames are not recorded; calls made by a constructor are.
+    /// See `Gas` for field semantics.
     function lastCallGas() external view returns (Gas memory gas);
 
     // ======== Filesystem ========
@@ -2629,17 +2611,13 @@ interface Vm is VmSafe {
     function setTip20LogoURI(address token, string calldata newLogoURI) external;
 
     /// Snapshot capture the gas usage of the last call or create by name from the callee perspective.
-    /// This scalar snapshot is not the EIP-8037 sum of regular and state gas.
-    /// It can include state gas drawn from regular gas, but excludes state gas paid from the reservoir.
-    /// Isolated frames with zero net state gas use receipt gas instead.
-    /// Use `lastFrameGas` for separate components. See <https://eips.ethereum.org/EIPS/eip-8037>.
+    /// Without isolation, measures regular counter consumption, including spillover but excluding reservoir-funded state gas.
+    /// Isolated frames with zero net state gas use receipt gas; see <https://getfoundry.sh/reference/cheatcodes/gas-snapshots>.
     function snapshotGasLastFrame(string calldata name) external returns (uint256 gasUsed);
 
     /// Snapshot capture the gas usage of the last call or create by name in a group from the callee perspective.
-    /// This scalar snapshot is not the EIP-8037 sum of regular and state gas.
-    /// It can include state gas drawn from regular gas, but excludes state gas paid from the reservoir.
-    /// Isolated frames with zero net state gas use receipt gas instead.
-    /// Use `lastFrameGas` for separate components. See <https://eips.ethereum.org/EIPS/eip-8037>.
+    /// Without isolation, measures regular counter consumption, including spillover but excluding reservoir-funded state gas.
+    /// Isolated frames with zero net state gas use receipt gas; see <https://getfoundry.sh/reference/cheatcodes/gas-snapshots>.
     function snapshotGasLastFrame(string calldata group, string calldata name) external returns (uint256 gasUsed);
 
     /// Snapshot the current state of the evm.
@@ -2668,32 +2646,27 @@ interface Vm is VmSafe {
 
     /// Start a snapshot capture of the current gas usage by name.
     /// The group name is derived from the contract name.
-    /// Measures regular gas-counter consumption; EIP-8037 state gas paid from the reservoir is not included.
-    /// This is not a combined transaction gas estimate. See <https://eips.ethereum.org/EIPS/eip-8037>.
+    /// Measures gas consumed from the regular counter, including state spillover but excluding reservoir-funded state gas.
     function startSnapshotGas(string calldata name) external;
 
     /// Start a snapshot capture of the current gas usage by name in a group.
-    /// Measures regular gas-counter consumption; EIP-8037 state gas paid from the reservoir is not included.
-    /// This is not a combined transaction gas estimate. See <https://eips.ethereum.org/EIPS/eip-8037>.
+    /// Measures gas consumed from the regular counter, including state spillover but excluding reservoir-funded state gas.
     function startSnapshotGas(string calldata group, string calldata name) external;
 
     /// Resets subsequent calls' `msg.sender` to be `address(this)`.
     function stopPrank() external;
 
     /// Stop the snapshot capture of the current gas by latest snapshot name, capturing the gas used since the start.
-    /// Measures regular gas-counter consumption; EIP-8037 state gas paid from the reservoir is not included.
-    /// This is not a combined transaction gas estimate. See <https://eips.ethereum.org/EIPS/eip-8037>.
+    /// Measures gas consumed from the regular counter, including state spillover but excluding reservoir-funded state gas.
     function stopSnapshotGas() external returns (uint256 gasUsed);
 
     /// Stop the snapshot capture of the current gas usage by name, capturing the gas used since the start.
     /// The group name is derived from the contract name.
-    /// Measures regular gas-counter consumption; EIP-8037 state gas paid from the reservoir is not included.
-    /// This is not a combined transaction gas estimate. See <https://eips.ethereum.org/EIPS/eip-8037>.
+    /// Measures gas consumed from the regular counter, including state spillover but excluding reservoir-funded state gas.
     function stopSnapshotGas(string calldata name) external returns (uint256 gasUsed);
 
     /// Stop the snapshot capture of the current gas usage by name in a group, capturing the gas used since the start.
-    /// Measures regular gas-counter consumption; EIP-8037 state gas paid from the reservoir is not included.
-    /// This is not a combined transaction gas estimate. See <https://eips.ethereum.org/EIPS/eip-8037>.
+    /// Measures gas consumed from the regular counter, including state spillover but excluding reservoir-funded state gas.
     function stopSnapshotGas(string calldata group, string calldata name) external returns (uint256 gasUsed);
 
     /// Stores a value to an address' storage slot.
@@ -2728,18 +2701,14 @@ interface Vm is VmSafe {
 
     /// DEPRECATED: use `snapshotGasLastFrame` instead.
     /// Snapshot capture the gas usage of the last call by name from the callee perspective.
-    /// This scalar snapshot is not the EIP-8037 sum of regular and state gas.
-    /// It can include state gas drawn from regular gas, but excludes state gas paid from the reservoir.
-    /// Isolated frames with zero net state gas use receipt gas instead.
-    /// Use `lastFrameGas` for separate components. See <https://eips.ethereum.org/EIPS/eip-8037>.
+    /// Without isolation, measures regular counter consumption, including spillover but excluding reservoir-funded state gas.
+    /// Isolated frames with zero net state gas use receipt gas; see <https://getfoundry.sh/reference/cheatcodes/gas-snapshots>.
     function snapshotGasLastCall(string calldata name) external returns (uint256 gasUsed);
 
     /// DEPRECATED: use `snapshotGasLastFrame` instead.
     /// Snapshot capture the gas usage of the last call by name in a group from the callee perspective.
-    /// This scalar snapshot is not the EIP-8037 sum of regular and state gas.
-    /// It can include state gas drawn from regular gas, but excludes state gas paid from the reservoir.
-    /// Isolated frames with zero net state gas use receipt gas instead.
-    /// Use `lastFrameGas` for separate components. See <https://eips.ethereum.org/EIPS/eip-8037>.
+    /// Without isolation, measures regular counter consumption, including spillover but excluding reservoir-funded state gas.
+    /// Isolated frames with zero net state gas use receipt gas; see <https://getfoundry.sh/reference/cheatcodes/gas-snapshots>.
     function snapshotGasLastCall(string calldata group, string calldata name) external returns (uint256 gasUsed);
 
     /// `snapshot` is being deprecated in favor of `snapshotState`. It will be removed in future versions.


### PR DESCRIPTION
Clarify every `Vm.Gas` field and the last-frame and snapshot cheatcode docs, including which values exclude EIP-8037 state gas, how state refills differ from ordinary refunds, and what isolation changes. Explain signed state deltas and why measured consumption is not a sufficient transaction gas limit, with references to the EIP and the book. Import the documentation from Foundry's canonical cheatcode metadata while preserving the existing interface surface.

The canonical documentation comes from foundry-rs/foundry#16772; merge that before the next full interface regeneration. The expanded guide is in foundry-rs/book#2076, with matching Rust API documentation in alloy-rs/alloy#4195.

AI assistance: Codex authored the documentation and PR description.
